### PR TITLE
Fix Wave launcher container repair safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ Installed widgets include:
 | `rustBench` | Starts or repairs `rust-bench`, then opens an interactive shell |
 | `cloudBench` | Starts or repairs `cloud-bench`, then opens an interactive shell |
 
+Opening a widget never recreates an already-running bench when mount
+requirements drift. The launcher warns and preserves the live container. Use
+`scripts/wave-container-shell.sh --repair <bench>` only when it is safe to
+recreate that container; stopped containers with missing mounts are repaired
+automatically.
+
 First-run setup offers consent-based work and personal AI profile onboarding,
 including GitHub credential-registry discovery and a local manual fallback.
 See [Shared AI provider profiles](docs/multi-provider-profiles.md).

--- a/devcontainer.test/test-wave-container-shell.sh
+++ b/devcontainer.test/test-wave-container-shell.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+launcher="${LAUNCHER_UNDER_TEST:-$repo_root/scripts/wave-container-shell.sh}"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+run_launcher_case() {
+    local case_name="$1"
+    local running="$2"
+    local mounts="$3"
+    shift 3
+
+    local case_root
+    case_root="$(mktemp -d)"
+    local fake_home="$case_root/home"
+    local fake_root="$case_root/workBenches"
+    local mock_bin="$case_root/bin"
+    local docker_log="$case_root/docker.log"
+    mkdir -p "$fake_home" "$fake_root/devBenches/pyBench/.devcontainer" "$mock_bin"
+    : > "$fake_root/devBenches/pyBench/.devcontainer/devcontainer.json"
+    : > "$fake_root/devBenches/pyBench/.devcontainer/docker-compose.yml"
+
+    cat > "$mock_bin/docker" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$MOCK_DOCKER_LOG"
+
+if [[ "${1:-}" == "container" && "${2:-}" == "inspect" ]]; then
+    if [[ "${3:-}" == "-f" ]]; then
+        case "${4:-}" in
+            *State.Running*) printf '%s\n' "$MOCK_RUNNING" ;;
+            *Mounts*)
+                if [[ "$MOCK_MOUNTS" == "complete" ]]; then
+                    cat <<'MOUNTS'
+/workspace/projects
+/home/tester/.workbenches-history
+/home/tester/.zshrc
+/home/tester/.oh-my-zsh
+/home/tester/.p10k.zsh
+/home/tester/.claude-profiles
+/home/tester/.chatgpt-profiles
+/home/tester/.pi-profiles
+/home/tester/.gemini-profiles
+/home/tester/.grok-profiles
+/home/tester/.glm-profiles
+MOUNTS
+                else
+                    printf '%s\n' /workspace/projects
+                fi
+                ;;
+        esac
+    fi
+    exit 0
+fi
+
+exit 0
+MOCK
+    chmod +x "$mock_bin/docker"
+
+    local output
+    if ! output="$(
+        env \
+            HOME="$fake_home" \
+            USER=tester \
+            PATH="$mock_bin:$PATH" \
+            MOCK_DOCKER_LOG="$docker_log" \
+            MOCK_RUNNING="$running" \
+            MOCK_MOUNTS="$mounts" \
+            "$launcher" \
+                --workbenches-root "$fake_root" \
+                --shell sh \
+                --check \
+                "$@" \
+                py-bench 2>&1
+    )"; then
+        echo "$output" >&2
+        rm -rf "$case_root"
+        fail "$case_name launcher invocation failed"
+    fi
+
+    CASE_OUTPUT="$output"
+    CASE_DOCKER_LOG="$(cat "$docker_log")"
+    rm -rf "$case_root"
+}
+
+bash -n "$launcher"
+"$launcher" --help | grep -q -- '--repair' || fail "help does not document --repair"
+
+run_launcher_case preserve-running true missing
+grep -q 'preserving the live container' <<<"$CASE_OUTPUT" || fail "running container was not preserved with a warning"
+if grep -q '^rm -f py-bench$' <<<"$CASE_DOCKER_LOG"; then
+    fail "normal launch removed a running container"
+fi
+if grep -q '^compose ' <<<"$CASE_DOCKER_LOG"; then
+    fail "normal launch recreated a running container"
+fi
+
+run_launcher_case explicit-repair true complete --repair
+grep -q '^rm -f py-bench$' <<<"$CASE_DOCKER_LOG" || fail "--repair did not remove the existing container"
+grep -q '^compose ' <<<"$CASE_DOCKER_LOG" || fail "--repair did not recreate the container"
+
+run_launcher_case stopped-auto-repair false missing
+grep -q '^rm -f py-bench$' <<<"$CASE_DOCKER_LOG" || fail "stopped container with missing mounts was not removed"
+grep -q '^compose ' <<<"$CASE_DOCKER_LOG" || fail "stopped container with missing mounts was not recreated"
+
+echo "PASS: wave container launcher lifecycle tests"

