### PR TITLE
Harden Sonar MCP mode selection and container reconciliation

### DIFF
--- a/devBenches/scripts/ensure-sonarqube-mcp.sh
+++ b/devBenches/scripts/ensure-sonarqube-mcp.sh
@@ -67,8 +67,22 @@ if [[ -z "${SONARQUBE_TOKEN:-}" ]]; then
   exit 0
 fi
 
-SONARQUBE_ORG="${SONARQUBE_ORG:-opensoft}"
 SONARQUBE_URL="${SONARQUBE_URL:-${SONAR_HOST_URL:-${SONARQUBE_CLOUD_URL:-https://sonarcloud.io}}}"
+SONARQUBE_ORG="${SONARQUBE_ORG:-${SONAR_ORGANIZATION:-}}"
+
+# The SonarQube MCP server uses the presence of SONARQUBE_ORG to select Cloud
+# mode. Preserve the existing Opensoft default for the supported Cloud
+# endpoints, but leave the variable unset for self-hosted SonarQube Server.
+if [[ -z "$SONARQUBE_ORG" ]]; then
+  case "${SONARQUBE_URL%/}" in
+    https://sonarcloud.io|https://sonarqube.us)
+      SONARQUBE_ORG="opensoft"
+      ;;
+    *)
+      unset SONARQUBE_ORG
+      ;;
+  esac
+fi
 
 ensure_network() {
   if ! docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
@@ -96,7 +110,11 @@ ensure_compose_services() {
   export SONARQUBE_MCP_BACKEND_PORT="$BACKEND_PORT"
   export SONARQUBE_MCP_PORT="$PROXY_PORT"
   export SONARQUBE_MCP_HOST_BIND="$HOST_BIND"
-  export SONARQUBE_ORG
+  if [[ -n "${SONARQUBE_ORG:-}" ]]; then
+    export SONARQUBE_ORG
+  else
+    unset SONARQUBE_ORG
+  fi
   export SONARQUBE_TOKEN
   export SONARQUBE_URL
 

--- a/devBenches/scripts/sonarqube-mcp.compose.yml
+++ b/devBenches/scripts/sonarqube-mcp.compose.yml
@@ -10,7 +10,9 @@ services:
       devbench.shared-service: sonarqube-mcp
     environment:
       SONARQUBE_TOKEN: ${SONARQUBE_TOKEN}
-      SONARQUBE_ORG: ${SONARQUBE_ORG:-opensoft}
+      # A null value inherits SONARQUBE_ORG when exported and omits it when
+      # unset, preserving SonarQube Server mode for self-hosted URLs.
+      SONARQUBE_ORG:
       SONARQUBE_URL: ${SONARQUBE_URL:-https://sonarcloud.io}
       SONARQUBE_TRANSPORT: http
       SONARQUBE_HTTP_HOST: 0.0.0.0

--- a/devBenches/scripts/test-helper-safety.sh
+++ b/devBenches/scripts/test-helper-safety.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+BIN_DIR="$TMP_ROOT/bin"
+DOCKER_LOG="$TMP_ROOT/docker.log"
+mkdir -p "$BIN_DIR"
+
+cat > "$BIN_DIR/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-} ${2:-}" in
+  "compose version"|"network inspect")
+    exit 0
+    ;;
+  "volume create"|"network create")
+    exit 0
+    ;;
+esac
+
+if [[ "${1:-}" == "compose" ]]; then
+  printf 'compose org_set=%s org=%s url=%s\n' \
+    "${SONARQUBE_ORG+x}" "${SONARQUBE_ORG:-}" "${SONARQUBE_URL:-}" >> "$DOCKER_LOG"
+  exit 0
+fi
+
+if [[ "${1:-} ${2:-}" == "container inspect" ]]; then
+  exit 0
+fi
+
+if [[ "${1:-} ${2:-}" == "image inspect" ]]; then
+  if [[ "${3:-}" == "--format" ]]; then
+    printf 'sha256:expected\n'
+  fi
+  exit 0
+fi
+
+if [[ "${1:-}" == "inspect" && "${2:-}" == "--format" ]]; then
+  case "${3:-}" in
+    '{{.Image}}') printf 'sha256:current\n' ;;
+    '{{.Config.Image}}') printf 'current:image\n' ;;
+    *compose.project*) printf '%s\n' "${MOCK_CURRENT_PROJECT:-expected-project}" ;;
+    *compose.service*) printf '%s\n' "${MOCK_CURRENT_SERVICE:-expected-service}" ;;
+    *) exit 1 ;;
+  esac
+  exit 0
+fi
+
+if [[ "${1:-} ${2:-}" == "rm -f" ]]; then
+  printf 'removed=%s\n' "${3:-}" >> "$DOCKER_LOG"
+  exit 0
+fi
+
+printf 'unexpected docker invocation: %s\n' "$*" >&2
+exit 1
+EOF
+chmod +x "$BIN_DIR/docker"
+
+run_sonar_case() {
+  env -i \
+    HOME="$TMP_ROOT/home" \
+    PATH="$BIN_DIR:/usr/bin:/bin" \
+    DOCKER_LOG="$DOCKER_LOG" \
+    SONARQUBE_ENV_FILE="$TMP_ROOT/missing.env" \
+    SONARQUBE_TOKEN="test-token" \
+    "$@" \
+    "$SCRIPT_DIR/ensure-sonarqube-mcp.sh" >/dev/null
+}
+
+: > "$DOCKER_LOG"
+run_sonar_case SONARQUBE_URL=https://sonarcloud.io SONAR_ORGANIZATION=customer-org
+grep -Fx 'compose org_set=x org=customer-org url=https://sonarcloud.io' "$DOCKER_LOG" >/dev/null
+
+: > "$DOCKER_LOG"
+run_sonar_case SONARQUBE_URL=https://sonarcloud.io
+grep -Fx 'compose org_set=x org=opensoft url=https://sonarcloud.io' "$DOCKER_LOG" >/dev/null
+
+: > "$DOCKER_LOG"
+run_sonar_case SONARQUBE_URL=https://sonar.example.test
+grep -Fx 'compose org_set= org= url=https://sonar.example.test' "$DOCKER_LOG" >/dev/null
+
+: > "$DOCKER_LOG"
+if PATH="$BIN_DIR:$PATH" DOCKER_LOG="$DOCKER_LOG" \
+  MOCK_CURRENT_PROJECT=other-project MOCK_CURRENT_SERVICE=other-service \
+  "$REPO_ROOT/scripts/reconcile-devcontainer-container.sh" \
+    --container protected-container \
+    --image expected:image \
+    --project expected-project \
+    --service expected-service \
+    --replace-existing >/dev/null 2>&1; then
+  echo "ownership mismatch unexpectedly succeeded" >&2
+  exit 1
+fi
+if grep -q '^removed=' "$DOCKER_LOG"; then
+  echo "ownership mismatch removed the protected container" >&2
+  exit 1
+fi
+
+: > "$DOCKER_LOG"
+PATH="$BIN_DIR:$PATH" DOCKER_LOG="$DOCKER_LOG" \
+  MOCK_CURRENT_PROJECT=expected-project MOCK_CURRENT_SERVICE=expected-service \
+  "$REPO_ROOT/scripts/reconcile-devcontainer-container.sh" \
+    --container managed-container \
+    --image expected:image \
+    --project expected-project \
+    --service expected-service \
+    --replace-existing >/dev/null
+grep -Fx 'removed=managed-container' "$DOCKER_LOG" >/dev/null
+
+printf 'helper safety tests passed\n'

