### PR TITLE
Give Corepack a user-writable Layer 3 cache

### DIFF
--- a/devBenches/devcontainer.test/README.md
+++ b/devBenches/devcontainer.test/README.md
@@ -6,7 +6,7 @@ Test harness for `dev-bench-base:$USER` - the Layer 3 user image built on top of
 
 Layer 1a adds developer tools on top of Layer 0:
 - Python 3.x with pip and development tools (black, flake8, isort, pylint, pytest, ipython)
-- Node.js LTS with npm and yarn
+- Node.js LTS with npm, yarn, and a user-writable Corepack cache for pnpm
 - Python package managers (uv)
 - Spec-driven tools (`specify`, `openspec`)
 - Speckit worktree bootstrap (`speckit-worktree-enable`)
@@ -42,7 +42,7 @@ docker compose down
 
 The `test.sh` script validates:
 - ✅ Python development tools
-- ✅ Node.js development tools
+- ✅ Node.js development tools and unprivileged pnpm/Corepack operation
 - ✅ Python package managers (uv)
 - ✅ Spec-driven tools (`specify`, `openspec`)
 - ✅ Worktree-mode Speckit bootstrap installation

--- a/devBenches/devcontainer.test/README.md
+++ b/devBenches/devcontainer.test/README.md
@@ -6,7 +6,7 @@ Test harness for `dev-bench-base:$USER` - the Layer 3 user image built on top of
 
 Layer 1a adds developer tools on top of Layer 0:
 - Python 3.x with pip and development tools (black, flake8, isort, pylint, pytest, ipython)
-- Node.js LTS with npm, yarn, and a user-writable Corepack cache for pnpm
+- Node.js LTS with npm and yarn
 - Python package managers (uv)
 - Spec-driven tools (`specify`, `openspec`)
 - Speckit worktree bootstrap (`speckit-worktree-enable`)
@@ -16,6 +16,9 @@ Layer 1a adds developer tools on top of Layer 0:
 - OpenCode configuration with plugins (oh-my-opencode, opencode-openai-codex-auth)
 - Zsh and oh-my-zsh with plugins
 - PATH configuration for all dev tools
+
+The Layer 3 user image adds the effective-user Corepack cache exercised by the
+unprivileged pnpm checks in this harness.
 
 ## Quick Start
 

--- a/devBenches/devcontainer.test/test.sh
+++ b/devBenches/devcontainer.test/test.sh
@@ -68,6 +68,9 @@ echo "=== Node.js Development ==="
 test_tool_output "Node.js" "node --version"
 test_tool_output "npm" "npm --version"
 test_tool_output "yarn" "yarn --version"
+test_tool_output "pnpm as unprivileged user" "pnpm --version"
+test_tool "Corepack cache is user-owned and writable" \
+    "runtime_home=\$(getent passwd \"\$(id -u)\" | cut -d: -f6); cache=\"\$runtime_home/.cache/corepack\"; test -d \"\$cache\" && test -w \"\$cache\" && test \"\$(stat -c '%u' \"\$cache\")\" = \"\$(id -u)\""
 test_tool "/usr/local/bin in PATH" "echo \$PATH | grep -q '/usr/local/bin'"
 
 echo ""

--- a/devBenches/devcontainer.test/test.sh
+++ b/devBenches/devcontainer.test/test.sh
@@ -68,6 +68,9 @@ echo "=== Node.js Development ==="
 test_tool_output "Node.js" "node --version"
 test_tool_output "npm" "npm --version"
 test_tool_output "yarn" "yarn --version"
+test_tool_output "pnpm as unprivileged user" "pnpm --version"
+test_tool "Corepack cache is user-owned and writable" \
+    "test \"\$COREPACK_HOME\" = \"\$HOME/.cache/corepack\" && test -d \"\$COREPACK_HOME\" && test -w \"\$COREPACK_HOME\""
 test_tool "/usr/local/bin in PATH" "echo \$PATH | grep -q '/usr/local/bin'"
 
 echo ""

--- a/user-layer/Dockerfile
+++ b/user-layer/Dockerfile
@@ -18,7 +18,7 @@ FROM ${BASE_IMAGE}
 # Container version labels
 LABEL layer="3"
 LABEL layer.name="user-layer"
-LABEL layer.version="1.2.0"
+LABEL layer.version="1.2.1"
 LABEL layer.description="User personalization layer"
 
 # Build arguments
@@ -29,6 +29,15 @@ ARG DOCKER_SOCKET_GID=""
 ARG EXTRA_CHOWN_DIRS=""
 
 USER root
+
+# Corepack's shared base-layer cache is root-owned. Route Corepack and its
+# package-manager shims through a runtime wrapper that selects a writable cache
+# from the effective user's passwd home, including for non-interactive calls.
+COPY corepack-user-cache /usr/local/libexec/workbenches-corepack-user-cache
+RUN chmod 0755 /usr/local/libexec/workbenches-corepack-user-cache && \
+    for command in corepack pnpm pnpx yarn yarnpkg; do \
+        ln -sfn /usr/local/libexec/workbenches-corepack-user-cache "/usr/local/bin/$command"; \
+    done
 
 # ========================================
 # USER CREATION

