### PR TITLE
Add rustBench Wave launcher integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Installed widgets include:
 | `pyBench` | Starts or repairs `py-bench`, then opens an interactive shell |
 | `flutterBench` | Starts or repairs `flutter-bench`, then opens an interactive shell |
 | `C++Bench` | Starts or repairs `cpp-bench`, then opens an interactive shell |
+| `rustBench` | Starts or repairs `rust-bench`, then opens an interactive shell |
 | `cloudBench` | Starts or repairs `cloud-bench`, then opens an interactive shell |
 
 First-run setup offers consent-based work and personal AI profile onboarding,

--- a/scripts/wave-container-shell.sh
+++ b/scripts/wave-container-shell.sh
@@ -27,6 +27,11 @@ resolve_bench_defaults() {
             bench_dir="$workbenches_root/devBenches/cppBench"
             compose_file="$bench_dir/.devcontainer/docker-compose.yml"
             ;;
+        rustBench|rust-bench)
+            container="rust-bench"
+            bench_dir="$workbenches_root/devBenches/rustBench"
+            compose_file="$bench_dir/.devcontainer/docker-compose.yml"
+            ;;
         flutterBench|flutter-bench)
             container="flutter-bench"
             bench_dir="$workbenches_root/devBenches/flutterBench"


### PR DESCRIPTION
## Summary

- register `rustBench` in the copied Wave container launcher
- document the new shared Wave widget in workBenches setup
- advance the rustBench submodule to its isolated-network startup fix

## Validation

- passed launcher shell syntax and whitespace checks
- rendered the shared `brands@rust` Wave widget
- launched and checked `rust-bench` through the Wave launcher while Flutter remained running

## Summary by Sourcery

Integrate the rustBench workbench into the Wave container launcher and update documentation to reflect the new widget.

New Features:
- Add rustBench support to the Wave container shell launcher so the rust-bench container can be started and accessed like other benches.

Documentation:
- Document the rustBench Wave widget alongside existing workBenches in the README.