--- a/devcontainer.test/test-wave-container-shell.sh
+++ b/devcontainer.test/test-wave-container-shell.sh
@@ -14,7 +14,9 @@ run_launcher_case() {
     local case_name="$1"
     local running="$2"
     local mounts="$3"
-    shift 3
+    local rm_refuse="$4"
+    local after_refusal_running="$5"
+    shift 5
 
     local case_root
     case_root="$(mktemp -d)"
@@ -34,7 +36,13 @@ printf '%s\n' "$*" >> "$MOCK_DOCKER_LOG"
 if [[ "${1:-}" == "container" && "${2:-}" == "inspect" ]]; then
     if [[ "${3:-}" == "-f" ]]; then
         case "${4:-}" in
-            *State.Running*) printf '%s\n' "$MOCK_RUNNING" ;;
+            *State.Running*)
+                if [[ -f "$MOCK_RM_REFUSED_MARKER" ]]; then
+                    printf '%s\n' "$MOCK_AFTER_REFUSAL_RUNNING"
+                else
+                    printf '%s\n' "$MOCK_RUNNING"
+                fi
+                ;;
             *Mounts*)
                 if [[ "$MOCK_MOUNTS" == "complete" ]]; then
                     cat <<'MOUNTS'
@@ -59,6 +67,11 @@ MOUNTS
     exit 0
 fi
 
+if [[ "${1:-}" == "rm" && "${2:-}" != "-f" && "$MOCK_RM_REFUSE" == "true" ]]; then
+    : > "$MOCK_RM_REFUSED_MARKER"
+    exit 1
+fi
+
 exit 0
 MOCK
     chmod +x "$mock_bin/docker"
@@ -72,6 +85,9 @@ MOCK
             MOCK_DOCKER_LOG="$docker_log" \
             MOCK_RUNNING="$running" \
             MOCK_MOUNTS="$mounts" \
+            MOCK_RM_REFUSE="$rm_refuse" \
+            MOCK_RM_REFUSED_MARKER="$case_root/rm-refused" \
+            MOCK_AFTER_REFUSAL_RUNNING="$after_refusal_running" \
             "$launcher" \
                 --workbenches-root "$fake_root" \
                 --shell sh \
@@ -92,7 +108,7 @@ MOCK
 bash -n "$launcher"
 "$launcher" --help | grep -q -- '--repair' || fail "help does not document --repair"
 
-run_launcher_case preserve-running true missing
+run_launcher_case preserve-running true missing true true
 grep -q 'preserving the live container' <<<"$CASE_OUTPUT" || fail "running container was not preserved with a warning"
 if grep -q '^rm -f py-bench$' <<<"$CASE_DOCKER_LOG"; then
     fail "normal launch removed a running container"
@@ -101,12 +117,21 @@ if grep -q '^compose ' <<<"$CASE_DOCKER_LOG"; then
     fail "normal launch recreated a running container"
 fi
 
-run_launcher_case explicit-repair true complete --repair
+run_launcher_case explicit-repair true complete false true --repair
 grep -q '^rm -f py-bench$' <<<"$CASE_DOCKER_LOG" || fail "--repair did not remove the existing container"
 grep -q '^compose ' <<<"$CASE_DOCKER_LOG" || fail "--repair did not recreate the container"
 
-run_launcher_case stopped-auto-repair false missing
-grep -q '^rm -f py-bench$' <<<"$CASE_DOCKER_LOG" || fail "stopped container with missing mounts was not removed"
+run_launcher_case stopped-auto-repair false missing false false
+grep -q '^rm py-bench$' <<<"$CASE_DOCKER_LOG" || fail "stopped container with missing mounts was not removed safely"
 grep -q '^compose ' <<<"$CASE_DOCKER_LOG" || fail "stopped container with missing mounts was not recreated"
+
+run_launcher_case started-during-check false missing true true
+grep -q 'started while Wave mounts were being checked' <<<"$CASE_OUTPUT" || fail "container start race was not reported"
+if grep -q '^rm -f py-bench$' <<<"$CASE_DOCKER_LOG"; then
+    fail "automatic repair force-removed a container that started during checks"
+fi
+if grep -q '^compose ' <<<"$CASE_DOCKER_LOG"; then
+    fail "automatic repair recreated a container that started during checks"
+fi
 
 echo "PASS: wave container launcher lifecycle tests"

--- a/scripts/wave-container-shell.sh
+++ b/scripts/wave-container-shell.sh
@@ -12,6 +12,7 @@ workdir="/workspace"
 shell_path="zsh"
 block_title="pyBench"
 check_only=false
+repair_requested=false
 profile_launcher_marker="/usr/local/share/workbenches/profile-launchers.sha256"
 bench_dir="$workbenches_root/devBenches/pyBench"
 compose_file="$bench_dir/.devcontainer/docker-compose.yml"
@@ -58,6 +59,7 @@ Options:
   --shell PATH             Shell to run inside the container (default: zsh)
   --title TEXT             Wave block/terminal title (default: pyBench)
   --check                  Verify that the container can run a command, then exit
+  --repair                 Recreate an existing container before opening it
   -h, --help               Show this help
 EOF
 }
@@ -71,6 +73,7 @@ while [[ $# -gt 0 ]]; do
         --shell) shell_path="$2"; shift 2 ;;
         --title) block_title="$2"; shift 2 ;;
         --check) check_only=true; shift ;;