--- a/user-layer/Dockerfile
+++ b/user-layer/Dockerfile
@@ -28,11 +28,6 @@ ARG USER_GID=1000
 ARG DOCKER_SOCKET_GID=""
 ARG EXTRA_CHOWN_DIRS=""
 
-# Corepack downloads package-manager shims and versions on demand. Keep its
-# mutable cache in the Layer 3 user's home rather than the root-owned cache
-# inherited from a shared base image.
-ENV COREPACK_HOME=/home/${USERNAME}/.cache/corepack
-
 USER root
 
 # Corepack's shared base-layer cache is root-owned. Route Corepack and its
@@ -113,10 +108,6 @@ RUN if [ -n "$EXTRA_CHOWN_DIRS" ]; then \
 # ========================================
 
 USER $USERNAME
-
-# Pre-create the user-owned Corepack cache so pnpm/yarn work immediately in
-# interactive and non-interactive bench sessions.
-RUN mkdir -p "$COREPACK_HOME"
 
 # Pre-create .vscode-server so volume mounts inherit correct ownership
 RUN mkdir -p /home/$USERNAME/.vscode-server/extensions

--- a/user-layer/Dockerfile
+++ b/user-layer/Dockerfile
@@ -18,7 +18,7 @@ FROM ${BASE_IMAGE}
 # Container version labels
 LABEL layer="3"
 LABEL layer.name="user-layer"
-LABEL layer.version="1.2.0"
+LABEL layer.version="1.2.1"
 LABEL layer.description="User personalization layer"
 
 # Build arguments
@@ -27,6 +27,11 @@ ARG USER_UID=1000
 ARG USER_GID=1000
 ARG DOCKER_SOCKET_GID=""
 ARG EXTRA_CHOWN_DIRS=""
+
+# Corepack downloads package-manager shims and versions on demand. Keep its
+# mutable cache in the Layer 3 user's home rather than the root-owned cache
+# inherited from a shared base image.
+ENV COREPACK_HOME=/home/${USERNAME}/.cache/corepack
 
 USER root
 
@@ -99,6 +104,10 @@ RUN if [ -n "$EXTRA_CHOWN_DIRS" ]; then \
 # ========================================
 
 USER $USERNAME
+
+# Pre-create the user-owned Corepack cache so pnpm/yarn work immediately in
+# interactive and non-interactive bench sessions.
+RUN mkdir -p "$COREPACK_HOME"
 
 # Pre-create .vscode-server so volume mounts inherit correct ownership
 RUN mkdir -p /home/$USERNAME/.vscode-server/extensions

--- a/user-layer/corepack-user-cache
+++ b/user-layer/corepack-user-cache
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+
+command_name=${0##*/}
+case "$command_name" in
+    corepack|pnpm|pnpx|yarn|yarnpkg) ;;
+    *)
+        echo "Unsupported Corepack command: $command_name" >&2
+        exit 64
+        ;;
+esac
+
+# Respect an explicit caller override. Replace only the shared image default,
+# which is root-owned and therefore unusable by Layer 3 runtime users.
+case "${COREPACK_HOME:-}" in
+    ""|/opt/corepack)
+        runtime_home=$(getent passwd "$(id -u)" | cut -d: -f6)
+        if [ -z "$runtime_home" ]; then
+            echo "Could not determine the effective user's home directory" >&2
+            exit 1
+        fi
+        COREPACK_HOME="$runtime_home/.cache/corepack"
+        export COREPACK_HOME
+        ;;
+esac
+
+mkdir -p "$COREPACK_HOME"
+exec "/usr/bin/$command_name" "$@"


### PR DESCRIPTION
## Summary
- override the inherited root-owned Corepack cache in the shared user layer
- pre-create the cache under each Layer 3 user home
- verify unprivileged pnpm execution and cache writability in the devBench harness

## Validation
- `git diff --check`
- shell syntax checks
- disposable Layer 3 build with synthetic user `corepacktest`
- `pnpm --version` downloaded pnpm 11.17.0 into `/home/corepacktest/.cache/corepack`
- new Corepack harness checks pass
- full harness baseline comparison confirms the same four unrelated existing failures before and after the patch

## Summary by Sourcery

Configure Corepack to use a user-owned cache in the Layer 3 user image and validate unprivileged pnpm/Corepack behavior in the dev container harness.

New Features:
- Provide a user-writable Corepack cache under the Layer 3 user home for on-demand package-manager downloads.

Enhancements:
- Bump the Layer 3 user-layer image version label to reflect the Corepack cache change.
- Pre-create the Corepack cache directory in the user image so pnpm and yarn work immediately in bench sessions.

Documentation:
- Update devBench devcontainer test README to document the user-writable Corepack cache and pnpm/Corepack validation.

Tests:
- Extend the devcontainer test harness to exercise pnpm as an unprivileged user and verify the Corepack cache is user-owned and writable.