### PR TITLE
Add rustBench development environment

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "sysBenches/365Bench"]
 	path = sysBenches/365Bench
 	url = git@github.com:opensoft/365Bench.git
+[submodule "devBenches/rustBench"]
+	path = devBenches/rustBench
+	url = git@github.com:opensoft/rustBench.git

--- a/devBenches/README.md
+++ b/devBenches/README.md
@@ -12,6 +12,7 @@ Each subfolder is a separate git repository containing a complete development en
 - **`javaBench/`** - Java development environment with DevContainer
 - **`phpBench/`** - PHP development environment with DevContainer
 - **`pyBench/`** - Python development environment with DevContainer
+- **`rustBench/`** - Rust development, analysis, cross-compilation, and WebAssembly environment
 
 ## Layered Containers (Current Standard)
 


### PR DESCRIPTION
## Summary

- add the public `opensoft/rustBench` repository as `devBenches/rustBench`
- register the SSH submodule URL
- document the Rust bench in the devBenches index

## Validation

- built `rust-bench:latest` and personalized `rust-bench:brett` images
- verified stable/nightly toolchains, Miri, Cargo tooling, Zig, cross, and WASM executables
- generated and tested a smoke Cargo project
- validated Dockerfile, devcontainer JSON, Compose config, shell syntax, and whitespace

## Summary by Sourcery

Add a new Rust development bench environment and register it as a submodule.

New Features:
- Introduce the rustBench DevContainer environment under devBenches for Rust development, analysis, cross-compilation, and WebAssembly workflows.

Enhancements:
- Update the devBenches index documentation to include the new rustBench environment.

Build:
- Register the rustBench repository as a git submodule for use as a development bench.