+        --repair) repair_requested=true; shift ;;
         -h|--help) usage; exit 0 ;;
         --*) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
         *) container="$1"; shift ;;
@@ -297,7 +300,18 @@ container_missing_required_mounts() {
     return 1
 }
 
-if ! docker container inspect "$container" >/dev/null 2>&1; then
+container_exists=false
+container_was_running=false
+if docker container inspect "$container" >/dev/null 2>&1; then
+    container_exists=true
+    if [[ "$(docker container inspect -f '{{.State.Running}}' "$container")" == "true" ]]; then
+        container_was_running=true
+    fi
+fi
+
+if [[ "$repair_requested" == true && "$container_exists" == true ]]; then
+    recreate_with_compose
+elif [[ "$container_exists" != true ]]; then
     if [[ -f "$bench_dir/.devcontainer/devcontainer.json" ]]; then
         echo "Creating $container with Dev Containers CLI..."
         if ! run_devcontainer_up; then
@@ -308,10 +322,13 @@ if ! docker container inspect "$container" >/dev/null 2>&1; then
     else
         create_with_compose
     fi
-fi
-
-if [[ -f "$bench_dir/.devcontainer/devcontainer.json" ]] && container_missing_required_mounts; then
-    recreate_with_compose
+elif [[ -f "$bench_dir/.devcontainer/devcontainer.json" ]] && container_missing_required_mounts; then
+    if [[ "$container_was_running" == true ]]; then
+        echo "Container '$container' is running but is missing required Wave mounts; preserving the live container." >&2
+        echo "Run this launcher with --repair when it is safe to recreate the container." >&2
+    else
+        recreate_with_compose
+    fi
 fi
 
 if [[ "$(docker container inspect -f '{{.State.Running}}' "$container")" != "true" ]]; then

--- a/scripts/wave-container-shell.sh
+++ b/scripts/wave-container-shell.sh
@@ -249,6 +249,23 @@ recreate_with_compose() {
     create_with_compose
 }
 
+recreate_stopped_with_compose() {
+    echo "Recreating stopped container $container with Wave compose mounts..."
+    if docker rm "$container" >/dev/null 2>&1; then
+        create_with_compose
+        return 0
+    fi
+
+    if [[ "$(docker container inspect -f '{{.State.Running}}' "$container" 2>/dev/null)" == "true" ]]; then
+        echo "Container '$container' started while Wave mounts were being checked; preserving the live container." >&2
+        echo "Run this launcher with --repair when it is safe to recreate the container." >&2
+        return 0
+    fi
+
+    echo "Could not remove stopped container '$container' for automatic Wave mount repair." >&2
+    return 1
+}
+
 mount_destination_covers() {
     local mount_destination="$1"
     local required_path="$2"
@@ -301,12 +318,8 @@ container_missing_required_mounts() {
 }
 
 container_exists=false
-container_was_running=false
 if docker container inspect "$container" >/dev/null 2>&1; then
     container_exists=true
-    if [[ "$(docker container inspect -f '{{.State.Running}}' "$container")" == "true" ]]; then
-        container_was_running=true
-    fi
 fi
 
 if [[ "$repair_requested" == true && "$container_exists" == true ]]; then
@@ -323,12 +336,7 @@ elif [[ "$container_exists" != true ]]; then
         create_with_compose
     fi
 elif [[ -f "$bench_dir/.devcontainer/devcontainer.json" ]] && container_missing_required_mounts; then
-    if [[ "$container_was_running" == true ]]; then
-        echo "Container '$container' is running but is missing required Wave mounts; preserving the live container." >&2
-        echo "Run this launcher with --repair when it is safe to recreate the container." >&2
-    else
-        recreate_with_compose
-    fi
+    recreate_stopped_with_compose
 fi
 
 if [[ "$(docker container inspect -f '{{.State.Running}}' "$container")" != "true" ]]; then


### PR DESCRIPTION
## Summary
- preserve an already-running bench when required Wave mounts drift
- add an explicit `--repair` option for intentional recreation
- retain automatic repair for stopped containers with missing mounts
- add mocked lifecycle regression coverage and document the safety boundary

## Verification
- `bash -n scripts/wave-container-shell.sh devcontainer.test/test-wave-container-shell.sh`
- `shellcheck -e SC2119,SC2120 scripts/wave-container-shell.sh devcontainer.test/test-wave-container-shell.sh`
- `bash devcontainer.test/test-wave-container-shell.sh`

## Summary by Sourcery

Make Wave container mount repair safe by preserving running benches unless recreation is explicitly requested.

New Features:
- Add an explicit `--repair` option for intentionally recreating existing bench containers.

Bug Fixes:
- Prevent automatic mount repair from force-removing or recreating a running container, including containers that start during mount checks.
- Continue automatically repairing stopped containers with missing required Wave mounts.

Enhancements:
- Document the launcher’s safety boundary for preserving live containers and opting into repair.

Documentation:
- Document when Wave bench containers are preserved versus automatically or explicitly repaired.

Tests:
- Add mocked lifecycle regression coverage for safe preservation, explicit repair, stopped-container repair, and startup races.