--- a/scripts/reconcile-devcontainer-container.sh
+++ b/scripts/reconcile-devcontainer-container.sh
@@ -61,12 +61,6 @@ CURRENT_IMAGE_ID="$(docker inspect --format '{{.Image}}' "$CONTAINER_NAME" 2>/de
 CURRENT_CONFIG_IMAGE="$(docker inspect --format '{{.Config.Image}}' "$CONTAINER_NAME" 2>/dev/null)" || exit 0
 EXPECTED_IMAGE_ID="$(docker image inspect --format '{{.Id}}' "$EXPECTED_IMAGE")"
 
-if [[ "$REPLACE_EXISTING" == true ]]; then
-    echo "Removing existing devcontainer '$CONTAINER_NAME' (${CURRENT_CONFIG_IMAGE}) so the caller can recreate it"
-    docker rm -f "$CONTAINER_NAME" >/dev/null
-    exit 0
-fi
-
 if [[ -n "$EXPECTED_PROJECT" || -n "$EXPECTED_SERVICE" ]]; then
     CURRENT_PROJECT="$(docker inspect --format '{{ index .Config.Labels "com.docker.compose.project" }}' "$CONTAINER_NAME" 2>/dev/null || true)"
     CURRENT_SERVICE="$(docker inspect --format '{{ index .Config.Labels "com.docker.compose.service" }}' "$CONTAINER_NAME" 2>/dev/null || true)"
@@ -83,10 +77,15 @@ if [[ -n "$EXPECTED_PROJECT" || -n "$EXPECTED_SERVICE" ]]; then
     fi
 
     if [[ "$PROJECT_MATCH" != true || "$SERVICE_MATCH" != true ]]; then
-        echo "Removing existing devcontainer '$CONTAINER_NAME' (${CURRENT_CONFIG_IMAGE}): not managed by expected compose service '${EXPECTED_PROJECT}/${EXPECTED_SERVICE}'"
-        docker rm -f "$CONTAINER_NAME" >/dev/null
-        exit 0
+        echo "Refusing to remove devcontainer '$CONTAINER_NAME' (${CURRENT_CONFIG_IMAGE}): managed by compose service '${CURRENT_PROJECT}/${CURRENT_SERVICE}', expected '${EXPECTED_PROJECT}/${EXPECTED_SERVICE}'" >&2
+        exit 1
     fi
+fi
+
+if [[ "$REPLACE_EXISTING" == true ]]; then
+    echo "Removing existing devcontainer '$CONTAINER_NAME' (${CURRENT_CONFIG_IMAGE}) so the caller can recreate it"
+    docker rm -f "$CONTAINER_NAME" >/dev/null
+    exit 0
 fi
 
 REMOVE_REASON=""


### PR DESCRIPTION
## Summary

- honor the existing `SONAR_ORGANIZATION` alias and only default the organization for known Sonar Cloud endpoints
- omit `SONARQUBE_ORG` for self-hosted SonarQube Server, as required by the official MCP mode-selection contract
- validate Compose ownership labels before any forced container replacement and refuse mismatched containers
- add disposable mocked-Docker regression coverage for Cloud/Server selection and ownership-safe reconciliation

## Validation

- `bash -n devBenches/scripts/ensure-sonarqube-mcp.sh scripts/reconcile-devcontainer-container.sh devBenches/scripts/test-helper-safety.sh`
- `devBenches/scripts/test-helper-safety.sh`
- `docker compose -f devBenches/scripts/sonarqube-mcp.compose.yml config --quiet`
- disposable Compose container inspection confirmed self-hosted mode omits `SONARQUBE_ORG`
- `git diff --check origin/main...HEAD`

Official contract: https://docs.sonarsource.com/sonarqube-mcp-server/build-and-configure/environment-variables

## Summary by Sourcery

Harden SonarQube MCP mode selection and devcontainer reconciliation safety.

New Features:
- Support SONAR_ORGANIZATION as an alias for SONARQUBE_ORG and only default the organization for known Sonar Cloud endpoints.
- Add a disposable test helper script that mocks Docker to validate SonarQube MCP configuration and devcontainer reconciliation behavior.

Bug Fixes:
- Ensure SONARQUBE_ORG is omitted for self-hosted SonarQube Server to comply with MCP mode-selection requirements.
- Prevent reconcile-devcontainer-container from force-removing containers owned by a different Docker Compose project or service.

Enhancements:
- Adjust SonarQube MCP Docker Compose configuration to inherit or omit SONARQUBE_ORG based on the calling environment.