### PR TITLE
Make OpenSpec/Speckit bootstrap and worktree overlay shape-aware

### DIFF
--- a/devBenches/base-image/files/claude/commands/opsx/apply.md
+++ b/devBenches/base-image/files/claude/commands/opsx/apply.md
@@ -5,6 +5,20 @@ category: Workflow
 tags: [workflow, artifacts, experimental, teams]
 ---
 
+<!-- OPENSPEC-SPECKIT-SHAPE:START -->
+## Repository Shape (managed by setup-openspeckit)
+
+Resolve the project shape once before any step below.
+
+1. The project root is the nearest directory at or above the current one that contains `.specify/`. Run every `.specify/scripts/...` command from that root.
+2. If the root has `project.yaml` with `kind: project-manifest` and `legs:` entries for `role: spec` and `role: code`, this is an openRepoShape **three-leg** project. `<spec>` and `<code>` are those legs' `path:` values (defaults `spec` and `code`). Otherwise it is a **single repository** and `<spec>` and `<code>` are both the root.
+3. Three-leg placement: `openspec/` and `specs/NNN-*` live in the spec leg; source and tests live in the code leg; a feature's worktrees live at `worktrees/<NNN-feature>/<spec>/` and `worktrees/<NNN-feature>/<code>/` under the root. Never write feature work into `<spec>/` or `<code>/` at the root; they sit at the pinned commit.
+4. Feature paths come from `.specify/scripts/bash/check-prerequisites.sh --json` (or `SPECIFY_FEATURE_DIRECTORY` / `.specify/feature.json`). In three-leg, `FEATURE_DIR` is inside the feature's spec worktree and the code worktree is the sibling `<code>/` directory beside it; implementation edits go there.
+5. Run the `openspec` CLI with the current directory at the owner of `openspec/`: the root in a single repository, `<spec>/` in a three-leg project.
+
+Full rules: `${AGENT_PROTOCOL_ROOT:-$HOME/.agents}/protocols/openspec-speckit-workflow.md` ("Repository Shape", "Worktree Rules").
+<!-- OPENSPEC-SPECKIT-SHAPE:END -->
+
 Apply a governed OpenSpec change by executing the tasks in its one linked Speckit feature. OpenSpec remains the decision and handoff record; `specs/<feature>/tasks.md` is the only executable task authority.
 
 **Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
@@ -164,7 +178,7 @@ After all packages complete:
 
 For each pending Speckit task:
 - Show which task is being worked on
-- Make the code changes required
+- OpenSpec `tasks.md` carries handoff-level tasks only; implementation happens through the linked Speckit feature (`/speckit.implement`); tick OpenSpec tasks only when the corresponding Speckit work or governance step has actually landed
 - Keep changes minimal and focused
 - Mark the linked Speckit task complete: `- [ ]` → `- [x]`
 - Continue to next task

--- a/devBenches/base-image/files/claude/commands/opsx/archive.md
+++ b/devBenches/base-image/files/claude/commands/opsx/archive.md
@@ -5,6 +5,20 @@ category: Workflow
 tags: [workflow, archive, experimental]
 ---
 
+<!-- OPENSPEC-SPECKIT-SHAPE:START -->
+## Repository Shape (managed by setup-openspeckit)
+
+Resolve the project shape once before any step below.
+
+1. The project root is the nearest directory at or above the current one that contains `.specify/`. Run every `.specify/scripts/...` command from that root.
+2. If the root has `project.yaml` with `kind: project-manifest` and `legs:` entries for `role: spec` and `role: code`, this is an openRepoShape **three-leg** project. `<spec>` and `<code>` are those legs' `path:` values (defaults `spec` and `code`). Otherwise it is a **single repository** and `<spec>` and `<code>` are both the root.
+3. Three-leg placement: `openspec/` and `specs/NNN-*` live in the spec leg; source and tests live in the code leg; a feature's worktrees live at `worktrees/<NNN-feature>/<spec>/` and `worktrees/<NNN-feature>/<code>/` under the root. Never write feature work into `<spec>/` or `<code>/` at the root; they sit at the pinned commit.
+4. Feature paths come from `.specify/scripts/bash/check-prerequisites.sh --json` (or `SPECIFY_FEATURE_DIRECTORY` / `.specify/feature.json`). In three-leg, `FEATURE_DIR` is inside the feature's spec worktree and the code worktree is the sibling `<code>/` directory beside it; implementation edits go there.
+5. Run the `openspec` CLI with the current directory at the owner of `openspec/`: the root in a single repository, `<spec>/` in a three-leg project.
+
+Full rules: `${AGENT_PROTOCOL_ROOT:-$HOME/.agents}/protocols/openspec-speckit-workflow.md` ("Repository Shape", "Worktree Rules").
+<!-- OPENSPEC-SPECKIT-SHAPE:END -->
+
 Archive a completed change in the experimental workflow.
 
 **Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
@@ -54,7 +68,7 @@ Archive a completed change in the experimental workflow.
 
 5. **Assess delta spec sync state**
 
-   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+   Check for delta specs at `openspec/changes/<name>/specs/` (relative to the owner of `openspec/`; see Repository Shape). If none exist, proceed without sync prompt.
 
    **If delta specs exist:**
    - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
@@ -67,7 +81,7 @@ Archive a completed change in the experimental workflow.
 
    If user chooses sync, apply the delta specs directly using the standard OpenSpec delta rules. Update the corresponding files under `openspec/specs/<capability>/spec.md`, then proceed to archive. Do not invoke a separate sync skill or command unless it exists in the current project.
 
-6. **Perform the archive**
+6. **Perform the archive** (paths below are relative to the owner of `openspec/`; see Repository Shape)
 
    Create the archive directory if it doesn't exist:
    ```bash

--- a/devBenches/base-image/files/claude/commands/opsx/explore.md
+++ b/devBenches/base-image/files/claude/commands/opsx/explore.md
@@ -5,6 +5,20 @@ category: Workflow
 tags: [workflow, explore, experimental, thinking, teams]
 ---
 
+<!-- OPENSPEC-SPECKIT-SHAPE:START -->
+## Repository Shape (managed by setup-openspeckit)
+
+Resolve the project shape once before any step below.
+
+1. The project root is the nearest directory at or above the current one that contains `.specify/`. Run every `.specify/scripts/...` command from that root.
+2. If the root has `project.yaml` with `kind: project-manifest` and `legs:` entries for `role: spec` and `role: code`, this is an openRepoShape **three-leg** project. `<spec>` and `<code>` are those legs' `path:` values (defaults `spec` and `code`). Otherwise it is a **single repository** and `<spec>` and `<code>` are both the root.
+3. Three-leg placement: `openspec/` and `specs/NNN-*` live in the spec leg; source and tests live in the code leg; a feature's worktrees live at `worktrees/<NNN-feature>/<spec>/` and `worktrees/<NNN-feature>/<code>/` under the root. Never write feature work into `<spec>/` or `<code>/` at the root; they sit at the pinned commit.
+4. Feature paths come from `.specify/scripts/bash/check-prerequisites.sh --json` (or `SPECIFY_FEATURE_DIRECTORY` / `.specify/feature.json`). In three-leg, `FEATURE_DIR` is inside the feature's spec worktree and the code worktree is the sibling `<code>/` directory beside it; implementation edits go there.
+5. Run the `openspec` CLI with the current directory at the owner of `openspec/`: the root in a single repository, `<spec>/` in a three-leg project.
+
+Full rules: `${AGENT_PROTOCOL_ROOT:-$HOME/.agents}/protocols/openspec-speckit-workflow.md` ("Repository Shape", "Worktree Rules").
+<!-- OPENSPEC-SPECKIT-SHAPE:END -->
+
 Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
 
 **IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
@@ -176,7 +190,7 @@ Think freely. When insights crystallize, you might offer:
 
 If the user mentions a change or you detect one is relevant:
 
-1. **Read existing artifacts for context**
+1. **Read existing artifacts for context** (paths below are relative to the owner of `openspec/`; see Repository Shape)
    - `openspec/changes/<name>/proposal.md`
    - `openspec/changes/<name>/design.md`
    - `openspec/changes/<name>/tasks.md`

--- a/devBenches/base-image/files/claude/commands/opsx/propose.md
+++ b/devBenches/base-image/files/claude/commands/opsx/propose.md
@@ -5,6 +5,20 @@ category: Workflow
 tags: [workflow, artifacts, experimental, teams]
 ---
 
+<!-- OPENSPEC-SPECKIT-SHAPE:START -->
+## Repository Shape (managed by setup-openspeckit)
+
+Resolve the project shape once before any step below.
+
+1. The project root is the nearest directory at or above the current one that contains `.specify/`. Run every `.specify/scripts/...` command from that root.
+2. If the root has `project.yaml` with `kind: project-manifest` and `legs:` entries for `role: spec` and `role: code`, this is an openRepoShape **three-leg** project. `<spec>` and `<code>` are those legs' `path:` values (defaults `spec` and `code`). Otherwise it is a **single repository** and `<spec>` and `<code>` are both the root.
+3. Three-leg placement: `openspec/` and `specs/NNN-*` live in the spec leg; source and tests live in the code leg; a feature's worktrees live at `worktrees/<NNN-feature>/<spec>/` and `worktrees/<NNN-feature>/<code>/` under the root. Never write feature work into `<spec>/` or `<code>/` at the root; they sit at the pinned commit.
+4. Feature paths come from `.specify/scripts/bash/check-prerequisites.sh --json` (or `SPECIFY_FEATURE_DIRECTORY` / `.specify/feature.json`). In three-leg, `FEATURE_DIR` is inside the feature's spec worktree and the code worktree is the sibling `<code>/` directory beside it; implementation edits go there.
+5. Run the `openspec` CLI with the current directory at the owner of `openspec/`: the root in a single repository, `<spec>/` in a three-leg project.
+
+Full rules: `${AGENT_PROTOCOL_ROOT:-$HOME/.agents}/protocols/openspec-speckit-workflow.md` ("Repository Shape", "Worktree Rules").
+<!-- OPENSPEC-SPECKIT-SHAPE:END -->
+
 Propose a new governed change. After drafting the proposal, two review gates run before design and the Speckit handoff are generated:
 
 1. **Alignment Review** — An architect and QA lead verify the proposal against your architecture docs and requirements docs, fixing mismatches before anyone debates the proposal.
@@ -99,7 +113,7 @@ Spawn 2 agents **in a single message** (parallel) using the **Agent tool** with 
 
 > You are the **Stack Architect** reviewing a proposal for alignment with the project's architecture and tech stack conventions.
 >
-> **Read these files:**
+> **Read these files:** (OpenSpec paths below are relative to the owner of `openspec/`; see Repository Shape)
 > - Proposal: `openspec/changes/<name>/proposal.md`
 > - Config: `openspec/config.yaml` (especially `tech_stack` and `rules.design`)
 > - Architecture docs: all files in `docs/architecture/`
@@ -126,7 +140,7 @@ Spawn 2 agents **in a single message** (parallel) using the **Agent tool** with 
 
 > You are the **QA Lead** reviewing a proposal for alignment with the project's requirements documentation.
 >
-> **Read these files:**
+> **Read these files:** (OpenSpec paths below are relative to the owner of `openspec/`; see Repository Shape)
 > - Proposal: `openspec/changes/<name>/proposal.md`
 > - Config: `openspec/config.yaml`
 > - Requirements docs: all files in `docs/requirements/`
@@ -216,7 +230,7 @@ Each agent prompt must include:
 
 > You are the **Product Advocate** on a proposal review council. You care about user outcomes, scope clarity, and business value.
 >
-> Read the proposal at `openspec/changes/<name>/proposal.md`, the project config at `openspec/config.yaml`, and docs in `docs/requirements/` and `docs/architecture/`.
+> Read the proposal at `openspec/changes/<name>/proposal.md`, the project config at `openspec/config.yaml`, and docs in `docs/requirements/` and `docs/architecture/`. (OpenSpec paths are relative to the owner of `openspec/`; see Repository Shape.)
 >
 > Evaluate the proposal on these dimensions:
 >
@@ -238,7 +252,7 @@ Each agent prompt must include:
 
 > You are the **Systems Architect** on a proposal review council. You care about technical feasibility, architectural fit, and risk.
 >
-> Read the proposal at `openspec/changes/<name>/proposal.md`, the project config at `openspec/config.yaml`, docs in `docs/requirements/` and `docs/architecture/`, and explore the existing codebase (entry point, services, models, dependency manifest).
+> Read the proposal at `openspec/changes/<name>/proposal.md`, the project config at `openspec/config.yaml`, docs in `docs/requirements/` and `docs/architecture/`, and explore the existing codebase (entry point, services, models, dependency manifest). (OpenSpec paths are relative to the owner of `openspec/`; see Repository Shape.)
 >
 > Evaluate the proposal on these dimensions:
 >
@@ -260,7 +274,7 @@ Each agent prompt must include:
 
 > You are the **Adversary Engineer** on a proposal review council. Your job is to break the proposal. You think about what goes wrong, what's missing, and what assumptions are hiding.
 >
-> Read the proposal at `openspec/changes/<name>/proposal.md`, the project config at `openspec/config.yaml`, docs in `docs/requirements/` and `docs/architecture/`, and explore the existing codebase.
+> Read the proposal at `openspec/changes/<name>/proposal.md`, the project config at `openspec/config.yaml`, docs in `docs/requirements/` and `docs/architecture/`, and explore the existing codebase. (OpenSpec paths are relative to the owner of `openspec/`; see Repository Shape.)
 >
 > Attack the proposal on these dimensions:
 >

--- a/devBenches/base-image/files/claude/skills/opsx-analyze/SKILL.md
+++ b/devBenches/base-image/files/claude/skills/opsx-analyze/SKILL.md
@@ -6,6 +6,20 @@ metadata:
   version: "1.1"
 ---
 
+<!-- OPENSPEC-SPECKIT-SHAPE:START -->
+## Repository Shape (managed by setup-openspeckit)
+
+Resolve the project shape once before any step below.
+
+1. The project root is the nearest directory at or above the current one that contains `.specify/`. Run every `.specify/scripts/...` command from that root.
+2. If the root has `project.yaml` with `kind: project-manifest` and `legs:` entries for `role: spec` and `role: code`, this is an openRepoShape **three-leg** project. `<spec>` and `<code>` are those legs' `path:` values (defaults `spec` and `code`). Otherwise it is a **single repository** and `<spec>` and `<code>` are both the root.
+3. Three-leg placement: `openspec/` and `specs/NNN-*` live in the spec leg; source and tests live in the code leg; a feature's worktrees live at `worktrees/<NNN-feature>/<spec>/` and `worktrees/<NNN-feature>/<code>/` under the root. Never write feature work into `<spec>/` or `<code>/` at the root; they sit at the pinned commit.
+4. Feature paths come from `.specify/scripts/bash/check-prerequisites.sh --json` (or `SPECIFY_FEATURE_DIRECTORY` / `.specify/feature.json`). In three-leg, `FEATURE_DIR` is inside the feature's spec worktree and the code worktree is the sibling `<code>/` directory beside it; implementation edits go there.
+5. Run the `openspec` CLI with the current directory at the owner of `openspec/`: the root in a single repository, `<spec>/` in a three-leg project.
+
+Full rules: `${AGENT_PROTOCOL_ROOT:-$HOME/.agents}/protocols/openspec-speckit-workflow.md` ("Repository Shape", "Worktree Rules").
+<!-- OPENSPEC-SPECKIT-SHAPE:END -->
+
 You are a principal engineer and **team lead**. Your job is to orchestrate a deep pre-implementation audit by assembling a team of specialist agents, collecting their findings, and producing a unified audit report.
 
 **IMPORTANT: This is analysis only.** The team reads everything, reports findings, and you write a structured audit report. Nobody fixes issues — that happens after the user reviews your findings.
@@ -26,7 +40,7 @@ If multiple exist, use **AskUserQuestion** to ask which change to analyze.
 
 Before spawning the team, gather and read ALL context yourself. You need to brief the agents.
 
-**Change artifacts:**
+**Change artifacts:** (paths below are relative to the owner of `openspec/`; see Repository Shape)
 - `openspec/changes/<name>/proposal.md`
 - `openspec/changes/<name>/design.md`
 - `openspec/changes/<name>/tasks.md`
@@ -96,7 +110,7 @@ members and cannot be shut down as part of the team.
 
 > You are an audit agent. Read the following files, then run two analysis passes.
 >
-> **Files to read:**
+> **Files to read:** (OpenSpec paths below are relative to the owner of `openspec/`; see Repository Shape)
 > - `openspec/changes/<name>/proposal.md`
 > - `openspec/changes/<name>/design.md`
 > - `openspec/changes/<name>/tasks.md`
@@ -115,7 +129,7 @@ members and cannot be shut down as part of the team.
 
 > You are an audit agent. Read the following files, then run two analysis passes.
 >
-> **Files to read:**
+> **Files to read:** (OpenSpec paths below are relative to the owner of `openspec/`; see Repository Shape)
 > - `openspec/changes/<name>/design.md`
 > - `openspec/changes/<name>/tasks.md`
 > - `openspec/config.yaml`
@@ -133,7 +147,7 @@ members and cannot be shut down as part of the team.
 
 > You are an audit agent. Read the following files, then run two analysis passes.
 >
-> **Files to read:**
+> **Files to read:** (OpenSpec paths below are relative to the owner of `openspec/`; see Repository Shape)
 > - `openspec/changes/<name>/tasks.md`
 > - `openspec/changes/<name>/design.md`
 > - `openspec/changes/<name>/proposal.md`
@@ -150,7 +164,7 @@ members and cannot be shut down as part of the team.
 
 > You are an audit agent. Read the following files, then run two analysis passes.
 >
-> **Files to read:**
+> **Files to read:** (OpenSpec paths below are relative to the owner of `openspec/`; see Repository Shape)
 > - `openspec/changes/<name>/design.md`
 > - `openspec/changes/<name>/tasks.md`
 > - `openspec/config.yaml`
@@ -193,7 +207,7 @@ Focus on:
 
 ## Phase 4: Assemble the Audit Report
 
-Collect findings from all 4 agents plus your own Pass 9 results. Write the unified report to:
+Collect findings from all 4 agents plus your own Pass 9 results. Write the unified report to (relative to the owner of `openspec/`; see Repository Shape):
 **`openspec/changes/<name>/audit-report.md`**
 
 ```markdown

--- a/devBenches/base-image/files/claude/skills/opsx-clarify/SKILL.md
+++ b/devBenches/base-image/files/claude/skills/opsx-clarify/SKILL.md
@@ -6,6 +6,20 @@ metadata:
   version: "2.0"
 ---
 
+<!-- OPENSPEC-SPECKIT-SHAPE:START -->
+## Repository Shape (managed by setup-openspeckit)
+
+Resolve the project shape once before any step below.
+
+1. The project root is the nearest directory at or above the current one that contains `.specify/`. Run every `.specify/scripts/...` command from that root.
+2. If the root has `project.yaml` with `kind: project-manifest` and `legs:` entries for `role: spec` and `role: code`, this is an openRepoShape **three-leg** project. `<spec>` and `<code>` are those legs' `path:` values (defaults `spec` and `code`). Otherwise it is a **single repository** and `<spec>` and `<code>` are both the root.
+3. Three-leg placement: `openspec/` and `specs/NNN-*` live in the spec leg; source and tests live in the code leg; a feature's worktrees live at `worktrees/<NNN-feature>/<spec>/` and `worktrees/<NNN-feature>/<code>/` under the root. Never write feature work into `<spec>/` or `<code>/` at the root; they sit at the pinned commit.
+4. Feature paths come from `.specify/scripts/bash/check-prerequisites.sh --json` (or `SPECIFY_FEATURE_DIRECTORY` / `.specify/feature.json`). In three-leg, `FEATURE_DIR` is inside the feature's spec worktree and the code worktree is the sibling `<code>/` directory beside it; implementation edits go there.
+5. Run the `openspec` CLI with the current directory at the owner of `openspec/`: the root in a single repository, `<spec>/` in a three-leg project.
+
+Full rules: `${AGENT_PROTOCOL_ROOT:-$HOME/.agents}/protocols/openspec-speckit-workflow.md` ("Repository Shape", "Worktree Rules").
+<!-- OPENSPEC-SPECKIT-SHAPE:END -->
+
 You are a **team lead** orchestrating a proposal clarification. You assemble a team of three specialist analysts who each examine the proposal from a different engineering perspective, then you curate their best questions, ask the user, and capture the answers.
 
 **IMPORTANT: This is a clarification step, not a design step.** The team finds gaps and generates candidate questions. You curate and ask them. You capture answers. Nobody writes design.md or tasks.md — those artifacts are prepared in the design/task phases before implementation.
@@ -26,7 +40,7 @@ If multiple exist, use **AskUserQuestion** to ask which change to clarify.
 
 Read ALL of these before spawning agents. You need the full picture to write good agent prompts.
 
-**Change artifacts:**
+**Change artifacts:** (paths below are relative to the owner of `openspec/`; see Repository Shape)
 - `openspec/changes/<name>/proposal.md` — the proposal to clarify
 - `openspec/changes/<name>/clarifications.md` — if it exists (don't re-ask answered questions)
 
@@ -166,7 +180,7 @@ Example of a bad question:
 
 After the user answers, create or update the clarifications file:
 
-**Write to:** `openspec/changes/<name>/clarifications.md`
+**Write to:** `openspec/changes/<name>/clarifications.md` (relative to the owner of `openspec/`; see Repository Shape)
 
 ```markdown
 # Clarifications

--- a/devBenches/base-image/files/openspeckit/setup-openspeckit
+++ b/devBenches/base-image/files/openspeckit/setup-openspeckit
@@ -5,8 +5,9 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Iterator
-from contextlib import ExitStack, contextmanager
+from contextlib import AbstractContextManager, ExitStack, contextmanager
 from dataclasses import dataclass
+import fnmatch
 import hashlib
 import json
 import os
@@ -16,13 +17,24 @@ import stat
 import subprocess
 import sys
 import tempfile
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Final
 
 
 START = "<!-- OPENSPEC-SPECKIT-GLOBAL:START -->"
 END = "<!-- OPENSPEC-SPECKIT-GLOBAL:END -->"
+SHAPE_START = "<!-- OPENSPEC-SPECKIT-SHAPE:START -->"
+SHAPE_END = "<!-- OPENSPEC-SPECKIT-SHAPE:END -->"
 REPO_AGENT_ROOT: Final = "${AGENT_PROTOCOL_ROOT:-$HOME/.agents}"
+SHAPE_FIRST_LINE_SENTINEL: Final = "AGENTS-shape.md"
+DEFAULT_LEG_PATHS: Final = {"spec": "spec", "code": "code"}
+THREE_LEG_WORKTREE_ROOT: Final = "worktrees"
+WORKTREES_IGNORE_LINE: Final = "/worktrees/"
+OVERLAY_SHAPE_MARKER: Final = "# speckit-overlay-shape: 1"
+OVERLAY_SHAPE_MARKER_FILES: Final = (
+    "scripts/bash/create-new-feature.sh",
+    "scripts/bash/git-common.sh",
+)
 DIRECTORY_OPEN_FLAGS: Final = (
     os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
 )
@@ -56,6 +68,14 @@ class SourceTreeEntry:
     mode: int
     device: int
     inode: int
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectShape:
+    spec_path: str
+    code_path: str
+    spec_leg: Path
+    code_leg: Path
 
 
 SKILLS = [
@@ -206,9 +226,23 @@ def parse_args() -> argparse.Namespace:
         help="Worktree parent path, relative to repo root unless absolute. Defaults to ../<repo-name>-worktrees.",
     )
     parser.add_argument(
+        "--shape",
+        choices=("auto", "on", "off"),
+        default="auto",
+        help=(
+            "Repository shape handling: auto detects project.yaml, on requires the "
+            "three-leg layout, off forces the single-repository layout."
+        ),
+    )
+    parser.add_argument(
         "--no-skill-links",
         action="store_true",
         help="Do not link global skills into repo-local agent folders.",
+    )
+    parser.add_argument(
+        "--no-skill-shape-blocks",
+        action="store_true",
+        help="Do not maintain the managed Repository Shape block in skills and commands.",
     )
     parser.add_argument(
         "--no-global-agent-pointers",
@@ -223,8 +257,66 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+LOG_PREFIX = ""
+LOG_RECORDER: list[str] | None = None
+
+
 def log(message: str) -> None:
-    print(message)
+    if LOG_RECORDER is not None:
+        LOG_RECORDER.append(message)
+    print(f"{LOG_PREFIX}{message}")
+
+
+@contextmanager
+def log_context(prefix: str, recorder: list[str] | None = None) -> Iterator[None]:
+    """Prefix and optionally record every log line written inside the block."""
+    global LOG_PREFIX, LOG_RECORDER
+    previous_prefix = LOG_PREFIX
+    previous_recorder = LOG_RECORDER
+    LOG_PREFIX = prefix
+    LOG_RECORDER = recorder
+    try:
+        yield
+    finally:
+        LOG_PREFIX = previous_prefix
+        LOG_RECORDER = previous_recorder
+
+
+ROOT_LOG_PREFIX = ""
+SPEC_LOG_PREFIX = ""
+SPEC_LEG_WRITES: list[str] = []
+
+
+def root_scope() -> AbstractContextManager[None]:
+    """Log lines written to the assembly root (or to a single repository)."""
+    return log_context(ROOT_LOG_PREFIX, None)
+
+
+def spec_scope() -> AbstractContextManager[None]:
+    """Log lines written to the spec leg (or to a single repository)."""
+    return log_context(SPEC_LOG_PREFIX, SPEC_LEG_WRITES)
+
+
+def enable_shape_log_scopes(dry_run: bool) -> None:
+    """Prefix planned three-leg writes with the repository they land in."""
+    global ROOT_LOG_PREFIX, SPEC_LOG_PREFIX
+    if dry_run:
+        ROOT_LOG_PREFIX = "[root] "
+        SPEC_LOG_PREFIX = "[spec] "
+
+
+def spec_leg_written_paths() -> list[str]:
+    written: list[str] = []
+    for message in SPEC_LEG_WRITES:
+        for verb in ("wrote ", "created ", "copied "):
+            if message.startswith(verb):
+                path = message[len(verb) :]
+                if verb == "copied " and " -> " in path:
+                    path = path.split(" -> ", 1)[1]
+                if path not in written:
+                    written.append(path)
+                break
+    return written
 
 
 def run_command(command: list[str], cwd: Path, dry_run: bool) -> None:
@@ -644,7 +736,28 @@ def upsert_block(path: Path, block_body: str, dry_run: bool) -> None:
                 # index points at the newline before the first section heading.
                 new_text = text[:index].rstrip() + "\n\n" + block + "\n" + text[index + 1 :]
 
+    assert_preserved_first_line(path, text, new_text)
     write_text(path, new_text, dry_run)
+
+
+def first_line(text: str) -> str:
+    lines = text.splitlines()
+    return lines[0] if lines else ""
+
+
+def assert_preserved_first_line(path: Path, before: str, after: str) -> None:
+    """Refuse to displace a shape pointer that must stay on line 1."""
+    before_first = first_line(before)
+    if SHAPE_FIRST_LINE_SENTINEL not in before_first:
+        return
+    after_first = first_line(after)
+    if after_first == before_first:
+        return
+    raise SystemExit(
+        f"Refusing to move the first line of {path}: "
+        f"line 1 is {before_first!r} but the managed block would make it "
+        f"{after_first!r}."
+    )
 
 
 def safe_source_tree_entries(src: Path) -> list[SourceTreeEntry]:
@@ -1460,7 +1573,26 @@ def skill_tree_will_be_usable(path: Path, force: bool) -> bool:
     return skill_mode is None or stat.S_ISREG(skill_mode) or force
 
 
-def has_compatible_worktree_git_overlay(repo: Path) -> bool:
+def has_overlay_shape_marker(overlay_root: Path) -> bool:
+    """Report whether a git overlay tree carries the shape-aware compatibility marker."""
+    try:
+        for relative_path in OVERLAY_SHAPE_MARKER_FILES:
+            content = read_destination_text(overlay_root / relative_path)
+            if content is None:
+                return False
+            if not any(
+                line.strip() == OVERLAY_SHAPE_MARKER for line in content.splitlines()
+            ):
+                return False
+    except (OSError, UnicodeError):
+        return False
+    return True
+
+
+def has_compatible_worktree_git_overlay(
+    repo: Path,
+    template_root: Path | None = None,
+) -> bool:
     overlay_root = repo / ".specify" / "extensions" / "git"
     contents: dict[str, str] = {}
     try:
@@ -1472,9 +1604,207 @@ def has_compatible_worktree_git_overlay(repo: Path) -> bool:
     except (OSError, UnicodeError):
         return False
 
-    return LOAD_GIT_WORKTREES_DEFINITION.search(
+    if LOAD_GIT_WORKTREES_DEFINITION.search(
         contents["scripts/bash/git-common.sh"]
-    ) is not None
+    ) is None:
+        return False
+
+    # The shape marker can only be demanded of an installed overlay once the
+    # templates this bootstrap installs from carry it themselves.
+    if template_root is not None and has_overlay_shape_marker(
+        template_root / "specify" / "extensions" / "git"
+    ):
+        return has_overlay_shape_marker(overlay_root)
+    return True
+
+
+def strip_yaml_comment(line: str) -> str:
+    """Drop a trailing ``#`` comment that starts outside a quoted scalar."""
+    quote: str | None = None
+    for index, character in enumerate(line):
+        if quote is not None:
+            if character == quote:
+                quote = None
+            continue
+        if character in "'\"":
+            quote = character
+            continue
+        if character == "#":
+            return line[:index].rstrip()
+    return line.rstrip()
+
+
+def unquote_yaml_scalar(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "'\"":
+        return value[1:-1]
+    return value
+
+
+def manifest_lines(path: Path) -> list[str] | None:
+    try:
+        text = read_destination_text(path)
+    except (OSError, UnicodeError):
+        return None
+    if text is None:
+        return None
+    return [strip_yaml_comment(line) for line in text.splitlines()]
+
+
+def manifest_top_level_value(lines: list[str], key: str) -> str | None:
+    for line in lines:
+        if not line or line[0] in " \t-":
+            continue
+        name, separator, value = line.partition(":")
+        if separator and name.strip() == key:
+            return unquote_yaml_scalar(value)
+    return None
+
+
+def manifest_legs(lines: list[str]) -> list[dict[str, str]]:
+    """Read the ``legs:`` list of a project manifest without a YAML library."""
+    legs: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    current_indent = 0
+    in_legs = False
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        indent = len(line) - len(line.lstrip(" \t"))
+        if indent == 0:
+            name, separator, _ = stripped.partition(":")
+            if separator and name.strip() == "legs":
+                in_legs = True
+                current = None
+                continue
+            if in_legs:
+                break
+            continue
+        if not in_legs:
+            continue
+        if stripped == "-" or stripped.startswith("- "):
+            offset = 1
+            while offset < len(stripped) and stripped[offset] == " ":
+                offset += 1
+            current = {}
+            current_indent = indent + offset
+            legs.append(current)
+            stripped = stripped[offset:]
+            if not stripped:
+                continue
+        elif current is None or indent != current_indent:
+            continue
+        name, separator, value = stripped.partition(":")
+        if not separator:
+            continue
+        scalar = unquote_yaml_scalar(value)
+        if scalar and current is not None:
+            current.setdefault(name.strip(), scalar)
+    return legs
+
+
+def relative_leg_path(root: Path, role: str, value: str) -> str:
+    candidate = PurePosixPath(value)
+    if candidate.is_absolute() or ".." in candidate.parts or value in ("", "."):
+        raise SystemExit(
+            f"Refusing unusable {role} leg path {value!r} in {root / 'project.yaml'}: "
+            "leg paths must be relative to the assembly root."
+        )
+    return value
+
+
+def detect_project_shape(repo: Path) -> ProjectShape | None:
+    """Return the three-leg shape of ``repo``, or None for a single repository."""
+    lines = manifest_lines(repo / "project.yaml")
+    if lines is None:
+        return None
+    if manifest_top_level_value(lines, "kind") != "project-manifest":
+        return None
+    if manifest_top_level_value(lines, "schema") != "project-repo-schema":
+        return None
+
+    paths: dict[str, str] = {}
+    for leg in manifest_legs(lines):
+        role = leg.get("role")
+        if role in DEFAULT_LEG_PATHS and role not in paths:
+            paths[role] = leg.get("path") or DEFAULT_LEG_PATHS[role]
+    if "spec" not in paths or "code" not in paths:
+        return None
+
+    spec_path = relative_leg_path(repo, "spec", paths["spec"])
+    code_path = relative_leg_path(repo, "code", paths["code"])
+    return ProjectShape(
+        spec_path=spec_path,
+        code_path=code_path,
+        spec_leg=repo / spec_path,
+        code_leg=repo / code_path,
+    )
+
+
+def is_family_holder(repo: Path) -> bool:
+    """Report whether ``repo`` is a family holder rather than a project."""
+    if mode_without_following(repo / "project.yaml") is not None:
+        return False
+    lines = manifest_lines(repo / "family.yaml")
+    if lines is None:
+        return False
+    return manifest_top_level_value(lines, "kind") == "family-manifest"
+
+
+def ensure_initialised_spec_leg(repo: Path, shape: ProjectShape) -> None:
+    """Refuse a three-leg root whose spec leg has not been fetched."""
+    remedy = (
+        "Fetch the legs first: `git submodule update --init` (or `make bootstrap`), "
+        "then re-run setup-openspeckit."
+    )
+    leg_mode = mode_without_following(shape.spec_leg)
+    if leg_mode is None or not stat.S_ISDIR(leg_mode):
+        raise SystemExit(
+            f"Refusing to bootstrap {repo}: the spec leg "
+            f"{shape.spec_path}/ named by project.yaml is missing. {remedy}"
+        )
+    if mode_without_following(shape.spec_leg / ".git") is None:
+        raise SystemExit(
+            f"Refusing to bootstrap {repo}: the spec leg "
+            f"{shape.spec_path}/ is not an initialised git checkout. {remedy}"
+        )
+
+
+def resolve_project_shape(repo: Path, mode: str) -> ProjectShape | None:
+    """Apply --shape to the detected manifest and validate the three-leg root."""
+    if mode == "off":
+        log("shape: single repository (forced by --shape off)")
+        return None
+
+    shape = detect_project_shape(repo)
+    if shape is None:
+        family = is_family_holder(repo)
+        if mode == "on":
+            reason = (
+                "it is a family holder (family.yaml, kind: family-manifest)"
+                if family
+                else "no project.yaml with kind: project-manifest and spec/code legs was found"
+            )
+            raise SystemExit(
+                f"Refusing --shape on for {repo}: {reason}. "
+                "Use --shape off or --shape auto for a single repository."
+            )
+        if family:
+            log(
+                "shape: family holder (family.yaml, kind: family-manifest); "
+                "using the single-repository layout"
+            )
+        else:
+            log("shape: single repository")
+        return None
+
+    ensure_initialised_spec_leg(repo, shape)
+    log(
+        "shape: openRepoShape three-leg "
+        f"(spec leg {shape.spec_path}/, code leg {shape.code_path}/)"
+    )
+    return shape
 
 
 def can_write_path_or_parent(path: Path) -> bool:
@@ -1512,21 +1842,34 @@ Core rule:
   specify/clarify/plan/tasks/analyze/implement lifecycle.
 - Do not duplicate task lists: OpenSpec records governance and handoff; Speckit
   owns implementation tasks.
+- The protocol is shape-aware. Detect the shape first (single repository or
+  openRepoShape three-leg, from `project.yaml`), then use the placement and
+  worktree rules for that shape. In a three-leg project `openspec/` and
+  `specs/` live in the spec leg, code lives in the code leg, and feature
+  worktrees live under `<root>/worktrees/<NNN-feature>/{{spec,code}}/`.
 
 ## Repository Overrides
 
 Repo-local instructions remain authoritative for project-specific details such
 as package commands, runtime prerequisites, test commands, source-of-truth docs,
 and deployment constraints.
+
+When a repo-local file conflicts with the global OpenSpec/Speckit mechanics,
+follow the global protocol unless the repo-local file explicitly says it is
+overriding the global rule for that repository.
 """
 
 
-def openspec_speckit_protocol() -> str:
-    return """# OpenSpec and Speckit Shared Workflow
+def openspec_speckit_protocol(agent_root: Path) -> str:
+    return f"""# OpenSpec and Speckit Shared Workflow
 
 This protocol is the shared source of truth for using OpenSpec and Speckit
 together across local coding agents. Repo-local files should reference this file
 instead of copying the same process text into each project.
+
+This protocol is shape-aware. It applies to single-repository projects and to
+openRepoShape three-leg projects alike; wherever the two differ, the rule names
+the shape it is for. Read "Repository Shape" first.
 
 ## Authority
 
@@ -1548,6 +1891,58 @@ and verification.
 
 Do not duplicate task lists between the two systems. OpenSpec records the
 governed decision and handoff. Speckit owns the executable implementation tasks.
+
+## Repository Shape
+
+Every project is one of two shapes.
+
+**Single repository.** One git repository holds tooling, specifications, and
+code together. `.specify/`, `openspec/`, `specs/`, and the source tree all sit
+at that repository's root.
+
+**Three-leg project (openRepoShape).** An assembly root that an engineer
+clones, with a `spec` leg and a `code` leg mounted inside it as git
+submodules. The root holds `project.yaml`, the pins, and the project-level
+tooling. The spec leg holds what the project has decided. The code leg holds
+the implementation. Committing in a leg does not advance the project; only a
+root commit that moves that leg's pin does. The bootstrap side of this shape
+is in `{agent_root / "protocols" / "project-agent-bootstrap.md"}`; the shape
+itself is the openRepoShape standard and its `AGENTS-shape.md` in every root.
+
+### Detecting the shape
+
+Read `project.yaml` at the checkout root. It is a three-leg project when the
+file carries `kind: project-manifest`, `schema: project-repo-schema`, and
+`legs:` entries for `role: spec` and `role: code`; their `path:` values are
+the mount points, `spec` and `code` by default. Anything else is a single
+repository.
+
+If the checkout has no `project.yaml` but its `AGENTS.md` says it is a leg of
+a project, you are standing in a leg clone. Stop and move to the assembly
+root: a leg clone can see neither the manifest nor the other leg, and this
+protocol runs from the root. A `family.yaml` with `kind: family-manifest` and
+no `project.yaml` is a family holder, not a project; go to a member project.
+
+### Placement
+
+| artifact | single repository | three-leg project |
+|---|---|---|
+| `.specify/` (templates, memory, scripts, git extension) | repo root | assembly root |
+| agent context files and their managed blocks | repo root | assembly root |
+| `.claude/commands/opsx/*` and skill links | repo root | assembly root |
+| `openspec/` (changes, specs, archive) | repo root | spec leg: `<spec>/openspec/` |
+| Speckit feature directories `specs/NNN-*` | repo root | spec leg: `<spec>/specs/NNN-*` |
+| implementation source and tests | repo root | code leg: `<code>/` |
+| feature worktrees | `../<repo>-worktrees/<NNN-feature>/` | `<root>/worktrees/<NNN-feature>/{{spec,code}}/` |
+
+`<spec>` and `<code>` are the `path:` values from `project.yaml`. In a single
+repository both resolve to the repository root, and every rule below that
+names a leg reads as "the repository".
+
+Run the `openspec` CLI with the current directory set to wherever `openspec/`
+lives: the repo root in a single repository, the spec leg checkout in a
+three-leg project. The CLI resolves `openspec/` from the current directory
+and has no flag for another location.
 
 ## When To Use OpenSpec
 
@@ -1571,12 +1966,19 @@ decision is being made.
 1. OpenSpec proposal or exploration captures the decision.
 2. OpenSpec apply work keeps proposal, design notes, and spec deltas current.
 3. The OpenSpec change hands off to exactly one Speckit feature under
-   `specs/NNN-*`.
+   `specs/NNN-*` (in a three-leg project, `<spec>/specs/NNN-*`).
 4. Speckit creates or updates the implementation worktree and artifacts.
 5. Implementation happens from the Speckit feature worktree.
-6. Review and verification happen on the implementation branch or PR.
+6. Review and verification happen on the implementation branch or PR. In a
+   three-leg project that means the leg PRs and then the root pin-bump PR.
 7. Archive the OpenSpec change only after the corresponding Speckit work and PR
-   have landed, or after the change is explicitly abandoned.
+   have landed, or after the change is explicitly abandoned. In a three-leg
+   project, "landed" means the root pin bump that carries the work has merged.
+
+In a three-leg project an OpenSpec change is authored in the spec leg checkout
+at `<root>/<spec>/` on a branch named after the change, and landed by pull
+request in the spec repository. Bump the root's spec pin when the project
+needs the root to see it, and always before the change is archived.
 
 For shipped-feature amendments, do not silently rewrite history. Capture the
 new interpretation as an OpenSpec change first, then update docs/specs/code
@@ -1584,8 +1986,66 @@ through the normal handoff.
 
 ## Worktree Rules
 
-Run `/speckit.specify` only from the root checkout on the repo base branch
-unless the repo explicitly documents a different creation path.
+A Speckit feature is always worked in a linked git worktree, never on the base
+branch of a checkout, in both shapes. The layout differs by shape and follows
+one rule: **a worktree never lives inside a tree that holds code.** A worktree
+nested in a code tree is swept by `git clean -fdx` and indexed by every tool
+that recurses from that tree's root.
+
+### Single repository layout
+
+Worktrees live beside the repository under `../<repo>-worktrees/`, one
+directory per feature named after the branch, for example
+`../IRRS-worktrees/001-irrs-routing-core/`. Each worktree is a full checkout of
+the repository on its `NNN-feature-name` branch and carries its own
+`.specify/`, `specs/NNN-feature-name/`, and code.
+`.specify/extensions/git/git-config.yml` records this as `checkout_mode:
+worktree`, `base_branch: <base>`, and `worktree_root: ../<repo>-worktrees`.
+
+### Three-leg layout
+
+Worktrees live inside the assembly root under `worktrees/`, one directory per
+feature, holding a linked worktree of each leg:
+
+```text
+<root>/
+  project.yaml
+  .specify/
+  spec/                        spec leg submodule, at the pinned commit
+  code/                        code leg submodule, at the pinned commit
+  worktrees/
+    001-irrs-routing-core/
+      spec/                    worktree of the spec repo, branch 001-irrs-routing-core
+      code/                    worktree of the code repo, branch 001-irrs-routing-core
+```
+
+The root holds no code, so nesting is safe there, and the legs never see the
+worktrees. The root's `.gitignore` carries `/worktrees/`, and nothing under
+that directory is ever committed to the root. `git-config.yml` records
+`worktree_root: worktrees`.
+
+Both leg worktrees use the same `NNN-feature-name` branch, cut from each leg's
+base branch as last fetched (`origin/<base>`), not from the pinned commit. The
+Speckit feature directory is
+`worktrees/<NNN-feature-name>/spec/specs/<NNN-feature-name>/`, and the
+implementation goes under `worktrees/<NNN-feature-name>/code/`. The root
+itself gets no feature branch until the pin bump at the end.
+
+Feature numbering takes the next free number after scanning `specs/` on the
+spec leg's base branch and the branch lists of both leg repositories.
+
+A linked worktree records an absolute path to its repository's git directory.
+That is machine-managed plumbing, exempt from the no-host-paths rule, but it
+breaks when the checkout moves on disk. After any move, symlink change, or
+container remount, run `git worktree repair` from the owning repository (from
+each leg, in a three-leg project) before doing anything else.
+
+### Creating a feature
+
+Run `/speckit.specify` only from the root checkout on the base branch unless
+the repo explicitly documents a different creation path. In a three-leg
+project the root checkout is the assembly root on its tracking branch, with
+both legs present (`git submodule update --init` or `make bootstrap`).
 
 Before running `/speckit.specify`, verify from the same shell/container:
 
@@ -1594,15 +2054,22 @@ git status -sb
 git branch --show-current
 ```
 
+In a three-leg project run the same two commands inside `<spec>/` and
+`<code>/` as well.
+
 If the root checkout is not on the intended base branch or has unintended dirty
 work, stop and preserve or commit that work before creating a new Speckit
 feature.
 
 Do not pre-create agent-prefixed branches for Speckit features. Let Speckit's
 feature/worktree hook create the canonical `NNN-feature-name` branch/worktree.
+In a three-leg project that hook creates both leg branches and both leg
+worktrees in one run.
 
-After `/speckit.specify` creates a worktree, run follow-on Speckit commands from
-that generated worktree, not from the root checkout:
+### Working a feature
+
+Run follow-on Speckit commands with the feature selected, never against the
+base branch:
 
 - `/speckit.clarify`
 - `/speckit.checklist`
@@ -1611,8 +2078,34 @@ that generated worktree, not from the root checkout:
 - `/speckit.analyze`
 - `/speckit.implement`
 
+Single repository: run them from inside the feature worktree, which carries
+its own `.specify/`.
+
+Three-leg project: run them from the assembly root, the only place `.specify/`
+exists, with the feature selected. `.specify/feature.json` records the feature
+most recently created. A session working any other feature first exports
+`SPECIFY_FEATURE=<NNN-feature-name>` and
+`SPECIFY_FEATURE_DIRECTORY=worktrees/<NNN-feature-name>/spec/specs/<NNN-feature-name>`.
+The feature's edits go to its two worktrees only; `<spec>/` and `<code>/` at
+the root sit at the pinned commit and belong to the project, not the feature.
+
 If a requested follow-on command targets a worktree that does not exist, stop
 and report that. Do not silently fall back to the root checkout.
+
+### Landing a feature
+
+Single repository: commit on the feature branch, open the PR, land it, then
+remove the worktree.
+
+Three-leg project: commit in the leg worktrees, and land each leg by pull
+request in its own repository. Landing a leg does not advance the project.
+Once the leg PRs have merged, cut a root branch of the same `NNN-feature-name`
+and make the pin bump: for each leg moved, one root commit that moves the
+gitlink, `commit:` in `contracts/<role>-pin.yaml`, and every workflow `@<sha>`
+naming that leg together. `bump-leg.py` from an openRepoShape checkout does
+this; never a bare `git submodule update` followed by a commit. Land the root
+branch by PR, then remove both leg worktrees and the feature's directory under
+`worktrees/`. Archive the OpenSpec change only after that root PR has merged.
 
 ## Speckit Clarify Rules
 
@@ -1637,6 +2130,10 @@ Claude:
 - `/opsx:archive` for completed OpenSpec changes
 - `/speckit.specify`, `/speckit.clarify`, `/speckit.plan`, `/speckit.tasks`,
   `/speckit.analyze`, and `/speckit.implement` for the Speckit lifecycle
+
+The `/opsx:*` commands run with the current directory at the owner of
+`openspec/` (see "Placement"). The `/speckit.*` commands run where "Worktree
+Rules" says for the shape.
 
 Codex:
 
@@ -1692,16 +2189,26 @@ setup-openspeckit
 
 That command installs managed pointers to this protocol and links common
 agent-facing OpenSpec/Speckit skills and command wrappers without overwriting
-repo-specific guidance outside managed blocks.
+repo-specific guidance outside managed blocks. Its shape handling, the
+`--shape` flag, and what the installed script implements today are recorded
+in `{agent_root / "protocols" / "project-agent-bootstrap.md"}`.
 """
 
 
 def project_agent_bootstrap_protocol(agent_root: Path) -> str:
     return f"""# Project Agent Bootstrap
 
-`setup-openspeckit` prepares a repository so Codex, Claude, opencode, and other
-local coding agents can find the same OpenSpec/Speckit workflow without copying
-long process docs into every repo.
+`setup-openspeckit` prepares a repository so Codex, Claude,
+opencode, and other local coding agents can find the same OpenSpec/Speckit
+workflow without copying long process docs into every repo.
+
+This contract is shape-aware: it covers single-repository projects and
+openRepoShape three-leg projects. The shape rules an agent follows once the
+bootstrap has run are in
+`{agent_root / "protocols" / "openspec-speckit-workflow.md"}` ("Repository
+Shape" and "Worktree Rules"); this file says what the bootstrap writes so
+those rules hold. See "Script Status" at the end for what the installed script
+implements today.
 
 ## What It Updates
 
@@ -1709,27 +2216,39 @@ The bootstrap script is idempotent and marker-based. It can be re-run safely.
 
 It updates or creates:
 
-- repo-local context files for Speckit-supported agent integrations
-- `openspec/README.md` and `.specify/README.md` as thin pointers to the global
-  workflow
+- repo-local context files for every Speckit-supported agent integration,
+  including `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`,
+  `.github/copilot-instructions.md`, `.cursor/rules/specify-rules.mdc`,
+  `.roo/rules/specify-rules.md`, `.windsurf/rules/specify-rules.md`, and the
+  other integration-specific files from Speckit's registry
+- `openspec/README.md` as a thin repo-local pointer to the global workflow
+- `.specify/README.md` as a thin repo-local pointer to the global workflow
 - `.claude/commands/opsx/*` from global templates when missing
-- copied directories under `.claude/skills`, `.codex/skills`, and
-  `.agents/skills` for available global OpenSpec/Speckit skills
+- `.claude/skills`, `.codex/skills`, and `.agents/skills` links for available
+  global OpenSpec/Speckit skills
 - minimal `openspec/changes/archive`, `openspec/specs`, and `.specify/`
-  scaffolding when those directories are absent
-- user-global agent entrypoint pointers for practical global agent homes
+  scaffolding when those directories are absent (in a three-leg project the
+  OpenSpec half of that lands in the spec leg — see Three-leg Projects)
+- the worktree settings in `.specify/extensions/git/git-config.yml`
+  (`checkout_mode`, `base_branch`, `worktree_root`) for the detected shape,
+  when that file exists and the keys are absent — see Worktree Layout
+- user-global agent entrypoint pointers for Codex, Claude, opencode, Cursor,
+  Gemini, Copilot, Roo, Windsurf, Qwen, Kimi, and other practical homes that
+  match Speckit's supported integration context files
 
 ## Idempotency Rules
 
-Generated sections are bounded by:
+The script only edits generated sections between:
 
 ```md
 <!-- OPENSPEC-SPECKIT-GLOBAL:START -->
 <!-- OPENSPEC-SPECKIT-GLOBAL:END -->
 ```
 
-Existing hand-written content outside those markers is preserved. Existing skill
-directories and command files are not overwritten unless `--force` is passed.
+Existing hand-written content outside those markers is preserved.
+
+Existing skill directories and command files are not overwritten unless `--force`
+is passed. Default behavior prefers leaving local customizations alone.
 
 ## Usage
 
@@ -1745,7 +2264,219 @@ From anywhere:
 setup-openspeckit --repo /path/to/repo
 ```
 
-The shared global entrypoint is `{agent_root / "AGENTS.md"}`.
+Dry run:
+
+```bash
+setup-openspeckit --repo /path/to/repo --dry-run
+```
+
+Keep existing `openspec/README.md` and `.specify/README.md` untouched:
+
+```bash
+setup-openspeckit --preserve-readmes
+```
+
+Skip skill links:
+
+```bash
+setup-openspeckit --no-skill-links
+```
+
+Skip repo-local agent context files:
+
+```bash
+setup-openspeckit --no-repo-agent-pointers
+```
+
+## Worktree Layout
+
+Speckit features are worked in linked git worktrees in both shapes. The
+bootstrap writes the layout for the detected shape into
+`.specify/extensions/git/git-config.yml` when the worktree keys are absent, and
+never overwrites keys that are present. The rule behind both layouts is that a
+worktree never lives inside a tree that holds code.
+
+Single repository:
+
+```yaml
+checkout_mode: worktree
+base_branch: main
+worktree_root: ../<repo>-worktrees
+```
+
+Worktrees sit beside the repository, one per feature, each a full checkout on
+its `NNN-feature-name` branch.
+
+Three-leg project:
+
+```yaml
+checkout_mode: worktree
+base_branch: main
+worktree_root: worktrees
+```
+
+Worktrees sit inside the assembly root under `worktrees/<NNN-feature-name>/`,
+each holding a `spec/` worktree of the spec repository and a `code/` worktree
+of the code repository, both on the `NNN-feature-name` branch. The bootstrap
+adds `/worktrees/` to the root's `.gitignore` (the root's own file, not a
+shape-pinned one) so nothing under it can reach the root repository. It does
+not create `worktrees/`; the Speckit feature hook does.
+
+## Three-leg Projects (openRepoShape)
+
+A project built to openRepoShape's shape spans three repositories: an assembly
+root an engineer clones, plus a `spec` and a `code` leg mounted inside it as
+submodules. The bootstrap detects that layout and splits its work between the
+root and the spec leg instead of writing everything into one repository.
+
+### Detection
+
+A small self-contained reader parses the root's `project.yaml` — no PyYAML, and
+no import of the project's own `scripts/repo_shape.py`. It is a three-leg
+project when that file carries:
+
+- `kind: project-manifest`
+- `schema: project-repo-schema`
+- `legs:` entries for `role: spec` and `role: code`, whose `path:` values are
+  the mount points (`spec` and `code` by default)
+
+### The Split
+
+| what | where |
+|---|---|
+| `.specify/` scaffolding, `specify init`, registration, `.specify/README.md` | root |
+| managed blocks in the agent context files | root |
+| `.claude/commands/opsx/*`, skill links, the worktree overlay | root |
+| worktree keys in `.specify/extensions/git/git-config.yml` (`worktree_root: worktrees`) | root |
+| `/worktrees/` line in `.gitignore` | root |
+| `openspec/changes/archive/.gitkeep`, `openspec/specs/.gitkeep`, `openspec/README.md` | spec leg |
+
+`.specify/` belongs to the project rather than to either leg — it drives a
+workflow that starts in the specification and lands in the implementation —
+which is the `root-spec-kit` row in openRepoShape's
+`contracts/path-classification.yaml`. OpenSpec is what the project has
+decided, so it is `spec-governance` and lives in the spec leg; run `openspec`
+from there. Speckit feature directories (`specs/NNN-*`) belong beside it in the
+spec leg by the same rule, but the bootstrap does not create `specs/` — the
+managed block says where they go and Speckit makes them, inside the feature's
+spec worktree. The code leg is never touched.
+
+### The Managed Block Names the Split
+
+In a three-leg root the managed block written into the agent context files
+states, in addition to the pointers: the shape detected, the two mount paths
+from `project.yaml`, that `openspec/` and `specs/` live in the spec leg, that
+implementation lives in the code leg, and that feature worktrees live under
+`worktrees/<NNN-feature-name>/{{spec,code}}/`. An agent that reads only the
+root's `AGENTS.md` must be able to find every artifact without opening this
+contract.
+
+### The Speckit Worktree Overlay in a Three-leg Root
+
+The overlay the bootstrap installs (the git extension's feature scripts and the
+`ct`/`ctp` helpers) must behave as follows when the root is three-leg. These
+are contract items for the overlay, not things the bootstrap itself does:
+
+- The feature hook creates the `NNN-feature-name` branch in each leg
+  repository from that leg's fetched base branch, and adds one linked
+  worktree per leg at `worktrees/<NNN-feature-name>/<spec>/` and
+  `worktrees/<NNN-feature-name>/<code>/`. It never adds a worktree of the
+  root repository.
+- Feature numbering scans `specs/` on the spec leg's base branch and the
+  branch lists of both leg repositories.
+- The resolved feature directory recorded in `.specify/feature.json` is
+  `worktrees/<NNN-feature-name>/<spec>/specs/<NNN-feature-name>`, relative to
+  the root.
+- The hook's JSON output carries `WORKTREE_PATH` for the feature directory
+  under `worktrees/`, plus `SPEC_WORKTREE_PATH` and `CODE_WORKTREE_PATH`.
+- `get-last-worktree.sh`, `ct`, and `ctp` report the feature directory and
+  both leg paths, and export `SPECIFY_FEATURE` and
+  `SPECIFY_FEATURE_DIRECTORY` for the session they start.
+- Removing a feature removes both leg worktrees and the feature directory,
+  and prunes both leg repositories.
+
+### The Legs Keep Their Own Pointers
+
+No managed block is written into either leg. Since openRepoShape `99b3774`
+every leg ships its own `AGENTS.md` and `CLAUDE.md` pointing back to the
+assembly root, and the global block would bury that pointer under protocol
+text an agent standing in a leg clone cannot act on anyway.
+
+### The First Line Is an Invariant
+
+The root's `AGENTS.md` opens with a pointer to `AGENTS-shape.md`, and that line
+stays first. On a scaffolded root the managed block appends after it; on an
+adopted root — where the pointer sits above `# Agent Instructions` and `## `
+sections — the block lands before the first `## ` heading. Either way line 1 is
+unchanged. The bootstrap asserts it and refuses, naming the file and both first
+lines, rather than moving the line.
+
+### Family Holders Are Not Three-leg Projects
+
+A family holder — `family.yaml` with `kind: family-manifest` and no
+`project.yaml` — pins its members' assembly roots and has no legs of its own.
+The bootstrap logs one line saying so and applies the ordinary
+single-repository layout: OpenSpec and Speckit belong in the member projects.
+
+### The `--shape` Flag
+
+```bash
+setup-openspeckit --shape auto   # default: detect project.yaml
+setup-openspeckit --shape on     # require the three-leg layout
+setup-openspeckit --shape off    # force the single-repository layout
+```
+
+`--shape on` exits non-zero when the manifest is absent, is not a project
+manifest, or is a family holder's. In `auto` and `on` alike a manifest whose
+spec leg is missing or empty is a refusal rather than a fallback: the submodule
+is simply not fetched, and writing OpenSpec into the root instead would put it
+in the wrong repository. The message names `git submodule update --init` and
+`make bootstrap`. `--shape off` is the escape hatch, and produces exactly the
+single-repository behavior.
+
+### Two Repositories Means Two Commits
+
+Files the bootstrap writes under the spec leg are commits in the spec
+repository, and they reach the assembly root only through a lockstep pin bump.
+The run ends by listing them with the two repositories involved: commit and
+push them in the spec repository, then move the gitlink, `commit:` in
+`contracts/spec-pin.yaml`, and every workflow `@<sha>` naming that leg together
+in one commit in the root. `--dry-run` prefixes every planned path with
+`[root]` or `[spec]`, so the split is visible before anything is written.
+
+## New Project Checklist
+
+1. Create or clone the repo. A three-leg project is created with
+   openRepoShape's `setup.sh` first — that writes `project.yaml` and mounts
+   the legs — and the bootstrap then detects `project.yaml`. An existing
+   single repository becomes three-leg through openRepoShape's
+   `adopt-project.py`; run that from a clean default branch with no linked
+   worktrees attached, and re-run the bootstrap afterwards.
+2. Run `setup-openspeckit --repo /path/to/repo`.
+3. Fill in repo-specific `AGENTS.md` or `CLAUDE.md` commands and runtime rules.
+4. Initialize OpenSpec/Speckit with their CLIs if the repo does not already have
+   real project templates.
+5. Confirm `.specify/extensions/git/git-config.yml` carries the worktree
+   layout for the shape (see Worktree Layout) and, in a three-leg root, that
+   `.gitignore` carries `/worktrees/`.
+6. Keep the global workflow in `{agent_root / "protocols"}/` and leave repo
+   files as pointers plus repo-specific overrides.
+
+## Script Status
+
+Recorded 2026-09-08. The script at this revision implements the contract
+above: `project.yaml` detection, `--shape`, the spec-leg split, the shape-aware
+managed block and first-line invariant, the worktree layout and `/worktrees/`
+ignore line, the managed shape block in skill and command files, and the
+overlay refresh keyed on the `speckit-overlay-shape` marker. The overlay's bash
+scripts create paired leg worktrees; the unmodified Spec Kit core scripts
+resolve the feature from the root through `.specify/feature.json`.
+
+This section is retained so that a future gap between the installed script and
+this contract can be recorded here. Known gap: the overlay's PowerShell scripts
+(`.specify/extensions/git/scripts/powershell/*.ps1`) have no three-leg logic,
+so a Windows-native run of the feature hook in a three-leg root still behaves
+as a single repository. Use the bash scripts (WSL2) for three-leg projects.
 """
 
 
@@ -1753,7 +2484,7 @@ def ensure_agent_protocol_files(agent_root: Path, dry_run: bool) -> None:
     write_text_if_missing(agent_root / "AGENTS.md", global_agent_entrypoint(agent_root), dry_run)
     write_text_if_missing(
         agent_root / "protocols" / "openspec-speckit-workflow.md",
-        openspec_speckit_protocol(),
+        openspec_speckit_protocol(agent_root),
         dry_run,
     )
     write_text_if_missing(
@@ -1763,8 +2494,8 @@ def ensure_agent_protocol_files(agent_root: Path, dry_run: bool) -> None:
     )
 
 
-def agent_block() -> str:
-    return f"""## Shared OpenSpec/Speckit Protocol
+def agent_block(shape: ProjectShape | None = None) -> str:
+    block = f"""## Shared OpenSpec/Speckit Protocol
 
 This repo uses the user-global OpenSpec/Speckit workflow instead of duplicating
 process rules in every repository.
@@ -1775,6 +2506,17 @@ process rules in every repository.
 
 Repo-local sections below remain authoritative for project-specific commands,
 runtime prerequisites, source-of-truth docs, tests, and deployment constraints."""
+    if shape is None:
+        return block
+    return block + f"""
+
+### Repository shape: openRepoShape three-leg
+
+- Spec leg: `{shape.spec_path}/` — `openspec/` and Speckit `specs/NNN-*` live here.
+- Code leg: `{shape.code_path}/` — implementation and tests live here.
+- Feature worktrees: `worktrees/<NNN-feature>/{shape.spec_path}/` and `worktrees/<NNN-feature>/{shape.code_path}/` (ignored by this root).
+- `.specify/` and these agent files belong to this root; run Speckit commands from here with the feature selected.
+- Committing in a leg does not advance the project; one root commit moving the leg's gitlink, `contracts/<role>-pin.yaml`, and workflow `@<sha>` does."""
 
 
 def global_pointer_block(agent_root: Path) -> str:
@@ -1817,36 +2559,44 @@ behavior when present.
 """
 
 
-def ensure_scaffold(repo: Path, dry_run: bool, skip_init: bool) -> None:
-    config = repo / "openspec" / "config.yaml"
+def ensure_scaffold(
+    repo: Path,
+    spec_root: Path,
+    dry_run: bool,
+    skip_init: bool,
+) -> None:
+    config = spec_root / "openspec" / "config.yaml"
     directories = [
-        repo / "openspec" / "changes" / "archive",
-        repo / "openspec" / "specs",
-        repo / ".specify",
+        (spec_root / "openspec" / "changes" / "archive", spec_scope),
+        (spec_root / "openspec" / "specs", spec_scope),
+        (repo / ".specify", root_scope),
     ]
     keep_files = [
-        repo / "openspec" / "changes" / "archive" / ".gitkeep",
-        repo / "openspec" / "specs" / ".gitkeep",
+        spec_root / "openspec" / "changes" / "archive" / ".gitkeep",
+        spec_root / "openspec" / "specs" / ".gitkeep",
     ]
     ensure_safe_destination_file(config, set())
     if not skip_init:
-        for path in [*directories, *keep_files]:
+        for path in [*(directory for directory, _ in directories), *keep_files]:
             ensure_safe_destination_file(path, set())
-    write_text_if_missing(
-        config,
-        "schema: spec-driven\n",
-        dry_run,
-    )
+    with spec_scope():
+        write_text_if_missing(
+            config,
+            "schema: spec-driven\n",
+            dry_run,
+        )
     if skip_init:
         return
-    for directory in directories:
-        if dry_run:
-            if not directory.exists():
-                log(f"would create directory {directory}")
-        else:
-            ensure_destination_directory(directory)
+    for directory, scope in directories:
+        with scope():
+            if dry_run:
+                if not directory.exists():
+                    log(f"would create directory {directory}")
+            else:
+                ensure_destination_directory(directory)
     for keep_file in keep_files:
-        touch(keep_file, dry_run)
+        with spec_scope():
+            touch(keep_file, dry_run)
 
 
 def ensure_skills(
@@ -1876,13 +2626,166 @@ def ensure_skills(
             )
 
 
-def ensure_repo_agent_pointers(repo: Path, dry_run: bool) -> None:
+def ensure_repo_agent_pointers(
+    repo: Path,
+    dry_run: bool,
+    shape: ProjectShape | None = None,
+) -> None:
     seen: set[str] = set()
+    block = agent_block(shape)
     for _, relative_path in SUPPORTED_AGENT_CONTEXT_FILES:
         if relative_path in seen:
             continue
         seen.add(relative_path)
-        upsert_block(repo / relative_path, agent_block(), dry_run)
+        upsert_block(repo / relative_path, block, dry_run)
+
+
+def shape_block_body(agent_root: str) -> str:
+    return f"""{SHAPE_START}
+## Repository Shape (managed by setup-openspeckit)
+
+Resolve the project shape once before any step below.
+
+1. The project root is the nearest directory at or above the current one that contains `.specify/`. Run every `.specify/scripts/...` command from that root.
+2. If the root has `project.yaml` with `kind: project-manifest` and `legs:` entries for `role: spec` and `role: code`, this is an openRepoShape **three-leg** project. `<spec>` and `<code>` are those legs' `path:` values (defaults `spec` and `code`). Otherwise it is a **single repository** and `<spec>` and `<code>` are both the root.
+3. Three-leg placement: `openspec/` and `specs/NNN-*` live in the spec leg; source and tests live in the code leg; a feature's worktrees live at `worktrees/<NNN-feature>/<spec>/` and `worktrees/<NNN-feature>/<code>/` under the root. Never write feature work into `<spec>/` or `<code>/` at the root; they sit at the pinned commit.
+4. Feature paths come from `.specify/scripts/bash/check-prerequisites.sh --json` (or `SPECIFY_FEATURE_DIRECTORY` / `.specify/feature.json`). In three-leg, `FEATURE_DIR` is inside the feature's spec worktree and the code worktree is the sibling `<code>/` directory beside it; implementation edits go there.
+5. Run the `openspec` CLI with the current directory at the owner of `openspec/`: the root in a single repository, `<spec>/` in a three-leg project.
+
+Full rules: `{agent_root}/protocols/openspec-speckit-workflow.md` ("Repository Shape", "Worktree Rules").
+{SHAPE_END}"""
+
+
+def frontmatter_end_index(text: str) -> int | None:
+    """Index of the frontmatter's closing ``---`` line, or None when absent."""
+    if not text.startswith("---\n"):
+        return None
+    lines = text.split("\n")
+    for index in range(1, len(lines)):
+        if lines[index] == "---":
+            return index
+    return None
+
+
+def shape_block_applied(text: str, block: str) -> str:
+    if SHAPE_START in text and SHAPE_END in text:
+        before, remainder = text.split(SHAPE_START, 1)
+        _, after = remainder.split(SHAPE_END, 1)
+        return before + block + after
+
+    end = frontmatter_end_index(text)
+    if end is None:
+        body = text.lstrip("\n")
+        return f"{block}\n\n{body}" if body else f"{block}\n"
+    lines = text.split("\n")
+    head = "\n".join(lines[: end + 1])
+    tail = "\n".join(lines[end + 1 :]).lstrip("\n")
+    return f"{head}\n\n{block}\n\n{tail}" if tail else f"{head}\n\n{block}\n"
+
+
+def upsert_shape_block(path: Path, block: str, dry_run: bool) -> None:
+    try:
+        text = read_destination_text(path)
+    except (OSError, UnicodeError):
+        log(f"skipped {path}: not a readable regular file")
+        return
+    if text is None:
+        return
+    write_text(path, shape_block_applied(text, block), dry_run)
+
+
+def regular_skill_documents(root: Path, patterns: tuple[str, ...]) -> list[Path]:
+    """Existing regular ``SKILL.md`` files in skill directories matching a pattern."""
+    documents: list[Path] = []
+    root_mode = mode_without_following(root)
+    if root_mode is None or not stat.S_ISDIR(root_mode):
+        return documents
+    try:
+        names = sorted(os.listdir(root))
+    except OSError:
+        return documents
+    for name in names:
+        if not any(fnmatch.fnmatchcase(name, pattern) for pattern in patterns):
+            continue
+        entry = root / name
+        entry_mode = mode_without_following(entry)
+        if entry_mode is None or not stat.S_ISDIR(entry_mode):
+            continue
+        document = entry / "SKILL.md"
+        document_mode = mode_without_following(document)
+        if document_mode is not None and stat.S_ISREG(document_mode):
+            documents.append(document)
+    return documents
+
+
+def regular_markdown_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    root_mode = mode_without_following(root)
+    if root_mode is None or not stat.S_ISDIR(root_mode):
+        return files
+    try:
+        names = sorted(os.listdir(root))
+    except OSError:
+        return files
+    for name in names:
+        if not name.endswith(".md"):
+            continue
+        entry = root / name
+        entry_mode = mode_without_following(entry)
+        if entry_mode is not None and stat.S_ISREG(entry_mode):
+            files.append(entry)
+    return files
+
+
+def repo_shape_block_targets(repo: Path) -> list[Path]:
+    targets: list[Path] = []
+    targets.extend(
+        regular_skill_documents(repo / ".claude" / "skills", ("speckit-*", "ct", "ctp"))
+    )
+    targets.extend(regular_markdown_files(repo / ".claude" / "commands" / "opsx"))
+    targets.extend(regular_skill_documents(repo / ".agents" / "skills", ("speckit-*",)))
+    targets.extend(regular_skill_documents(repo / ".codex" / "skills", ("speckit-*",)))
+    return targets
+
+
+def global_shape_block_targets(home: Path) -> list[Path]:
+    targets: list[Path] = []
+    targets.extend(
+        regular_skill_documents(
+            home / ".claude" / "skills",
+            ("speckit-*", "openspec-*", "ct", "ctp"),
+        )
+    )
+    targets.extend(regular_skill_documents(home / ".agents" / "skills", ("speckit-*",)))
+    targets.extend(
+        regular_skill_documents(
+            home / ".codex" / "skills",
+            ("speckit-*", "openspec-*"),
+        )
+    )
+    return targets
+
+
+def ensure_skill_shape_blocks(
+    repo: Path,
+    agent_root: Path,
+    dry_run: bool,
+    include_global: bool,
+) -> None:
+    """Maintain the managed Repository Shape block in skills and commands."""
+    repo_block = shape_block_body(REPO_AGENT_ROOT)
+    for path in repo_shape_block_targets(repo):
+        upsert_shape_block(path, repo_block, dry_run)
+    if not include_global:
+        return
+    global_block = shape_block_body(str(agent_root))
+    for path in global_shape_block_targets(Path.home()):
+        try:
+            upsert_shape_block(path, global_block, dry_run)
+        except PermissionError as exc:
+            log(f"skipped {path}: permission denied ({exc})")
+        except OSError as exc:
+            log(f"skipped {path}: {exc}")
 
 
 def ensure_global_agent_pointers(agent_root: Path, dry_run: bool) -> None:
@@ -2137,6 +3040,46 @@ def refresh_git_extension_manifest_hash(
     write_text(registry_path, json.dumps(registry, indent=2) + "\n", dry_run)
 
 
+def replace_overlay_skill_link(destination: Path, dry_run: bool) -> bool:
+    """Drop a symlinked overlay skill destination so a real directory replaces it.
+
+    An earlier bootstrap could leave a link to a global skill where the worktree
+    overlay belongs. A link is never a legitimate overlay copy, so remove the
+    link itself, never following it, and let the overlay copy build a fresh
+    directory. Every other unsafe destination keeps its ordinary refusal.
+    """
+    mode = mode_without_following(destination)
+    if mode is None or not stat.S_ISLNK(mode):
+        return False
+    if dry_run:
+        log(f"would replace skill link {destination} with worktree overlay")
+        return True
+    remove_destination_without_following(destination)
+    log(f"replaced skill link {destination} with worktree overlay")
+    return True
+
+
+def ensure_worktrees_ignored(repo: Path, dry_run: bool) -> None:
+    """Keep the three-leg root's own .gitignore carrying `/worktrees/`."""
+    path = repo / ".gitignore"
+    ensure_safe_destination_file(path, set())
+    existing_text = read_destination_text(path)
+    if existing_text is None:
+        write_text(path, f"{WORKTREES_IGNORE_LINE}\n", dry_run)
+        return
+    if any(
+        line.strip() == WORKTREES_IGNORE_LINE for line in existing_text.splitlines()
+    ):
+        log(f"unchanged {path}")
+        return
+    separator = "" if not existing_text or existing_text.endswith("\n") else "\n"
+    write_text(
+        path,
+        f"{existing_text}{separator}{WORKTREES_IGNORE_LINE}\n",
+        dry_run,
+    )
+
+
 def ensure_worktree_overlay(
     repo: Path,
     template_root: Path | None,
@@ -2145,6 +3088,7 @@ def ensure_worktree_overlay(
     base_branch: str | None,
     worktree_root: str | None,
     skip_worktrees: bool,
+    shape: ProjectShape | None = None,
 ) -> set[Path]:
     if skip_worktrees:
         return set()
@@ -2152,12 +3096,16 @@ def ensure_worktree_overlay(
     if template_root is None:
         raise SystemExit("Speckit worktree template root not found.")
 
-    git_overlay_force = force or not has_compatible_worktree_git_overlay(repo)
+    git_overlay_force = force or not has_compatible_worktree_git_overlay(
+        repo,
+        template_root,
+    )
     if git_overlay_force and not force:
         log("replacing incompatible Spec Kit git extension with worktree-aware overlay")
+    overlay_force = force or git_overlay_force
 
     copy_overlay_tree(template_root / "specify" / "extensions" / "git", repo / ".specify" / "extensions" / "git", dry_run, git_overlay_force)
-    copy_overlay_tree(template_root / "specify" / "shell", repo / ".specify" / "shell", dry_run, force)
+    copy_overlay_tree(template_root / "specify" / "shell", repo / ".specify" / "shell", dry_run, overlay_force)
     skill_overlays = (
         (
             template_root / "agents" / "skills" / "speckit-specify",
@@ -2202,9 +3150,14 @@ def ensure_worktree_overlay(
         if not is_usable_skill_tree(source):
             log(f"skipped unusable worktree skill overlay {source}")
             continue
-        copy_overlay_tree(source, destination, dry_run, force)
+        if replace_overlay_skill_link(destination, dry_run) and dry_run:
+            # The link is still in place, so the copy would refuse it. The
+            # planned replacement has already been logged.
+            overlay_owned_destinations.add(destination)
+            continue
+        copy_overlay_tree(source, destination, dry_run, overlay_force)
         if is_usable_skill_tree(destination) or (
-            dry_run and skill_tree_will_be_usable(destination, force)
+            dry_run and skill_tree_will_be_usable(destination, overlay_force)
         ):
             overlay_owned_destinations.add(destination)
 
@@ -2221,7 +3174,9 @@ def ensure_worktree_overlay(
         "branch_numbering": "sequential",
         "checkout_mode": "worktree",
         "base_branch": default_base_branch(repo),
-        "worktree_root": f"../{repo.name}-worktrees",
+        "worktree_root": (
+            THREE_LEG_WORKTREE_ROOT if shape is not None else f"../{repo.name}-worktrees"
+        ),
     }
     values = {
         key: value for key, value in required_values.items() if key not in existing_keys
@@ -2250,6 +3205,24 @@ def ensure_worktree_overlay(
     return overlay_owned_destinations
 
 
+def report_two_commit_split(repo: Path, shape: ProjectShape) -> None:
+    """Close a three-leg run with the spec-leg paths and the pin-bump reminder."""
+    written = spec_leg_written_paths()
+    log("")
+    log("Two Repositories Means Two Commits")
+    if written:
+        log(f"Written in the spec repository ({shape.spec_path}/):")
+        for path in written:
+            log(f"  {path}")
+    else:
+        log(f"Nothing new was written in the spec repository ({shape.spec_path}/).")
+    log(
+        "Commit and push those in the spec repository first, then in the assembly "
+        f"root {repo} move the gitlink, `commit:` in `contracts/spec-pin.yaml`, and "
+        "every workflow `@<sha>` naming that leg together in one commit."
+    )
+
+
 def main() -> int:
     args = parse_args()
     repo = (args.repo.resolve() if args.repo else git_root())
@@ -2266,42 +3239,70 @@ def main() -> int:
     log(f"agent root: {agent_root}")
     log(f"integration: {integration}")
 
-    ensure_agent_protocol_files(agent_root, args.dry_run)
-    ensure_scaffold(repo, args.dry_run, args.skip_init)
-    ensure_speckit_initialized(repo, integration, args.dry_run, args.skip_init)
-    ensure_speckit_registration(repo, args.dry_run, args.no_speckit_registration)
-    overlay_owned_destinations = ensure_worktree_overlay(
-        repo,
-        worktree_templates,
-        args.dry_run,
-        args.force,
-        args.base_branch,
-        args.worktree_root,
-        args.no_worktrees,
-    )
+    shape = resolve_project_shape(repo, args.shape)
+    spec_root = shape.spec_leg if shape is not None else repo
+    if shape is not None:
+        enable_shape_log_scopes(args.dry_run)
 
-    if not args.no_repo_agent_pointers:
-        ensure_repo_agent_pointers(repo, args.dry_run)
-
-    if not args.preserve_readmes:
-        write_text(repo / "openspec" / "README.md", openspec_readme(), args.dry_run)
-        write_text(repo / ".specify" / "README.md", specify_readme(), args.dry_run)
-
-    if command_templates:
-        copy_missing_tree(
-            command_templates,
-            repo / ".claude" / "commands" / "opsx",
+    with root_scope():
+        ensure_agent_protocol_files(agent_root, args.dry_run)
+    ensure_scaffold(repo, spec_root, args.dry_run, args.skip_init)
+    with root_scope():
+        ensure_speckit_initialized(repo, integration, args.dry_run, args.skip_init)
+        ensure_speckit_registration(repo, args.dry_run, args.no_speckit_registration)
+        overlay_owned_destinations = ensure_worktree_overlay(
+            repo,
+            worktree_templates,
             args.dry_run,
             args.force,
+            args.base_branch,
+            args.worktree_root,
+            args.no_worktrees,
+            shape,
         )
-    else:
-        log("skipped opsx command templates: no template root found")
+        if shape is not None:
+            ensure_worktrees_ignored(repo, args.dry_run)
 
-    if not args.no_skill_links:
-        ensure_skills(repo, args.dry_run, args.force, overlay_owned_destinations)
+        if not args.no_repo_agent_pointers:
+            ensure_repo_agent_pointers(repo, args.dry_run, shape)
 
-    if not args.no_global_agent_pointers:
-        ensure_global_agent_pointers(agent_root, args.dry_run)
+    if not args.preserve_readmes:
+        with spec_scope():
+            write_text(
+                spec_root / "openspec" / "README.md",
+                openspec_readme(),
+                args.dry_run,
+            )
+        with root_scope():
+            write_text(repo / ".specify" / "README.md", specify_readme(), args.dry_run)
+
+    with root_scope():
+        if command_templates:
+            copy_missing_tree(
+                command_templates,
+                repo / ".claude" / "commands" / "opsx",
+                args.dry_run,
+                args.force,
+            )
+        else:
+            log("skipped opsx command templates: no template root found")
+
+        if not args.no_skill_links:
+            ensure_skills(repo, args.dry_run, args.force, overlay_owned_destinations)
+
+        if not args.no_skill_shape_blocks:
+            ensure_skill_shape_blocks(
+                repo,
+                agent_root,
+                args.dry_run,
+                not args.no_global_agent_pointers,
+            )
+
+        if not args.no_global_agent_pointers:
+            ensure_global_agent_pointers(agent_root, args.dry_run)
+
+    if shape is not None and not args.dry_run:
+        report_two_commit_split(repo, shape)
 
     log("done")
     return 0

--- a/devBenches/base-image/files/speckit-worktree/templates/agents/skills/speckit-git-feature/SKILL.md
+++ b/devBenches/base-image/files/speckit-worktree/templates/agents/skills/speckit-git-feature/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   author: github-spec-kit
   source: git:commands/speckit.git.feature.md
 ---
+<!-- speckit-overlay-shape: 1 -->
 
 # Create Feature Checkout
 
@@ -30,6 +31,21 @@ If the user explicitly provided `GIT_BRANCH_NAME` (e.g., via environment variabl
 
 - Verify Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
 - If Git is not available, warn the user and skip branch creation
+
+## Repository Shape
+
+The script resolves the project shape itself and reports it as `REPO_SHAPE`.
+
+- **Single repository** (`REPO_SHAPE: "single"`): one feature branch, and in worktree mode one linked worktree under `worktree_root`.
+- **Three-leg project** (`REPO_SHAPE: "three-leg"` — an openRepoShape assembly root whose `project.yaml` declares `legs:` for `role: spec` and `role: code`): the same `NNN-feature-name` branch is created in **both** leg repositories, and one linked worktree is added per leg at `worktrees/<NNN-feature-name>/<spec>/` and `worktrees/<NNN-feature-name>/<code>/`. The assembly root never receives a feature branch or a worktree. The script also writes `.specify/feature.json` **at the project root**, pointing at `worktrees/<NNN-feature-name>/<spec>/specs/<NNN-feature-name>`.
+
+In a three-leg project:
+
+- Run the script from the project root (the directory holding `.specify/`).
+- `checkout_mode` must be `worktree`; `branch` is refused with an error naming `checkout_mode` in `.specify/extensions/git/git-config.yml`.
+- Both legs must be initialised checkouts. If one is not, the script refuses and tells you to run `git submodule update --init` (or `make bootstrap`) rather than writing into the wrong repository.
+- Feature numbering scans `specs/` on the spec leg's base branch and in its working tree, plus the branch lists of both leg repositories.
+- Each leg's branch is cut from `origin/<base_branch>` after a best-effort fetch, falling back to the local base branch when offline.
 
 ## Branch Numbering Mode
 
@@ -73,6 +89,7 @@ Run the appropriate script based on your platform:
 - You must only ever run this script once per feature
 - The JSON output will always contain `BRANCH_NAME`, `FEATURE_NUM`, and `CHECKOUT_MODE`
 - In worktree mode the JSON output also contains `BASE_BRANCH` and `WORKTREE_PATH`
+- In a three-leg project the JSON also contains `REPO_SHAPE`, `PROJECT_ROOT`, `SPEC_WORKTREE_PATH`, `CODE_WORKTREE_PATH`, and `FEATURE_DIR`; there `WORKTREE_PATH` is the feature directory that holds both leg worktrees
 
 ## Graceful Degradation
 
@@ -88,3 +105,8 @@ The script outputs JSON with:
 - `CHECKOUT_MODE`: `branch` or `worktree`
 - `BASE_BRANCH`: the configured worktree base branch when `CHECKOUT_MODE=worktree`
 - `WORKTREE_PATH`: the linked worktree root when `CHECKOUT_MODE=worktree`
+- `REPO_SHAPE`: `single` or `three-leg`
+- `PROJECT_ROOT`: the project root that holds `.specify/` (three-leg only)
+- `SPEC_WORKTREE_PATH`: the spec leg worktree `worktrees/<NNN-feature-name>/<spec>/` (three-leg only)
+- `CODE_WORKTREE_PATH`: the code leg worktree `worktrees/<NNN-feature-name>/<code>/` (three-leg only)
+- `FEATURE_DIR`: the Speckit feature directory `<spec worktree>/specs/<NNN-feature-name>` (three-leg only)

--- a/devBenches/base-image/files/speckit-worktree/templates/agents/skills/speckit-git-validate/SKILL.md
+++ b/devBenches/base-image/files/speckit-worktree/templates/agents/skills/speckit-git-validate/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   author: github-spec-kit
   source: git:commands/speckit.git.validate.md
 ---
+<!-- speckit-overlay-shape: 1 -->
 
 # Validate Feature Branch
 
@@ -18,6 +19,20 @@ Validate that the current Git branch follows the expected feature branch naming 
   ```
   [specify] Warning: Git repository not detected; skipped branch validation
   ```
+
+## Repository Shape
+
+Resolve the shape before validating anything.
+
+- **Single repository**: the branch to validate is the current checkout's branch (`git rev-parse --abbrev-ref HEAD`), and `.specify/feature.json` is read from that checkout.
+- **Three-leg project** (the project root has `project.yaml` with `kind: project-manifest` and `legs:` for `role: spec` and `role: code`): the assembly root has **no** feature branch, so validating its branch is meaningless. Validate the two **leg worktree** branches instead.
+
+In a three-leg project:
+
+1. Resolve the feature from `SPECIFY_FEATURE` / `SPECIFY_FEATURE_DIRECTORY`, or from `.specify/feature.json` at the project root — its `feature_directory` is `worktrees/<NNN-feature-name>/<spec>/specs/<NNN-feature-name>`, relative to the project root. The `speckit.git.feature` hook's JSON carries the same values as `SPEC_WORKTREE_PATH`, `CODE_WORKTREE_PATH`, and `FEATURE_DIR`.
+2. Read the branch of each leg worktree with `git -C <SPEC_WORKTREE_PATH> rev-parse --abbrev-ref HEAD` and `git -C <CODE_WORKTREE_PATH> rev-parse --abbrev-ref HEAD`.
+3. Both must match the feature-branch patterns below **and** be the same branch name in both legs. Report a mismatch between the legs as an error naming both branches.
+4. Do not validate the assembly root's branch and do not report it as a failure; it stays on its tracking branch until the pin bump.
 
 ## Validation Rules
 
@@ -48,6 +63,12 @@ If on a feature branch (matches either pattern):
 If NOT on a feature branch:
 - Output: `✗ Not on a feature branch. Current branch: <branch-name>`
 - Output: `Feature branches should be named like: 001-feature-name, 20260319-143022-feature-name, or <namespace>/001-feature-name`
+
+In a three-leg project apply the same reporting per leg, using the leg worktree branch instead of the root branch:
+
+- `✓ On feature branch: <branch-name> (spec worktree)` and the same line for the code worktree
+- `✗ Leg branches differ: spec=<spec-branch>, code=<code-branch>` when the two legs are not on the same branch
+- The spec directory is `FEATURE_DIR` inside the spec worktree (`worktrees/<NNN-feature-name>/<spec>/specs/<NNN-feature-name>`), resolved from `.specify/feature.json` at the project root; do not look for `specs/<prefix>-*` at the root
 
 ## Graceful Degradation
 

--- a/devBenches/base-image/files/speckit-worktree/templates/agents/skills/speckit-specify/SKILL.md
+++ b/devBenches/base-image/files/speckit-worktree/templates/agents/skills/speckit-specify/SKILL.md
@@ -6,6 +6,7 @@ metadata:
   author: "github-spec-kit"
   source: "templates/commands/specify.md"
 ---
+<!-- speckit-overlay-shape: 1 -->
 
 
 ## User Input
@@ -77,12 +78,22 @@ Given that feature description, do this:
    - Otherwise, set `TARGET_REPO_ROOT` to the current project root.
    - Note `BRANCH_NAME` for reference, but the branch name does **not** dictate the spec directory name.
    - A linked worktree does **not** change the user's current shell directory automatically. If `WORKTREE_PATH` is returned, remember that the current CLI session is still in the original checkout unless the user manually changes directories or opens a new session there.
+   - The hook also returns `REPO_SHAPE` (`single` or `three-leg`). When it is `three-leg` it additionally returns `PROJECT_ROOT`, `SPEC_WORKTREE_PATH`, `CODE_WORKTREE_PATH`, and `FEATURE_DIR`; `WORKTREE_PATH` is then the feature directory that holds both leg worktrees, not a checkout. See "Three-leg projects" in step 3.
 
    If the user explicitly provided `GIT_BRANCH_NAME`, pass it through to the hook so the branch script uses the exact value as the branch name (bypassing all prefix/suffix generation).
 
 3. **Create the spec feature directory**:
 
    Specs live under the default `specs/` directory inside `TARGET_REPO_ROOT` unless the user explicitly provides `SPECIFY_FEATURE_DIRECTORY`.
+
+   **Three-leg projects (`REPO_SHAPE: "three-leg"`)**:
+
+   When the hook's JSON reports `REPO_SHAPE: "three-leg"` (an openRepoShape assembly root), the spec files do **not** go in a repo-root-shaped worktree:
+
+   - Use `FEATURE_DIR` from the hook JSON verbatim as `SPECIFY_FEATURE_DIRECTORY`; it is `<SPEC_WORKTREE_PATH>/specs/<BRANCH_NAME>`, inside the feature's spec leg worktree. Do not invent a directory name and do not scan `specs/` yourself.
+   - Set `TARGET_REPO_ROOT` to `PROJECT_ROOT` from the hook JSON. The feature directory has **no** `.specify/` of its own: templates come from `PROJECT_ROOT/.specify/templates/` and `.specify/feature.json` is written at `PROJECT_ROOT/.specify/feature.json`, relative to `PROJECT_ROOT` (`worktrees/<BRANCH_NAME>/<spec>/specs/<BRANCH_NAME>`). The hook has already written it; leave it alone unless it is missing or wrong.
+   - Implementation source and tests belong in `CODE_WORKTREE_PATH`, the sibling code leg worktree — never in the spec worktree and never in `<spec>/` or `<code>/` at the project root, which sit at the pinned commit.
+   - Follow-on commands (`/speckit.clarify`, `/speckit.plan`, `/speckit.tasks`, `/speckit.analyze`, `/speckit.implement`) run **from `PROJECT_ROOT`**, not from the worktree, with `SPECIFY_FEATURE=<BRANCH_NAME>` and `SPECIFY_FEATURE_DIRECTORY=worktrees/<BRANCH_NAME>/<spec>/specs/<BRANCH_NAME>` exported.
 
    **Resolution order for `SPECIFY_FEATURE_DIRECTORY`**:
    1. If the user explicitly provided `SPECIFY_FEATURE_DIRECTORY` (e.g., via environment variable, argument, or configuration), use it as-is
@@ -239,6 +250,7 @@ Given that feature description, do this:
      - the spec artifacts were written in `WORKTREE_PATH`
      - the user's current shell did **not** automatically move there
      - all follow-on commands (`/speckit.clarify`, `/speckit.plan`, `/speckit.tasks`, `/speckit.implement`) must be run from that worktree
+     - in a three-leg project instead: the spec artifacts are in `FEATURE_DIR` inside `SPEC_WORKTREE_PATH`, implementation goes in `CODE_WORKTREE_PATH`, and all follow-on commands run from `PROJECT_ROOT` with `SPECIFY_FEATURE` and `SPECIFY_FEATURE_DIRECTORY` exported
    - `SPECIFY_FEATURE_DIRECTORY` — the feature directory path
    - `SPEC_FILE` — the spec file path
    - `WORKTREE_PATH` — include when the hook created a linked worktree, and state that subsequent `/speckit.*` commands should run from that worktree
@@ -274,7 +286,7 @@ Given that feature description, do this:
        ```
    - If no hooks are registered or `TARGET_REPO_ROOT/.specify/extensions.yml` does not exist, skip silently
 
-**NOTE:** Feature checkout creation is handled by the `before_specify` hook (git extension). Spec directory and file creation are always handled by this core command inside the target checkout or worktree. Worktree creation does not move the user's existing shell session.
+**NOTE:** Feature checkout creation is handled by the `before_specify` hook (git extension). Spec directory and file creation are always handled by this core command inside the target checkout or worktree. Worktree creation does not move the user's existing shell session. In a three-leg project the hook creates both leg worktrees and writes `.specify/feature.json` at `PROJECT_ROOT`; this command still creates the spec directory and files, inside `FEATURE_DIR`.
 
 ## Quick Guidelines
 

--- a/devBenches/base-image/files/speckit-worktree/templates/claude/skills/speckit-git-feature/SKILL.md
+++ b/devBenches/base-image/files/speckit-worktree/templates/claude/skills/speckit-git-feature/SKILL.md
@@ -8,6 +8,7 @@ metadata:
 user-invocable: true
 disable-model-invocation: true
 ---
+<!-- speckit-overlay-shape: 1 -->
 
 # Create Feature Checkout
 
@@ -32,6 +33,21 @@ If the user explicitly provided `GIT_BRANCH_NAME` (e.g., via environment variabl
 
 - Verify Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
 - If Git is not available, warn the user and skip branch creation
+
+## Repository Shape
+
+The script resolves the project shape itself and reports it as `REPO_SHAPE`.
+
+- **Single repository** (`REPO_SHAPE: "single"`): one feature branch, and in worktree mode one linked worktree under `worktree_root`.
+- **Three-leg project** (`REPO_SHAPE: "three-leg"` — an openRepoShape assembly root whose `project.yaml` declares `legs:` for `role: spec` and `role: code`): the same `NNN-feature-name` branch is created in **both** leg repositories, and one linked worktree is added per leg at `worktrees/<NNN-feature-name>/<spec>/` and `worktrees/<NNN-feature-name>/<code>/`. The assembly root never receives a feature branch or a worktree. The script also writes `.specify/feature.json` **at the project root**, pointing at `worktrees/<NNN-feature-name>/<spec>/specs/<NNN-feature-name>`.
+
+In a three-leg project:
+
+- Run the script from the project root (the directory holding `.specify/`).
+- `checkout_mode` must be `worktree`; `branch` is refused with an error naming `checkout_mode` in `.specify/extensions/git/git-config.yml`.
+- Both legs must be initialised checkouts. If one is not, the script refuses and tells you to run `git submodule update --init` (or `make bootstrap`) rather than writing into the wrong repository.
+- Feature numbering scans `specs/` on the spec leg's base branch and in its working tree, plus the branch lists of both leg repositories.
+- Each leg's branch is cut from `origin/<base_branch>` after a best-effort fetch, falling back to the local base branch when offline.
 
 ## Branch Numbering Mode
 
@@ -71,6 +87,7 @@ Run the appropriate script based on your platform:
 - You must only ever run this script once per feature
 - The JSON output will always contain `BRANCH_NAME`, `FEATURE_NUM`, and `CHECKOUT_MODE`
 - In worktree mode the JSON output also contains `BASE_BRANCH` and `WORKTREE_PATH`
+- In a three-leg project the JSON also contains `REPO_SHAPE`, `PROJECT_ROOT`, `SPEC_WORKTREE_PATH`, `CODE_WORKTREE_PATH`, and `FEATURE_DIR`; there `WORKTREE_PATH` is the feature directory that holds both leg worktrees
 - A linked worktree does **not** change the user's current shell directory automatically
 
 ## Graceful Degradation
@@ -87,3 +104,8 @@ The script outputs JSON with:
 - `CHECKOUT_MODE`: `branch` or `worktree`
 - `BASE_BRANCH`: the configured worktree base branch when `CHECKOUT_MODE=worktree`
 - `WORKTREE_PATH`: the linked worktree root when `CHECKOUT_MODE=worktree`
+- `REPO_SHAPE`: `single` or `three-leg`
+- `PROJECT_ROOT`: the project root that holds `.specify/` (three-leg only)
+- `SPEC_WORKTREE_PATH`: the spec leg worktree `worktrees/<NNN-feature-name>/<spec>/` (three-leg only)
+- `CODE_WORKTREE_PATH`: the code leg worktree `worktrees/<NNN-feature-name>/<code>/` (three-leg only)
+- `FEATURE_DIR`: the Speckit feature directory `<spec worktree>/specs/<NNN-feature-name>` (three-leg only)

--- a/devBenches/base-image/files/speckit-worktree/templates/claude/skills/speckit-git-validate/SKILL.md
+++ b/devBenches/base-image/files/speckit-worktree/templates/claude/skills/speckit-git-validate/SKILL.md
@@ -8,6 +8,7 @@ metadata:
 user-invocable: true
 disable-model-invocation: false
 ---
+<!-- speckit-overlay-shape: 1 -->
 
 # Validate Feature Branch
 
@@ -20,6 +21,20 @@ Validate that the current Git branch follows the expected feature branch naming 
   ```
   [specify] Warning: Git repository not detected; skipped branch validation
   ```
+
+## Repository Shape
+
+Resolve the shape before validating anything.
+
+- **Single repository**: the branch to validate is the current checkout's branch (`git rev-parse --abbrev-ref HEAD`), and `.specify/feature.json` is read from that checkout.
+- **Three-leg project** (the project root has `project.yaml` with `kind: project-manifest` and `legs:` for `role: spec` and `role: code`): the assembly root has **no** feature branch, so validating its branch is meaningless. Validate the two **leg worktree** branches instead.
+
+In a three-leg project:
+
+1. Resolve the feature from `SPECIFY_FEATURE` / `SPECIFY_FEATURE_DIRECTORY`, or from `.specify/feature.json` at the project root — its `feature_directory` is `worktrees/<NNN-feature-name>/<spec>/specs/<NNN-feature-name>`, relative to the project root. The `speckit.git.feature` hook's JSON carries the same values as `SPEC_WORKTREE_PATH`, `CODE_WORKTREE_PATH`, and `FEATURE_DIR`.
+2. Read the branch of each leg worktree with `git -C <SPEC_WORKTREE_PATH> rev-parse --abbrev-ref HEAD` and `git -C <CODE_WORKTREE_PATH> rev-parse --abbrev-ref HEAD`.
+3. Both must match the feature-branch patterns below **and** be the same branch name in both legs. Report a mismatch between the legs as an error naming both branches.
+4. Do not validate the assembly root's branch and do not report it as a failure; it stays on its tracking branch until the pin bump.
 
 ## Validation Rules
 
@@ -50,6 +65,12 @@ If on a feature branch (matches either pattern):
 If NOT on a feature branch:
 - Output: `✗ Not on a feature branch. Current branch: <branch-name>`
 - Output: `Feature branches should be named like: 001-feature-name, 20260319-143022-feature-name, or <namespace>/001-feature-name`
+
+In a three-leg project apply the same reporting per leg, using the leg worktree branch instead of the root branch:
+
+- `✓ On feature branch: <branch-name> (spec worktree)` and the same line for the code worktree
+- `✗ Leg branches differ: spec=<spec-branch>, code=<code-branch>` when the two legs are not on the same branch
+- The spec directory is `FEATURE_DIR` inside the spec worktree (`worktrees/<NNN-feature-name>/<spec>/specs/<NNN-feature-name>`), resolved from `.specify/feature.json` at the project root; do not look for `specs/<prefix>-*` at the root
 
 ## Graceful Degradation
 

--- a/devBenches/base-image/files/speckit-worktree/templates/claude/skills/speckit-specify/SKILL.md
+++ b/devBenches/base-image/files/speckit-worktree/templates/claude/skills/speckit-specify/SKILL.md
@@ -9,6 +9,7 @@ metadata:
 user-invocable: true
 disable-model-invocation: true
 ---
+<!-- speckit-overlay-shape: 1 -->
 
 
 ## User Input
@@ -81,6 +82,8 @@ Given that feature description, do this:
    - Write the spec files and `.specify/feature.json` in that worktree, not in the original checkout
    - Remember that a linked worktree does **not** change the user's current shell directory automatically
 
+   The hook also returns `REPO_SHAPE` (`single` or `three-leg`). When it is `three-leg` it additionally returns `PROJECT_ROOT`, `SPEC_WORKTREE_PATH`, `CODE_WORKTREE_PATH`, and `FEATURE_DIR`; `WORKTREE_PATH` is then the feature directory that holds both leg worktrees, not a checkout. See "Three-leg projects" in step 3.
+
    If the user explicitly provided `GIT_BRANCH_NAME`, pass it through to the hook so the branch script uses the exact value as the branch name (bypassing all prefix/suffix generation).
 
 3. **Create the spec feature directory**:
@@ -94,6 +97,15 @@ Given that feature description, do this:
 
    When `WORKTREE_PATH` is not returned:
    - Set `TARGET_REPO_ROOT` to the current repository root
+
+   **Three-leg projects (`REPO_SHAPE: "three-leg"`)**:
+
+   When the hook's JSON reports `REPO_SHAPE: "three-leg"` (an openRepoShape assembly root), the spec files do **not** go in a repo-root-shaped worktree:
+
+   - Use `FEATURE_DIR` from the hook JSON verbatim as `SPECIFY_FEATURE_DIRECTORY`; it is `<SPEC_WORKTREE_PATH>/specs/<BRANCH_NAME>`, inside the feature's spec leg worktree. Do not invent a directory name and do not scan `specs/` yourself.
+   - Set `TARGET_REPO_ROOT` to `PROJECT_ROOT` from the hook JSON. The feature directory has **no** `.specify/` of its own: templates come from `PROJECT_ROOT/.specify/templates/` and `.specify/feature.json` is written at `PROJECT_ROOT/.specify/feature.json`, relative to `PROJECT_ROOT` (`worktrees/<BRANCH_NAME>/<spec>/specs/<BRANCH_NAME>`). The hook has already written it; leave it alone unless it is missing or wrong.
+   - Implementation source and tests belong in `CODE_WORKTREE_PATH`, the sibling code leg worktree — never in the spec worktree and never in `<spec>/` or `<code>/` at the project root, which sit at the pinned commit.
+   - Follow-on commands (`/speckit.clarify`, `/speckit.plan`, `/speckit.tasks`, `/speckit.analyze`, `/speckit.implement`) run **from `PROJECT_ROOT`**, not from the worktree, with `SPECIFY_FEATURE=<BRANCH_NAME>` and `SPECIFY_FEATURE_DIRECTORY=worktrees/<BRANCH_NAME>/<spec>/specs/<BRANCH_NAME>` exported.
 
    **Resolution order for `SPECIFY_FEATURE_DIRECTORY`**:
    1. If the user explicitly provided `SPECIFY_FEATURE_DIRECTORY` (e.g., via environment variable, argument, or configuration), use it as-is
@@ -249,6 +261,7 @@ Given that feature description, do this:
    - `SPECIFY_FEATURE_DIRECTORY` — the feature directory path
    - `SPEC_FILE` — the spec file path
    - `WORKTREE_PATH` — include when the hook created a linked worktree, and state that subsequent `/speckit.*` commands should run from that worktree
+   - In a three-leg project, also `SPEC_WORKTREE_PATH`, `CODE_WORKTREE_PATH`, and `PROJECT_ROOT`, and state that subsequent `/speckit.*` commands run from `PROJECT_ROOT` with `SPECIFY_FEATURE` and `SPECIFY_FEATURE_DIRECTORY` exported
    - Checklist results summary
    - Readiness for the next phase (`/speckit.clarify` or `/speckit.plan`)
 
@@ -281,7 +294,7 @@ Given that feature description, do this:
        ```
    - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
 
-**NOTE:** Checkout creation is handled by the `before_specify` hook (git extension). Spec directory and file creation are always handled by this core command.
+**NOTE:** Checkout creation is handled by the `before_specify` hook (git extension). Spec directory and file creation are always handled by this core command. In a three-leg project the hook creates both leg worktrees and writes `.specify/feature.json` at `PROJECT_ROOT`; this command still creates the spec directory and files, inside `FEATURE_DIR`.
 
 ## Quick Guidelines
 

--- a/devBenches/base-image/files/speckit-worktree/templates/codex/skills/speckit-git-feature/SKILL.md
+++ b/devBenches/base-image/files/speckit-worktree/templates/codex/skills/speckit-git-feature/SKILL.md
@@ -2,6 +2,7 @@
 name: "speckit-git-feature"
 description: "Codex wrapper for the Speckit git feature workflow."
 ---
+<!-- speckit-overlay-shape: 1 -->
 
 # speckit-git-feature
 
@@ -13,3 +14,4 @@ Rules:
 - Read the source skill before doing anything else.
 - Pass any text after `/speckit.git.feature` through as the original command input for the source skill.
 - Execute the source skill exactly, including branch creation behavior.
+- The hook is shape-aware: in an openRepoShape three-leg project it creates the branch and a worktree in BOTH legs and returns `REPO_SHAPE`, `PROJECT_ROOT`, `SPEC_WORKTREE_PATH`, `CODE_WORKTREE_PATH`, and `FEATURE_DIR`. Never run it against the assembly root expecting a root branch.

--- a/devBenches/base-image/files/speckit-worktree/templates/codex/skills/speckit-git-validate/SKILL.md
+++ b/devBenches/base-image/files/speckit-worktree/templates/codex/skills/speckit-git-validate/SKILL.md
@@ -2,6 +2,7 @@
 name: "speckit-git-validate"
 description: "Codex wrapper for the Speckit git branch validation workflow."
 ---
+<!-- speckit-overlay-shape: 1 -->
 
 # speckit-git-validate
 
@@ -13,3 +14,4 @@ Rules:
 - Read the source skill before doing anything else.
 - Pass any text after `/speckit.git.validate` through as the original command input for the source skill.
 - Execute the source skill exactly, including validation behavior.
+- In an openRepoShape three-leg project validate the two leg worktree branches (from `.specify/feature.json` at the project root), not the assembly root's branch.

--- a/devBenches/base-image/files/speckit-worktree/templates/codex/skills/speckit-specify/SKILL.md
+++ b/devBenches/base-image/files/speckit-worktree/templates/codex/skills/speckit-specify/SKILL.md
@@ -2,6 +2,7 @@
 name: "speckit-specify"
 description: "Codex wrapper for the Speckit specification workflow."
 ---
+<!-- speckit-overlay-shape: 1 -->
 
 # speckit-specify
 
@@ -13,3 +14,4 @@ Rules:
 - Read the source skill before doing anything else.
 - Treat text after `/speckit.specify` as the original command input for the source skill.
 - Execute the source skill exactly, including prerequisite checks, file generation, and summary output.
+- Honour the source skill's "Three-leg projects" rules when the `before_specify` hook reports `REPO_SHAPE: "three-leg"`: spec files go under `FEATURE_DIR`, `.specify/feature.json` lives at `PROJECT_ROOT`, and follow-on commands run from `PROJECT_ROOT`.

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/commands/speckit.git.feature.md
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/commands/speckit.git.feature.md
@@ -26,6 +26,21 @@ If the user explicitly provided `GIT_BRANCH_NAME` (e.g., via environment variabl
 - Verify Git is available by running `git rev-parse --is-inside-work-tree 2>/dev/null`
 - If Git is not available, warn the user and skip branch creation
 
+## Repository Shape
+
+The script resolves the project shape itself and reports it as `REPO_SHAPE`.
+
+- **Single repository** (`REPO_SHAPE: "single"`): one feature branch, and in worktree mode one linked worktree under `worktree_root`.
+- **Three-leg project** (`REPO_SHAPE: "three-leg"` — an openRepoShape assembly root whose `project.yaml` declares `legs:` for `role: spec` and `role: code`): the same `NNN-feature-name` branch is created in **both** leg repositories and one linked worktree is added per leg at `worktrees/<NNN-feature-name>/<spec>/` and `worktrees/<NNN-feature-name>/<code>/`. The assembly root never receives a feature branch or a worktree. The script writes `.specify/feature.json` **at the project root**, pointing at `worktrees/<NNN-feature-name>/<spec>/specs/<NNN-feature-name>`.
+
+In a three-leg project:
+
+- Run the script from the project root (the directory holding `.specify/`).
+- `checkout_mode` must be `worktree`; `branch` is refused with an error naming `checkout_mode` in `.specify/extensions/git/git-config.yml`.
+- Both legs must be initialised checkouts; otherwise the script refuses and names `git submodule update --init` / `make bootstrap`.
+- Feature numbering scans `specs/` on the spec leg's base branch and working tree, plus the branch lists of both leg repositories.
+- Each leg's branch is cut from `origin/<base_branch>` after a best-effort fetch, falling back to the local base branch when offline.
+
 ## Branch Numbering Mode
 
 Determine the branch numbering strategy by checking configuration in this order:
@@ -68,6 +83,7 @@ Run the appropriate script based on your platform:
 - You must only ever run this script once per feature
 - The JSON output will always contain `BRANCH_NAME`, `FEATURE_NUM`, and `CHECKOUT_MODE`
 - In worktree mode the JSON output also contains `BASE_BRANCH` and `WORKTREE_PATH`
+- In a three-leg project the JSON also contains `REPO_SHAPE`, `PROJECT_ROOT`, `SPEC_WORKTREE_PATH`, `CODE_WORKTREE_PATH`, and `FEATURE_DIR`; there `WORKTREE_PATH` is the feature directory that holds both leg worktrees
 
 ## Graceful Degradation
 
@@ -83,3 +99,8 @@ The script outputs JSON with:
 - `CHECKOUT_MODE`: `branch` or `worktree`
 - `BASE_BRANCH`: the configured worktree base branch when `CHECKOUT_MODE=worktree`
 - `WORKTREE_PATH`: the linked worktree root when `CHECKOUT_MODE=worktree`
+- `REPO_SHAPE`: `single` or `three-leg`
+- `PROJECT_ROOT`: the project root that holds `.specify/` (three-leg only)
+- `SPEC_WORKTREE_PATH`: the spec leg worktree `worktrees/<NNN-feature-name>/<spec>/` (three-leg only)
+- `CODE_WORKTREE_PATH`: the code leg worktree `worktrees/<NNN-feature-name>/<code>/` (three-leg only)
+- `FEATURE_DIR`: the Speckit feature directory `<spec worktree>/specs/<NNN-feature-name>` (three-leg only)

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/auto-commit.sh
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/auto-commit.sh
@@ -7,6 +7,7 @@
 #   e.g.: auto-commit.sh after_specify
 
 set -e
+# speckit-overlay-shape: 1
 
 EVENT_NAME="${1:-}"
 if [ -z "$EVENT_NAME" ]; then
@@ -30,6 +31,15 @@ _find_project_root() {
 
 REPO_ROOT=$(_find_project_root "$SCRIPT_DIR") || REPO_ROOT="$(pwd)"
 cd "$REPO_ROOT"
+
+# Resolve the repository shape. In a three-leg project the commits belong in
+# the feature's two leg worktrees, never in the assembly root.
+REPO_SHAPE=single
+if [ -f "$SCRIPT_DIR/git-common.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$SCRIPT_DIR/git-common.sh"
+    load_repo_shape "$REPO_ROOT"
+fi
 
 # Check if git is available
 if ! command -v git >/dev/null 2>&1; then
@@ -150,6 +160,122 @@ fi
 
 if [ "$_enabled" != "true" ]; then
     exit 0
+fi
+
+# Read one scalar from git-config.yml (used for worktree_root in three-leg).
+_shape_config_scalar() {
+    local key="$1"
+    local default_value="$2"
+    local line value
+
+    if [ ! -f "$_config_file" ]; then
+        printf '%s\n' "$default_value"
+        return 0
+    fi
+    line=$(grep -E "^[[:space:]]*$key:[[:space:]]*" "$_config_file" | tail -n 1 || true)
+    if [ -z "$line" ]; then
+        printf '%s\n' "$default_value"
+        return 0
+    fi
+    value="${line#*:}"
+    value=$(_normalize_yaml_scalar "$value")
+    if [ -z "$value" ]; then
+        value="$default_value"
+    fi
+    printf '%s\n' "$value"
+}
+
+# Mirror core read_feature_json_feature_directory: jq -> python3 -> grep/sed.
+_shape_feature_directory_from_json() {
+    local feature_json="$REPO_ROOT/.specify/feature.json"
+    local value=""
+
+    [ -f "$feature_json" ] || return 1
+    if command -v jq >/dev/null 2>&1; then
+        value=$(jq -r '.feature_directory // empty' "$feature_json" 2>/dev/null) || value=""
+    fi
+    if [ -z "$value" ] && command -v python3 >/dev/null 2>&1; then
+        value=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); v=d.get('feature_directory'); print(v if v else '')" \
+            "$feature_json" 2>/dev/null) || value=""
+    fi
+    if [ -z "$value" ]; then
+        value=$( { grep -E '"feature_directory"[[:space:]]*:' "$feature_json" 2>/dev/null || true; } \
+            | head -n 1 \
+            | sed -E 's/^[^:]*:[[:space:]]*"([^"]*)".*$/\1/' )
+    fi
+    [ -n "$value" ] || return 1
+    printf '%s\n' "$value"
+}
+
+# Absolute path of the selected feature directory (worktrees/<NNN-feature>).
+_shape_resolve_feature_dir() {
+    local feature_directory feature_dir worktree_root
+
+    if [ -n "${SPECIFY_FEATURE:-}" ]; then
+        worktree_root=$(_shape_config_scalar "worktree_root" "worktrees")
+        case "$worktree_root" in
+            /*) printf '%s/%s\n' "$worktree_root" "$SPECIFY_FEATURE" ;;
+            *) printf '%s/%s/%s\n' "$REPO_ROOT" "$worktree_root" "$SPECIFY_FEATURE" ;;
+        esac
+        return 0
+    fi
+
+    feature_directory=$(_shape_feature_directory_from_json) || return 1
+    case "$feature_directory" in
+        /*) ;;
+        *) feature_directory="$REPO_ROOT/$feature_directory" ;;
+    esac
+    feature_dir="${feature_directory%/*}"
+    case "$feature_dir" in
+        */specs) feature_dir="${feature_dir%/specs}" ;;
+        *) return 1 ;;
+    esac
+    case "$feature_dir" in
+        */"$SHAPE_SPEC_PATH") feature_dir="${feature_dir%/"$SHAPE_SPEC_PATH"}" ;;
+        *) return 1 ;;
+    esac
+    printf '%s\n' "$feature_dir"
+}
+
+_commit_in_tree() {
+    local tree="$1"
+    local label="$2"
+    local out
+
+    if [ ! -d "$tree" ]; then
+        echo "[specify] Warning: $label worktree not found; skipped: $tree" >&2
+        return 0
+    fi
+    if git -C "$tree" diff --quiet HEAD 2>/dev/null \
+        && git -C "$tree" diff --cached --quiet 2>/dev/null \
+        && [ -z "$(git -C "$tree" ls-files --others --exclude-standard 2>/dev/null)" ]; then
+        echo "[specify] No changes to commit in the $label worktree after $EVENT_NAME" >&2
+        return 0
+    fi
+    out=$(git -C "$tree" add . 2>&1) || { echo "[specify] Error: git add failed in the $label worktree: $out" >&2; return 1; }
+    out=$(git -C "$tree" commit -q -m "$_commit_msg" 2>&1) || { echo "[specify] Error: git commit failed in the $label worktree: $out" >&2; return 1; }
+    echo "✓ Changes committed ${_phase} ${_command_name} in the $label worktree" >&2
+}
+
+if [ "$REPO_SHAPE" = "three-leg" ]; then
+    # Derive a human-readable command name from the event
+    # e.g., after_specify -> specify, before_plan -> plan
+    _command_name=$(echo "$EVENT_NAME" | sed 's/^after_//' | sed 's/^before_//')
+    _phase=$(echo "$EVENT_NAME" | grep -q '^before_' && echo 'before' || echo 'after')
+    if [ -z "$_commit_msg" ]; then
+        _commit_msg="[Spec Kit] Auto-commit ${_phase} ${_command_name}"
+    fi
+
+    if ! _feature_dir=$(_shape_resolve_feature_dir); then
+        echo "[specify] No Speckit feature is selected in this three-leg project; skipped auto-commit." >&2
+        echo "[specify] Export SPECIFY_FEATURE (and SPECIFY_FEATURE_DIRECTORY) or run /speckit.specify first." >&2
+        exit 0
+    fi
+
+    _shape_status=0
+    _commit_in_tree "$_feature_dir/$SHAPE_SPEC_PATH" spec || _shape_status=1
+    _commit_in_tree "$_feature_dir/$SHAPE_CODE_PATH" code || _shape_status=1
+    exit "$_shape_status"
 fi
 
 # Check if there are changes to commit

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/create-new-feature.sh
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/create-new-feature.sh
@@ -5,6 +5,7 @@
 # git-common.sh for minimal git helpers.
 
 set -e
+# speckit-overlay-shape: 1
 
 JSON_MODE=false
 DRY_RUN=false
@@ -591,6 +592,202 @@ resolve_base_ref() {
     return 1
 }
 
+# ---------------------------------------------------------------------------
+# Three-leg (openRepoShape) helpers.
+#
+# In a three-leg project the feature lives in two linked worktrees, one per leg
+# repository, under <root>/worktrees/<NNN-feature>/. The root repository never
+# receives a feature branch or a worktree from this hook.
+# ---------------------------------------------------------------------------
+
+shape_highest_from_leg_specs_tree() {
+    local leg="$1"
+    local base_ref="$2"
+
+    git -C "$leg" ls-tree --name-only "$base_ref:specs" 2>/dev/null \
+        | _extract_highest_number ""
+}
+
+shape_highest_from_leg_branches() {
+    local leg="$1"
+
+    git -C "$leg" for-each-ref --format='%(refname)' refs/heads refs/remotes 2>/dev/null \
+        | sed -E 's|^refs/heads/||; s|^refs/remotes/[^/]*/||' \
+        | _extract_highest_number ""
+}
+
+# Highest of: specs/ on the spec leg's base ref, specs/ in the spec leg working
+# tree, and the sequential branch names of BOTH leg repositories.
+shape_next_feature_number() {
+    local highest=0
+    local candidate
+
+    for candidate in \
+        "$(shape_highest_from_leg_specs_tree "$SPEC_LEG" "$SPEC_BASE_REF")" \
+        "$(get_highest_from_specs "$SPEC_LEG/specs")" \
+        "$(shape_highest_from_leg_branches "$SPEC_LEG")" \
+        "$(shape_highest_from_leg_branches "$CODE_LEG")"; do
+        [ -n "$candidate" ] || candidate=0
+        if [ "$candidate" -gt "$highest" ]; then
+            highest="$candidate"
+        fi
+    done
+
+    echo $((highest + 1))
+}
+
+shape_fetch_leg_base() {
+    local leg="$1"
+    local role="$2"
+    local fetch_error=""
+
+    git -C "$leg" remote get-url origin >/dev/null 2>&1 || return 0
+    if ! fetch_error=$(GIT_TERMINAL_PROMPT=0 git -C "$leg" fetch origin "$BASE_BRANCH" 2>&1); then
+        >&2 echo "[specify] Warning: could not fetch '$BASE_BRANCH' from origin in the $role leg; using the refs already present."
+        if [ -n "$fetch_error" ]; then
+            >&2 printf '%s\n' "$fetch_error"
+        fi
+    fi
+}
+
+shape_resolve_leg_base_ref() {
+    local leg="$1"
+
+    if git -C "$leg" show-ref --verify --quiet "refs/remotes/origin/$BASE_BRANCH"; then
+        printf 'origin/%s\n' "$BASE_BRANCH"
+        return 0
+    fi
+    if git -C "$leg" show-ref --verify --quiet "refs/heads/$BASE_BRANCH"; then
+        printf '%s\n' "$BASE_BRANCH"
+        return 0
+    fi
+    return 1
+}
+
+shape_branch_exists_in_leg() {
+    local leg="$1"
+    local branch="$2"
+
+    git -C "$leg" show-ref --verify --quiet "refs/heads/$branch"
+}
+
+shape_add_leg_worktree() {
+    local leg="$1"
+    local role="$2"
+    local path="$3"
+    local base_ref="$4"
+    local create_branch="$5"
+    local worktree_error=""
+
+    if [ "$create_branch" = true ]; then
+        if ! worktree_error=$(git -C "$leg" worktree add -b "$BRANCH_NAME" "$path" "$base_ref" 2>&1); then
+            >&2 echo "Error: Failed to create the $role leg worktree '$path' from '$base_ref'."
+            if [ -n "$worktree_error" ]; then
+                >&2 printf '%s\n' "$worktree_error"
+            fi
+            return 1
+        fi
+        return 0
+    fi
+
+    if ! worktree_error=$(git -C "$leg" worktree add "$path" "$BRANCH_NAME" 2>&1); then
+        >&2 echo "Error: Failed to add the $role leg worktree '$path' for existing branch '$BRANCH_NAME'."
+        if [ -n "$worktree_error" ]; then
+            >&2 printf '%s\n' "$worktree_error"
+        fi
+        return 1
+    fi
+}
+
+shape_rollback_spec_worktree() {
+    local created_branch="$1"
+
+    >&2 echo "[specify] Rolling back the spec leg worktree after the code leg failed."
+    git -C "$SPEC_LEG" worktree remove --force "$SPEC_WORKTREE_PATH" >/dev/null 2>&1 \
+        || rm -rf "$SPEC_WORKTREE_PATH" >/dev/null 2>&1 || true
+    git -C "$SPEC_LEG" worktree prune >/dev/null 2>&1 || true
+    if [ "$created_branch" = true ]; then
+        git -C "$SPEC_LEG" branch -D "$BRANCH_NAME" >/dev/null 2>&1 || true
+    fi
+    rmdir "$WORKTREE_PATH" >/dev/null 2>&1 || true
+}
+
+# Record the resolved feature directory in the ROOT's .specify/feature.json so
+# core check-prerequisites.sh resolves FEATURE_DIR without any change to core.
+shape_persist_feature_json() {
+    local relative_dir="$1"
+    local feature_json="$REPO_ROOT/.specify/feature.json"
+
+    if [ "$(type -t _persist_feature_json 2>/dev/null || true)" = "function" ]; then
+        _persist_feature_json "$REPO_ROOT" "$relative_dir"
+        return 0
+    fi
+
+    mkdir -p "$REPO_ROOT/.specify"
+    if command -v jq >/dev/null 2>&1; then
+        jq -cn --arg fd "$relative_dir" '{feature_directory:$fd}' > "$feature_json"
+    elif [ "$(type -t json_escape 2>/dev/null || true)" = "function" ]; then
+        printf '{"feature_directory":"%s"}\n' "$(json_escape "$relative_dir")" > "$feature_json"
+    elif command -v python3 >/dev/null 2>&1; then
+        python3 - "$feature_json" "$relative_dir" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "w", encoding="utf-8") as stream:
+    json.dump({"feature_directory": sys.argv[2]}, stream)
+    stream.write("\n")
+PY
+    else
+        >&2 echo "Error: Writing .specify/feature.json requires jq or Python 3."
+        return 1
+    fi
+}
+
+shape_create_feature_worktrees() {
+    local spec_branch_exists=false
+    local code_branch_exists=false
+    local spec_branch_created=false
+
+    if [ -e "$WORKTREE_PATH" ]; then
+        >&2 echo "Error: Feature worktree directory '$WORKTREE_PATH' already exists. Remove it or specify a different number with --number."
+        exit 1
+    fi
+
+    if shape_branch_exists_in_leg "$SPEC_LEG" "$BRANCH_NAME"; then
+        spec_branch_exists=true
+    fi
+    if shape_branch_exists_in_leg "$CODE_LEG" "$BRANCH_NAME"; then
+        code_branch_exists=true
+    fi
+    if { [ "$spec_branch_exists" = true ] || [ "$code_branch_exists" = true ]; } \
+        && [ "$ALLOW_EXISTING" != true ]; then
+        >&2 echo "Error: Branch '$BRANCH_NAME' already exists in a leg repository. Please use a different feature name or specify a different number with --number."
+        exit 1
+    fi
+
+    mkdir -p "$WORKTREE_PATH"
+
+    if [ "$spec_branch_exists" = true ]; then
+        shape_add_leg_worktree "$SPEC_LEG" spec "$SPEC_WORKTREE_PATH" "$SPEC_BASE_REF" false || exit 1
+    else
+        shape_add_leg_worktree "$SPEC_LEG" spec "$SPEC_WORKTREE_PATH" "$SPEC_BASE_REF" true || exit 1
+        spec_branch_created=true
+    fi
+
+    if [ "$code_branch_exists" = true ]; then
+        if ! shape_add_leg_worktree "$CODE_LEG" code "$CODE_WORKTREE_PATH" "$CODE_BASE_REF" false; then
+            shape_rollback_spec_worktree "$spec_branch_created"
+            exit 1
+        fi
+    elif ! shape_add_leg_worktree "$CODE_LEG" code "$CODE_WORKTREE_PATH" "$CODE_BASE_REF" true; then
+        shape_rollback_spec_worktree "$spec_branch_created"
+        exit 1
+    fi
+
+    mkdir -p "$FEATURE_DIR"
+    shape_persist_feature_json "$FEATURE_DIR_RELATIVE" || exit 1
+}
+
 find_worktree_for_branch() {
     local target_branch="$1"
     local index
@@ -734,8 +931,18 @@ PY
 
 cd "$REPO_ROOT"
 
+# Resolve the repository shape once; every layout decision below reads it.
+load_repo_shape "$REPO_ROOT"
+PROJECT_ROOT="${PROJECT_ROOT:-$REPO_ROOT}"
+
 SPECS_DIR="$REPO_ROOT/specs"
 DEFAULT_WORKTREE_ROOT="../$(basename "$REPO_ROOT")-worktrees"
+SPEC_BASE_REF=""
+CODE_BASE_REF=""
+if [ "$REPO_SHAPE" = "three-leg" ]; then
+    SPECS_DIR="$SPEC_LEG/specs"
+    DEFAULT_WORKTREE_ROOT="worktrees"
+fi
 CHECKOUT_MODE=$(get_config_value "checkout_mode" "branch" "SPECKIT_GIT_CHECKOUT_MODE")
 CHECKOUT_MODE=$(printf '%s' "$CHECKOUT_MODE" | tr '[:upper:]' '[:lower:]')
 BRANCH_NUMBERING=$(get_config_value "branch_numbering" "sequential" "SPECKIT_GIT_BRANCH_NUMBERING")
@@ -753,6 +960,24 @@ if [ "$BRANCH_NUMBERING" != "sequential" ] && [ "$BRANCH_NUMBERING" != "timestam
     exit 1
 fi
 
+if [ "$REPO_SHAPE" = "three-leg" ]; then
+    if [ "$CHECKOUT_MODE" != "worktree" ]; then
+        echo "Error: a three-leg project requires checkout_mode: worktree in .specify/extensions/git/git-config.yml (got '$CHECKOUT_MODE')." >&2
+        echo "Branch mode would put the feature on the assembly root, which never carries a feature branch." >&2
+        exit 1
+    fi
+    if ! shape_leg_is_checkout "$SPEC_LEG"; then
+        echo "Error: the spec leg '$SHAPE_SPEC_PATH' is not an initialised Git checkout at '$SPEC_LEG'." >&2
+        echo "Run 'git submodule update --init' (or 'make bootstrap') in the project root first." >&2
+        exit 1
+    fi
+    if ! shape_leg_is_checkout "$CODE_LEG"; then
+        echo "Error: the code leg '$SHAPE_CODE_PATH' is not an initialised Git checkout at '$CODE_LEG'." >&2
+        echo "Run 'git submodule update --init' (or 'make bootstrap') in the project root first." >&2
+        exit 1
+    fi
+fi
+
 JSON_ENCODER=""
 if [ "$JSON_MODE" = true ] || { [ "$CHECKOUT_MODE" = "worktree" ] && [ "$DRY_RUN" != true ]; }; then
     if ! JSON_ENCODER=$(select_json_encoder); then
@@ -763,6 +988,23 @@ fi
 if [ "$CHECKOUT_MODE" = "worktree" ] && [ "$DRY_RUN" != true ] && ! command -v python3 >/dev/null 2>&1; then
     echo "Error: Non-dry-run worktree creation requires Python 3 for safe state publication." >&2
     exit 1
+fi
+
+if [ "$REPO_SHAPE" = "three-leg" ]; then
+    # Base ref per leg: origin/<base_branch> after a best-effort fetch (failure
+    # is a warning so offline work keeps working), else the local base branch.
+    if [ "$DRY_RUN" != true ]; then
+        shape_fetch_leg_base "$SPEC_LEG" spec
+        shape_fetch_leg_base "$CODE_LEG" code
+    fi
+    if ! SPEC_BASE_REF=$(shape_resolve_leg_base_ref "$SPEC_LEG"); then
+        echo "Error: Base branch '$BASE_BRANCH' does not exist locally or on origin in the spec leg '$SHAPE_SPEC_PATH'." >&2
+        exit 1
+    fi
+    if ! CODE_BASE_REF=$(shape_resolve_leg_base_ref "$CODE_LEG"); then
+        echo "Error: Base branch '$BASE_BRANCH' does not exist locally or on origin in the code leg '$SHAPE_CODE_PATH'." >&2
+        exit 1
+    fi
 fi
 
 if [ "$BRANCH_NUMBERING" = "timestamp" ]; then
@@ -846,7 +1088,9 @@ else
     else
         BRANCH_SCOPE_PREFIX=$(branch_scope_prefix)
         if [ -z "$BRANCH_NUMBER" ]; then
-            if [ "$DRY_RUN" = true ] && [ "$HAS_GIT" = true ]; then
+            if [ "$REPO_SHAPE" = "three-leg" ]; then
+                BRANCH_NUMBER=$(shape_next_feature_number)
+            elif [ "$DRY_RUN" = true ] && [ "$HAS_GIT" = true ]; then
                 BRANCH_NUMBER=$(check_existing_branches "$SPECS_DIR" true "$BRANCH_SCOPE_PREFIX")
             elif [ "$DRY_RUN" = true ]; then
                 if [ -n "$BRANCH_SCOPE_PREFIX" ]; then
@@ -913,6 +1157,20 @@ if [ "$CHECKOUT_MODE" = "worktree" ]; then
     WORKTREE_PATH="$WORKTREE_ROOT/$BRANCH_NAME"
 fi
 
+SPEC_WORKTREE_PATH=""
+CODE_WORKTREE_PATH=""
+FEATURE_DIR=""
+FEATURE_DIR_RELATIVE=""
+if [ "$REPO_SHAPE" = "three-leg" ]; then
+    SPEC_WORKTREE_PATH="$WORKTREE_PATH/$SHAPE_SPEC_PATH"
+    CODE_WORKTREE_PATH="$WORKTREE_PATH/$SHAPE_CODE_PATH"
+    FEATURE_DIR="$SPEC_WORKTREE_PATH/specs/$BRANCH_NAME"
+    FEATURE_DIR_RELATIVE="$FEATURE_DIR"
+    case "$FEATURE_DIR" in
+        "$REPO_ROOT"/*) FEATURE_DIR_RELATIVE="${FEATURE_DIR#"$REPO_ROOT/"}" ;;
+    esac
+fi
+
 STATE_FILE=""
 if [ "$DRY_RUN" != true ] && [ "$HAS_GIT" = true ] && [ "$CHECKOUT_MODE" = "worktree" ]; then
     if ! STATE_COMMON_DIR=$(resolve_git_common_dir); then
@@ -926,7 +1184,9 @@ if [ "$DRY_RUN" != true ] && [ "$HAS_GIT" = true ] && [ "$CHECKOUT_MODE" = "work
 fi
 
 if [ "$DRY_RUN" != true ]; then
-    if [ "$HAS_GIT" = true ]; then
+    if [ "$REPO_SHAPE" = "three-leg" ]; then
+        shape_create_feature_worktrees
+    elif [ "$HAS_GIT" = true ]; then
         if [ "$CHECKOUT_MODE" = "worktree" ]; then
             existing_worktree=""
             find_worktree_status=0
@@ -1023,9 +1283,16 @@ if [ "$DRY_RUN" != true ]; then
     fi
 
     printf '# To persist: export SPECIFY_FEATURE=%q\n' "$BRANCH_NAME" >&2
+    if [ "$REPO_SHAPE" = "three-leg" ]; then
+        printf '#             export SPECIFY_FEATURE_DIRECTORY=%q\n' "$FEATURE_DIR_RELATIVE" >&2
+    fi
     if [ "$CHECKOUT_MODE" = "worktree" ] && [ -n "$WORKTREE_PATH" ]; then
         write_last_worktree_state "$BRANCH_NAME" "$WORKTREE_PATH" "$BASE_BRANCH"
         printf '# Feature worktree: %q\n' "$WORKTREE_PATH" >&2
+        if [ "$REPO_SHAPE" = "three-leg" ]; then
+            printf '# Spec worktree: %q\n' "$SPEC_WORKTREE_PATH" >&2
+            printf '# Code worktree: %q\n' "$CODE_WORKTREE_PATH" >&2
+        fi
     fi
 fi
 
@@ -1039,34 +1306,34 @@ if $JSON_MODE; then
             --arg base_branch "$BASE_BRANCH" \
             --arg worktree_path "$WORKTREE_PATH" \
             --arg dry_run "$DRY_RUN" \
-            '({BRANCH_NAME:$branch_name,FEATURE_NUM:$feature_num,CHECKOUT_MODE:$checkout_mode,HAS_GIT:($has_git == "true")}
+            --arg repo_shape "$REPO_SHAPE" \
+            --arg project_root "$PROJECT_ROOT" \
+            --arg spec_worktree_path "$SPEC_WORKTREE_PATH" \
+            --arg code_worktree_path "$CODE_WORKTREE_PATH" \
+            --arg feature_dir "$FEATURE_DIR" \
+            '({BRANCH_NAME:$branch_name,FEATURE_NUM:$feature_num,CHECKOUT_MODE:$checkout_mode,HAS_GIT:($has_git == "true"),REPO_SHAPE:$repo_shape}
               + (if $checkout_mode == "worktree" then {BASE_BRANCH:$base_branch,WORKTREE_PATH:$worktree_path} else {} end)
+              + (if $repo_shape == "three-leg" then {PROJECT_ROOT:$project_root,SPEC_WORKTREE_PATH:$spec_worktree_path,CODE_WORKTREE_PATH:$code_worktree_path,FEATURE_DIR:$feature_dir} else {} end)
               + (if $dry_run == "true" then {DRY_RUN:true} else {} end))'
     elif [ "$JSON_ENCODER" = json_escape ]; then
-        _je_branch=$(json_escape "$BRANCH_NAME")
-        _je_num=$(json_escape "$FEATURE_NUM")
-        _je_mode=$(json_escape "$CHECKOUT_MODE")
-        _je_base=$(json_escape "$BASE_BRANCH")
-        _je_worktree=$(json_escape "$WORKTREE_PATH")
-        if [ "$DRY_RUN" = true ]; then
-            if [ "$CHECKOUT_MODE" = "worktree" ]; then
-                printf '{"BRANCH_NAME":"%s","FEATURE_NUM":"%s","CHECKOUT_MODE":"%s","HAS_GIT":%s,"BASE_BRANCH":"%s","WORKTREE_PATH":"%s","DRY_RUN":true}\n' \
-                    "$_je_branch" "$_je_num" "$_je_mode" "$HAS_GIT" "$_je_base" "$_je_worktree"
-            else
-                printf '{"BRANCH_NAME":"%s","FEATURE_NUM":"%s","CHECKOUT_MODE":"%s","HAS_GIT":%s,"DRY_RUN":true}\n' \
-                    "$_je_branch" "$_je_num" "$_je_mode" "$HAS_GIT"
-            fi
-        else
-            if [ "$CHECKOUT_MODE" = "worktree" ]; then
-                printf '{"BRANCH_NAME":"%s","FEATURE_NUM":"%s","CHECKOUT_MODE":"%s","HAS_GIT":%s,"BASE_BRANCH":"%s","WORKTREE_PATH":"%s"}\n' \
-                    "$_je_branch" "$_je_num" "$_je_mode" "$HAS_GIT" "$_je_base" "$_je_worktree"
-            else
-                printf '{"BRANCH_NAME":"%s","FEATURE_NUM":"%s","CHECKOUT_MODE":"%s","HAS_GIT":%s}\n' \
-                    "$_je_branch" "$_je_num" "$_je_mode" "$HAS_GIT"
-            fi
+        _je_payload=$(printf '{"BRANCH_NAME":"%s","FEATURE_NUM":"%s","CHECKOUT_MODE":"%s","HAS_GIT":%s,"REPO_SHAPE":"%s"' \
+            "$(json_escape "$BRANCH_NAME")" "$(json_escape "$FEATURE_NUM")" \
+            "$(json_escape "$CHECKOUT_MODE")" "$HAS_GIT" "$(json_escape "$REPO_SHAPE")")
+        if [ "$CHECKOUT_MODE" = "worktree" ]; then
+            _je_payload="$_je_payload$(printf ',"BASE_BRANCH":"%s","WORKTREE_PATH":"%s"' \
+                "$(json_escape "$BASE_BRANCH")" "$(json_escape "$WORKTREE_PATH")")"
         fi
+        if [ "$REPO_SHAPE" = "three-leg" ]; then
+            _je_payload="$_je_payload$(printf ',"PROJECT_ROOT":"%s","SPEC_WORKTREE_PATH":"%s","CODE_WORKTREE_PATH":"%s","FEATURE_DIR":"%s"' \
+                "$(json_escape "$PROJECT_ROOT")" "$(json_escape "$SPEC_WORKTREE_PATH")" \
+                "$(json_escape "$CODE_WORKTREE_PATH")" "$(json_escape "$FEATURE_DIR")")"
+        fi
+        if [ "$DRY_RUN" = true ]; then
+            _je_payload="$_je_payload,\"DRY_RUN\":true"
+        fi
+        printf '%s}\n' "$_je_payload"
     else
-        python3 - "$BRANCH_NAME" "$FEATURE_NUM" "$CHECKOUT_MODE" "$HAS_GIT" "$BASE_BRANCH" "$WORKTREE_PATH" "$DRY_RUN" <<'PY'
+        python3 - "$BRANCH_NAME" "$FEATURE_NUM" "$CHECKOUT_MODE" "$HAS_GIT" "$BASE_BRANCH" "$WORKTREE_PATH" "$DRY_RUN" "$REPO_SHAPE" "$PROJECT_ROOT" "$SPEC_WORKTREE_PATH" "$CODE_WORKTREE_PATH" "$FEATURE_DIR" <<'PY'
 import json
 import sys
 
@@ -1075,10 +1342,16 @@ payload = {
     "FEATURE_NUM": sys.argv[2],
     "CHECKOUT_MODE": sys.argv[3],
     "HAS_GIT": sys.argv[4] == "true",
+    "REPO_SHAPE": sys.argv[8],
 }
 if sys.argv[3] == "worktree":
     payload["BASE_BRANCH"] = sys.argv[5]
     payload["WORKTREE_PATH"] = sys.argv[6]
+if sys.argv[8] == "three-leg":
+    payload["PROJECT_ROOT"] = sys.argv[9]
+    payload["SPEC_WORKTREE_PATH"] = sys.argv[10]
+    payload["CODE_WORKTREE_PATH"] = sys.argv[11]
+    payload["FEATURE_DIR"] = sys.argv[12]
 if sys.argv[7] == "true":
     payload["DRY_RUN"] = True
 json.dump(payload, sys.stdout, ensure_ascii=False, separators=(",", ":"))
@@ -1090,11 +1363,21 @@ else
     echo "FEATURE_NUM: $FEATURE_NUM"
     echo "CHECKOUT_MODE: $CHECKOUT_MODE"
     echo "HAS_GIT: $HAS_GIT"
+    echo "REPO_SHAPE: $REPO_SHAPE"
     if [ "$CHECKOUT_MODE" = "worktree" ]; then
         echo "BASE_BRANCH: $BASE_BRANCH"
         echo "WORKTREE_PATH: $WORKTREE_PATH"
     fi
+    if [ "$REPO_SHAPE" = "three-leg" ]; then
+        echo "PROJECT_ROOT: $PROJECT_ROOT"
+        echo "SPEC_WORKTREE_PATH: $SPEC_WORKTREE_PATH"
+        echo "CODE_WORKTREE_PATH: $CODE_WORKTREE_PATH"
+        echo "FEATURE_DIR: $FEATURE_DIR"
+    fi
     if [ "$DRY_RUN" != true ]; then
         printf '# To persist in your shell: export SPECIFY_FEATURE=%q\n' "$BRANCH_NAME"
+        if [ "$REPO_SHAPE" = "three-leg" ]; then
+            printf '#                           export SPECIFY_FEATURE_DIRECTORY=%q\n' "$FEATURE_DIR_RELATIVE"
+        fi
     fi
 fi

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/get-last-worktree.sh
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/get-last-worktree.sh
@@ -1,11 +1,22 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+# speckit-overlay-shape: 1
 
 JSON_MODE=false
-if [ "${1:-}" = "--json" ]; then
-    JSON_MODE=true
-fi
+ENV_MODE=false
+case "${1:-}" in
+    --json) JSON_MODE=true ;;
+    --env) ENV_MODE=true ;;
+esac
+
+# Shape-dependent extras filled in before emit_result runs.
+EMIT_REPO_SHAPE=single
+EMIT_PROJECT_ROOT=""
+EMIT_SPEC_WORKTREE_PATH=""
+EMIT_CODE_WORKTREE_PATH=""
+EMIT_FEATURE_DIR=""
+EMIT_FEATURE_DIR_RELATIVE=""
 
 capture_path() {
     local frame='__SPECKIT_PATH_CAPTURE_FRAME_7D3A9C__'
@@ -383,6 +394,24 @@ emit_result() {
     local repo_root="$4"
     local source="$5"
 
+    if $ENV_MODE; then
+        printf 'REPO_SHAPE=%q\n' "$EMIT_REPO_SHAPE"
+        printf 'PROJECT_ROOT=%q\n' "${EMIT_PROJECT_ROOT:-$repo_root}"
+        printf 'REPO_ROOT=%q\n' "$repo_root"
+        printf 'BRANCH_NAME=%q\n' "$branch_name"
+        printf 'BASE_BRANCH=%q\n' "$base_branch"
+        printf 'WORKTREE_PATH=%q\n' "$worktree_path"
+        printf 'SOURCE=%q\n' "$source"
+        if [ "$EMIT_REPO_SHAPE" = three-leg ]; then
+            printf 'SPEC_WORKTREE_PATH=%q\n' "$EMIT_SPEC_WORKTREE_PATH"
+            printf 'CODE_WORKTREE_PATH=%q\n' "$EMIT_CODE_WORKTREE_PATH"
+            printf 'FEATURE_DIR=%q\n' "$EMIT_FEATURE_DIR"
+            printf 'SPECIFY_FEATURE=%q\n' "$branch_name"
+            printf 'SPECIFY_FEATURE_DIRECTORY=%q\n' "$EMIT_FEATURE_DIR_RELATIVE"
+        fi
+        return 0
+    fi
+
     if $JSON_MODE; then
         if command -v jq >/dev/null 2>&1; then
             jq -cn \
@@ -391,19 +420,34 @@ emit_result() {
                 --arg base_branch "$base_branch" \
                 --arg repo_root "$repo_root" \
                 --arg source "$source" \
-                '{BRANCH_NAME:$branch_name,WORKTREE_PATH:$worktree_path,BASE_BRANCH:$base_branch,REPO_ROOT:$repo_root,SOURCE:$source}'
+                --arg repo_shape "$EMIT_REPO_SHAPE" \
+                --arg project_root "${EMIT_PROJECT_ROOT:-$repo_root}" \
+                --arg spec_worktree_path "$EMIT_SPEC_WORKTREE_PATH" \
+                --arg code_worktree_path "$EMIT_CODE_WORKTREE_PATH" \
+                --arg feature_dir "$EMIT_FEATURE_DIR" \
+                '({BRANCH_NAME:$branch_name,WORKTREE_PATH:$worktree_path,BASE_BRANCH:$base_branch,REPO_ROOT:$repo_root,SOURCE:$source,REPO_SHAPE:$repo_shape}
+                  + (if $repo_shape == "three-leg" then {PROJECT_ROOT:$project_root,SPEC_WORKTREE_PATH:$spec_worktree_path,CODE_WORKTREE_PATH:$code_worktree_path,FEATURE_DIR:$feature_dir} else {} end))'
         elif command -v python3 >/dev/null 2>&1; then
-            python3 - "$branch_name" "$worktree_path" "$base_branch" "$repo_root" "$source" <<'PY'
+            python3 - "$branch_name" "$worktree_path" "$base_branch" "$repo_root" "$source" \
+                "$EMIT_REPO_SHAPE" "${EMIT_PROJECT_ROOT:-$repo_root}" "$EMIT_SPEC_WORKTREE_PATH" \
+                "$EMIT_CODE_WORKTREE_PATH" "$EMIT_FEATURE_DIR" <<'PY'
 import json
 import sys
 
-print(json.dumps({
+payload = {
     "BRANCH_NAME": sys.argv[1],
     "WORKTREE_PATH": sys.argv[2],
     "BASE_BRANCH": sys.argv[3],
     "REPO_ROOT": sys.argv[4],
     "SOURCE": sys.argv[5],
-}))
+    "REPO_SHAPE": sys.argv[6],
+}
+if sys.argv[6] == "three-leg":
+    payload["PROJECT_ROOT"] = sys.argv[7]
+    payload["SPEC_WORKTREE_PATH"] = sys.argv[8]
+    payload["CODE_WORKTREE_PATH"] = sys.argv[9]
+    payload["FEATURE_DIR"] = sys.argv[10]
+print(json.dumps(payload))
 PY
         else
             echo "Error: JSON output requires jq or python3." >&2
@@ -412,6 +456,20 @@ PY
     else
         printf '%s\n' "$worktree_path"
     fi
+}
+
+shape_fill_emit_fields() {
+    local project_root="$1"
+    local feature_dir="$2"
+    local branch="$3"
+
+    shape_feature_paths_for "$project_root" "$feature_dir" "$branch"
+    EMIT_REPO_SHAPE=three-leg
+    EMIT_PROJECT_ROOT="$project_root"
+    EMIT_SPEC_WORKTREE_PATH="$SHAPE_SPEC_WORKTREE_PATH"
+    EMIT_CODE_WORKTREE_PATH="$SHAPE_CODE_WORKTREE_PATH"
+    EMIT_FEATURE_DIR="${SHAPE_FEATURE_DIR}"
+    EMIT_FEATURE_DIR_RELATIVE="$SHAPE_FEATURE_DIR_RELATIVE"
 }
 
 if capture_path git rev-parse --show-toplevel 2>/dev/null; then
@@ -443,6 +501,57 @@ fi
 
 STATE_FILE="$COMMON_DIR/speckit-last-worktree.json"
 BASE_BRANCH=$(resolve_config_value "$REPO_ROOT" "base_branch" "main")
+
+load_repo_shape "$MAIN_REPO_ROOT"
+if [ "$REPO_SHAPE" = "three-leg" ]; then
+    if ! shape_leg_is_checkout "$SPEC_LEG"; then
+        echo "Error: the spec leg '$SHAPE_SPEC_PATH' is not an initialised Git checkout at '$SPEC_LEG'." >&2
+        echo "Run 'git submodule update --init' (or 'make bootstrap') in the project root first." >&2
+        exit 1
+    fi
+    SHAPE_WORKTREE_ROOT_RAW=$(resolve_config_value "$MAIN_REPO_ROOT" "worktree_root" "worktrees")
+    if ! capture_path resolve_path_from_root "$MAIN_REPO_ROOT" "$SHAPE_WORKTREE_ROOT_RAW"; then
+        echo "Error: Failed to resolve the Speckit worktree root." >&2
+        exit 1
+    fi
+    SHAPE_WORKTREE_ROOT="$CAPTURED_PATH"
+    if ! shape_load_features "$SHAPE_WORKTREE_ROOT"; then
+        echo "Error: Failed to list Git worktrees." >&2
+        exit 1
+    fi
+
+    SHAPE_SELECTED=-1
+    SHAPE_SOURCE=worktree_root_fallback
+    if [ ! -L "$STATE_FILE" ] && [ -f "$STATE_FILE" ]; then
+        WORKTREE_PATH=""
+        if read_state_worktree_path "$STATE_FILE" && [ -n "$WORKTREE_PATH" ]; then
+            SHAPE_INDEX=0
+            while [ "$SHAPE_INDEX" -lt "${#SHAPE_FEATURE_PATHS[@]}" ]; do
+                if [ "$WORKTREE_PATH" = "${SHAPE_FEATURE_PATHS[$SHAPE_INDEX]}" ]; then
+                    SHAPE_SELECTED=$SHAPE_INDEX
+                    SHAPE_SOURCE=state_file
+                    break
+                fi
+                SHAPE_INDEX=$((SHAPE_INDEX + 1))
+            done
+        fi
+    fi
+    if [ "$SHAPE_SELECTED" -lt 0 ] && [ "${#SHAPE_FEATURE_PATHS[@]}" -gt 0 ]; then
+        SHAPE_SELECTED=0
+    fi
+    if [ "$SHAPE_SELECTED" -lt 0 ]; then
+        echo "Error: no Speckit worktree handoff has been recorded yet." >&2
+        exit 1
+    fi
+
+    SHAPE_SELECTED_DIR="${SHAPE_FEATURE_PATHS[$SHAPE_SELECTED]}"
+    SHAPE_SELECTED_BRANCH="${SHAPE_FEATURE_BRANCHES[$SHAPE_SELECTED]}"
+    shape_fill_emit_fields "$MAIN_REPO_ROOT" "$SHAPE_SELECTED_DIR" "$SHAPE_SELECTED_BRANCH"
+    emit_result "$SHAPE_SELECTED_BRANCH" "$SHAPE_SELECTED_DIR" "$BASE_BRANCH" \
+        "$MAIN_REPO_ROOT" "$SHAPE_SOURCE"
+    exit 0
+fi
+
 if ! capture_path resolve_worktree_root "$REPO_ROOT"; then
     echo "Error: Failed to list Git worktrees." >&2
     exit 1

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/git-common.sh
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/git-common.sh
@@ -1,7 +1,290 @@
 #!/usr/bin/env bash
+# speckit-overlay-shape: 1
 # Git-specific common functions for the git extension.
 # Extracted from scripts/bash/common.sh — contains Git-specific branch
 # validation, repository detection, and worktree discovery logic.
+
+# ---------------------------------------------------------------------------
+# Repository shape detection (single repository vs openRepoShape three-leg).
+#
+# load_repo_shape <root> sets, for its callers:
+#   REPO_SHAPE        single | three-leg
+#   PROJECT_ROOT      absolute path of the directory holding .specify/
+#   SHAPE_SPEC_PATH   relative mount path of the spec leg (empty when single)
+#   SHAPE_CODE_PATH   relative mount path of the code leg (empty when single)
+#   SPEC_LEG          absolute path of the spec leg checkout (root when single)
+#   CODE_LEG          absolute path of the code leg checkout (root when single)
+#   SHAPE_FAMILY      1 when a family holder was detected, else 0
+#
+# The manifest is read line by line with parameter expansion only: no YAML
+# library, no Python, no forks per line.
+# ---------------------------------------------------------------------------
+
+_shape_set_trimmed() {
+    _SHAPE_TRIMMED="$1"
+    _SHAPE_TRIMMED="${_SHAPE_TRIMMED#"${_SHAPE_TRIMMED%%[![:space:]]*}"}"
+    _SHAPE_TRIMMED="${_SHAPE_TRIMMED%"${_SHAPE_TRIMMED##*[![:space:]]}"}"
+}
+
+_shape_set_scalar() {
+    _shape_set_trimmed "$1"
+    _SHAPE_SCALAR="$_SHAPE_TRIMMED"
+    case "$_SHAPE_SCALAR" in
+        \"*\")
+            _SHAPE_SCALAR="${_SHAPE_SCALAR#\"}"
+            _SHAPE_SCALAR="${_SHAPE_SCALAR%\"}"
+            ;;
+        \'*\')
+            _SHAPE_SCALAR="${_SHAPE_SCALAR#\'}"
+            _SHAPE_SCALAR="${_SHAPE_SCALAR%\'}"
+            ;;
+    esac
+}
+
+_shape_record_leg() {
+    local role="$1"
+    local path="$2"
+
+    case "$role" in
+        spec) _SHAPE_LEG_SPEC_PATH="${path:-spec}" ;;
+        code) _SHAPE_LEG_CODE_PATH="${path:-code}" ;;
+    esac
+}
+
+_shape_is_family_holder() {
+    local family_manifest="$1"
+
+    [ -f "$family_manifest" ] || return 1
+    grep -Eq "^[[:space:]]*kind:[[:space:]]*[\"']?family-manifest[\"']?[[:space:]]*$" \
+        "$family_manifest"
+}
+
+# shellcheck disable=SC2034  # the shape variables are consumed by the callers
+load_repo_shape() {
+    local root="$1"
+    local manifest="$root/project.yaml"
+    local family_manifest="$root/family.yaml"
+    local raw content trimmed indent_ws indent key value rest
+    local manifest_kind="" manifest_schema=""
+    local in_legs=false key_col=-1
+    local cur_role="" cur_path=""
+
+    REPO_SHAPE="single"
+    PROJECT_ROOT="$root"
+    SHAPE_SPEC_PATH=""
+    SHAPE_CODE_PATH=""
+    SPEC_LEG="$root"
+    CODE_LEG="$root"
+    SHAPE_FAMILY=0
+    _SHAPE_LEG_SPEC_PATH=""
+    _SHAPE_LEG_CODE_PATH=""
+
+    if [ ! -f "$manifest" ]; then
+        if _shape_is_family_holder "$family_manifest"; then
+            SHAPE_FAMILY=1
+            echo "[specify] Family holder detected ($family_manifest); using the single-repository layout." >&2
+        fi
+        return 0
+    fi
+
+    while IFS= read -r raw || [ -n "$raw" ]; do
+        content="${raw%%#*}"
+        _shape_set_trimmed "$content"
+        trimmed="$_SHAPE_TRIMMED"
+        [ -n "$trimmed" ] || continue
+        indent_ws="${content%%[![:space:]]*}"
+        indent=${#indent_ws}
+
+        if [ "$in_legs" = true ]; then
+            if [ "$indent" -eq 0 ]; then
+                _shape_record_leg "$cur_role" "$cur_path"
+                cur_role=""
+                cur_path=""
+                in_legs=false
+            elif [ "${trimmed:0:2}" = "- " ] || [ "$trimmed" = "-" ]; then
+                _shape_record_leg "$cur_role" "$cur_path"
+                cur_role=""
+                cur_path=""
+                key_col=$((indent + 2))
+                _shape_set_trimmed "${trimmed#-}"
+                rest="$_SHAPE_TRIMMED"
+                key="${rest%%:*}"
+                if [ -n "$rest" ] && [ "$key" != "$rest" ]; then
+                    _shape_set_scalar "${rest#*:}"
+                    value="$_SHAPE_SCALAR"
+                    case "$key" in
+                        role) cur_role="$value" ;;
+                        path) cur_path="$value" ;;
+                    esac
+                fi
+                continue
+            elif [ "$indent" -eq "$key_col" ]; then
+                key="${trimmed%%:*}"
+                if [ "$key" != "$trimmed" ]; then
+                    _shape_set_scalar "${trimmed#*:}"
+                    value="$_SHAPE_SCALAR"
+                    case "$key" in
+                        role) cur_role="$value" ;;
+                        path) cur_path="$value" ;;
+                    esac
+                fi
+                continue
+            else
+                continue
+            fi
+        fi
+
+        if [ "$indent" -eq 0 ]; then
+            key="${trimmed%%:*}"
+            [ "$key" != "$trimmed" ] || continue
+            _shape_set_scalar "${trimmed#*:}"
+            value="$_SHAPE_SCALAR"
+            case "$key" in
+                kind) manifest_kind="$value" ;;
+                schema) manifest_schema="$value" ;;
+                legs)
+                    in_legs=true
+                    key_col=-1
+                    ;;
+            esac
+        fi
+    done < "$manifest"
+    _shape_record_leg "$cur_role" "$cur_path"
+
+    if [ "$manifest_kind" = "project-manifest" ] \
+        && [ "$manifest_schema" = "project-repo-schema" ] \
+        && [ -n "$_SHAPE_LEG_SPEC_PATH" ] \
+        && [ -n "$_SHAPE_LEG_CODE_PATH" ]; then
+        REPO_SHAPE="three-leg"
+        SHAPE_SPEC_PATH="$_SHAPE_LEG_SPEC_PATH"
+        SHAPE_CODE_PATH="$_SHAPE_LEG_CODE_PATH"
+        SPEC_LEG="$root/$SHAPE_SPEC_PATH"
+        CODE_LEG="$root/$SHAPE_CODE_PATH"
+    fi
+
+    return 0
+}
+
+# True when the leg mount point holds an initialised Git checkout. A submodule
+# that was never fetched is an empty directory, which is the case this guards.
+shape_leg_is_checkout() {
+    local leg="$1"
+
+    [ -d "$leg" ] || return 1
+    { [ -d "$leg/.git" ] || [ -f "$leg/.git" ]; } || return 1
+    command -v git >/dev/null 2>&1 || return 1
+    git -C "$leg" rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
+# ---------------------------------------------------------------------------
+# Three-leg feature discovery.
+#
+# shape_load_features <worktree_root> enumerates the spec leg's linked
+# worktrees and keeps the ones that sit at <worktree_root>/<feature>/<spec>/
+# with a sibling <code>/ worktree. The feature directory is the parent of the
+# spec worktree. Results are ordered newest first by feature directory mtime:
+#
+#   SHAPE_FEATURE_PATHS     feature directories
+#   SHAPE_FEATURE_BRANCHES  branch names, same index
+#   SHAPE_FEATURE_MTIMES    mtimes, same index
+#
+# Requires load_repo_shape to have run (SPEC_LEG / SHAPE_SPEC_PATH /
+# SHAPE_CODE_PATH) and load_git_worktrees from this file.
+# ---------------------------------------------------------------------------
+SHAPE_FEATURE_PATHS=()
+SHAPE_FEATURE_BRANCHES=()
+SHAPE_FEATURE_MTIMES=()
+
+_shape_mtime_for_path() {
+    if stat -c %Y "$1" >/dev/null 2>&1; then
+        stat -c %Y "$1"
+    else
+        stat -f %m "$1"
+    fi
+}
+
+shape_insert_feature() {
+    local path="$1"
+    local branch="$2"
+    local mtime="$3"
+    local count insert_at index previous_index
+
+    count=${#SHAPE_FEATURE_PATHS[@]}
+    insert_at=$count
+    index=0
+    while [ "$index" -lt "$count" ]; do
+        if [ "$mtime" -gt "${SHAPE_FEATURE_MTIMES[$index]}" ]; then
+            insert_at=$index
+            break
+        fi
+        index=$((index + 1))
+    done
+
+    SHAPE_FEATURE_PATHS+=("")
+    SHAPE_FEATURE_BRANCHES+=("")
+    SHAPE_FEATURE_MTIMES+=("")
+    index=$count
+    while [ "$index" -gt "$insert_at" ]; do
+        previous_index=$((index - 1))
+        SHAPE_FEATURE_PATHS[index]="${SHAPE_FEATURE_PATHS[previous_index]}"
+        SHAPE_FEATURE_BRANCHES[index]="${SHAPE_FEATURE_BRANCHES[previous_index]}"
+        SHAPE_FEATURE_MTIMES[index]="${SHAPE_FEATURE_MTIMES[previous_index]}"
+        index=$previous_index
+    done
+    SHAPE_FEATURE_PATHS[insert_at]="$path"
+    SHAPE_FEATURE_BRANCHES[insert_at]="$branch"
+    SHAPE_FEATURE_MTIMES[insert_at]="$mtime"
+}
+
+shape_load_features() {
+    local worktree_root="$1"
+    local index path branch feature_dir code_dir mtime
+
+    SHAPE_FEATURE_PATHS=()
+    SHAPE_FEATURE_BRANCHES=()
+    SHAPE_FEATURE_MTIMES=()
+    load_git_worktrees "$SPEC_LEG" || return 1
+    index=0
+    while [ "$index" -lt "${#GIT_WORKTREE_PATHS[@]}" ]; do
+        path="${GIT_WORKTREE_PATHS[$index]}"
+        branch="${GIT_WORKTREE_BRANCH_REFS[$index]}"
+        index=$((index + 1))
+        [ -n "$branch" ] || continue
+        [ -d "$path" ] || continue
+        case "$path" in
+            */"$SHAPE_SPEC_PATH") feature_dir="${path%/"$SHAPE_SPEC_PATH"}" ;;
+            *) continue ;;
+        esac
+        feature_dir="${feature_dir%/}"
+        case "$feature_dir" in
+            "$worktree_root"/*) ;;
+            *) continue ;;
+        esac
+        code_dir="$feature_dir/$SHAPE_CODE_PATH"
+        [ -d "$code_dir" ] || continue
+        mtime="$(_shape_mtime_for_path "$feature_dir" 2>/dev/null || true)"
+        [ -n "$mtime" ] || continue
+        shape_insert_feature "$feature_dir" "${branch#refs/heads/}" "$mtime"
+    done
+}
+
+# Derive the per-feature paths of a three-leg feature directory:
+#   SHAPE_SPEC_WORKTREE_PATH, SHAPE_CODE_WORKTREE_PATH,
+#   SHAPE_FEATURE_DIR, SHAPE_FEATURE_DIR_RELATIVE (relative to the root).
+# shellcheck disable=SC2034  # consumed by the scripts that source this file
+shape_feature_paths_for() {
+    local project_root="$1"
+    local feature_dir="$2"
+    local branch="$3"
+
+    SHAPE_SPEC_WORKTREE_PATH="$feature_dir/$SHAPE_SPEC_PATH"
+    SHAPE_CODE_WORKTREE_PATH="$feature_dir/$SHAPE_CODE_PATH"
+    SHAPE_FEATURE_DIR="$SHAPE_SPEC_WORKTREE_PATH/specs/$branch"
+    SHAPE_FEATURE_DIR_RELATIVE="$SHAPE_FEATURE_DIR"
+    case "$SHAPE_FEATURE_DIR" in
+        "$project_root"/*) SHAPE_FEATURE_DIR_RELATIVE="${SHAPE_FEATURE_DIR#"$project_root/"}" ;;
+    esac
+}
 
 # Check if we have git available at the repo root
 has_git() {

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/initialize-repo.sh
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/initialize-repo.sh
@@ -5,6 +5,7 @@
 # default branch config, git-flow, LFS, signing, etc.
 
 set -e
+# speckit-overlay-shape: 1
 
 SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -37,6 +38,23 @@ fi
 # Check if git is available
 if ! command -v git >/dev/null 2>&1; then
     echo "[specify] Warning: Git not found; skipped repository initialization" >&2
+    exit 0
+fi
+
+# In a three-leg project the assembly root is always already a repository, and
+# the legs are submodules that must never be re-initialised from here.
+REPO_SHAPE=single
+if [ -f "$SCRIPT_DIR/git-common.sh" ]; then
+    # shellcheck source=/dev/null
+    . "$SCRIPT_DIR/git-common.sh"
+    load_repo_shape "$REPO_ROOT"
+fi
+if [ "$REPO_SHAPE" = "three-leg" ]; then
+    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "[specify] Three-leg project root is already a Git repository; skipping" >&2
+    else
+        echo "[specify] Warning: three-leg project root is not a Git repository; skipped initialization" >&2
+    fi
     exit 0
 fi
 

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/shell/ct.zsh
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/shell/ct.zsh
@@ -1,7 +1,13 @@
+# speckit-overlay-shape: 1
 # Source this file from zsh to enable Speckit worktree helpers.
 #
 # Example:
 #   source .specify/shell/ct.zsh
+#
+# The helpers are shape-aware: in an openRepoShape three-leg project ct/cta/
+# ctc/ctg/cts start in the project root (the only place .specify/ exists) with
+# SPECIFY_FEATURE and SPECIFY_FEATURE_DIRECTORY exported, while the feature's
+# files live in worktrees/<NNN-feature>/<spec>/ and .../<code>/.
 
 _speckit_ct_dir="${${(%):-%x}:A:h}"
 source "$_speckit_ct_dir/worktrees.sh"

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/shell/select-worktree.sh
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/shell/select-worktree.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+# speckit-overlay-shape: 1
 
 capture_path() {
     local frame='__SPECKIT_PATH_CAPTURE_FRAME_7D3A9C__'
@@ -326,40 +327,96 @@ if [ "${1:-}" = "--path" ]; then
     MODE="path"
 elif [ "${1:-}" = "--list" ]; then
     MODE="list"
+elif [ "${1:-}" = "--env" ]; then
+    MODE="env"
 elif [ $# -gt 0 ]; then
-    echo "Usage: $0 [--path|--list]" >&2
+    echo "Usage: $0 [--path|--list|--env]" >&2
     exit 1
 fi
 
 capture_path resolve_main_repo_root "$REPO_ROOT"
 MAIN_REPO_ROOT="$CAPTURED_PATH"
-if ! capture_path resolve_worktree_root "$REPO_ROOT"; then
-    echo "Error: Failed to list Git worktrees." >&2
-    exit 1
-fi
-WORKTREE_ROOT="$CAPTURED_PATH"
-if [ ! -d "$WORKTREE_ROOT" ]; then
-    echo "No Speckit worktree root found at: $WORKTREE_ROOT" >&2
-    exit 1
-fi
+load_repo_shape "$MAIN_REPO_ROOT"
 
 PATHS=()
 BRANCHES=()
-if ! load_registered_worktrees_by_mtime "$WORKTREE_ROOT" "$MAIN_REPO_ROOT"; then
-    echo "Error: Failed to list Git worktrees." >&2
-    exit 1
+if [ "$REPO_SHAPE" = "three-leg" ]; then
+    if ! shape_leg_is_checkout "$SPEC_LEG"; then
+        echo "Error: the spec leg '$SHAPE_SPEC_PATH' is not an initialised Git checkout at '$SPEC_LEG'." >&2
+        echo "Run 'git submodule update --init' (or 'make bootstrap') in the project root first." >&2
+        exit 1
+    fi
+    SHAPE_WORKTREE_ROOT_RAW=$(resolve_config_value "$MAIN_REPO_ROOT" "worktree_root" "worktrees")
+    if ! capture_path resolve_path_from_root "$MAIN_REPO_ROOT" "$SHAPE_WORKTREE_ROOT_RAW"; then
+        echo "Error: Failed to resolve the Speckit worktree root." >&2
+        exit 1
+    fi
+    WORKTREE_ROOT="$CAPTURED_PATH"
+    if [ ! -d "$WORKTREE_ROOT" ]; then
+        echo "No Speckit worktree root found at: $WORKTREE_ROOT" >&2
+        exit 1
+    fi
+    if ! shape_load_features "$WORKTREE_ROOT"; then
+        echo "Error: Failed to list Git worktrees." >&2
+        exit 1
+    fi
+    if [ "${#SHAPE_FEATURE_PATHS[@]}" -eq 0 ]; then
+        echo "No Speckit worktrees found under: $WORKTREE_ROOT" >&2
+        exit 1
+    fi
+    PATHS=("${SHAPE_FEATURE_PATHS[@]}")
+    BRANCHES=("${SHAPE_FEATURE_BRANCHES[@]}")
+else
+    if ! capture_path resolve_worktree_root "$REPO_ROOT"; then
+        echo "Error: Failed to list Git worktrees." >&2
+        exit 1
+    fi
+    WORKTREE_ROOT="$CAPTURED_PATH"
+    if [ ! -d "$WORKTREE_ROOT" ]; then
+        echo "No Speckit worktree root found at: $WORKTREE_ROOT" >&2
+        exit 1
+    fi
+
+    if ! load_registered_worktrees_by_mtime "$WORKTREE_ROOT" "$MAIN_REPO_ROOT"; then
+        echo "Error: Failed to list Git worktrees." >&2
+        exit 1
+    fi
+    if [ "${#REGISTERED_WORKTREE_PATHS[@]}" -eq 0 ]; then
+        echo "No Speckit worktrees found under: $WORKTREE_ROOT" >&2
+        exit 1
+    fi
+    PATHS=("${REGISTERED_WORKTREE_PATHS[@]}")
+    BRANCHES=("${REGISTERED_WORKTREE_BRANCHES[@]}")
 fi
-if [ "${#REGISTERED_WORKTREE_PATHS[@]}" -eq 0 ]; then
-    echo "No Speckit worktrees found under: $WORKTREE_ROOT" >&2
-    exit 1
-fi
-PATHS=("${REGISTERED_WORKTREE_PATHS[@]}")
-BRANCHES=("${REGISTERED_WORKTREE_BRANCHES[@]}")
 
 if [ "${#PATHS[@]}" -eq 0 ]; then
     echo "No usable Speckit worktrees found under: $WORKTREE_ROOT" >&2
     exit 1
 fi
+
+# In --env mode the selection is emitted as shell assignments so the ct-family
+# launchers can jump to the right place without a JSON parser.
+emit_selection() {
+    local index="$1"
+
+    if [ "$MODE" != "env" ]; then
+        printf '%s\n' "${PATHS[$index]}"
+        return 0
+    fi
+
+    printf 'REPO_SHAPE=%q\n' "$REPO_SHAPE"
+    printf 'PROJECT_ROOT=%q\n' "$MAIN_REPO_ROOT"
+    printf 'BRANCH_NAME=%q\n' "${BRANCHES[$index]}"
+    printf 'WORKTREE_PATH=%q\n' "${PATHS[$index]}"
+    if [ "$REPO_SHAPE" = "three-leg" ]; then
+        shape_feature_paths_for "$MAIN_REPO_ROOT" "${PATHS[$index]}" "${BRANCHES[$index]}"
+        printf 'SPEC_WORKTREE_PATH=%q\n' "$SHAPE_SPEC_WORKTREE_PATH"
+        printf 'CODE_WORKTREE_PATH=%q\n' "$SHAPE_CODE_WORKTREE_PATH"
+        printf 'FEATURE_DIR=%q\n' "$SHAPE_FEATURE_DIR"
+        printf 'SPECIFY_FEATURE=%q\n' "${BRANCHES[$index]}"
+        printf 'SPECIFY_FEATURE_DIRECTORY=%q\n' "$SHAPE_FEATURE_DIR_RELATIVE"
+    fi
+}
 
 if [ "$MODE" = "list" ]; then
     for i in "${!PATHS[@]}"; do
@@ -374,8 +431,8 @@ if [ "$MODE" = "list" ]; then
     exit 0
 fi
 
-if [ "$MODE" = "path" ] && ! [ -t 0 ]; then
-    printf '%s\n' "${PATHS[0]}"
+if { [ "$MODE" = "path" ] || [ "$MODE" = "env" ]; } && ! [ -t 0 ]; then
+    emit_selection 0
     exit 0
 fi
 
@@ -408,7 +465,7 @@ while true; do
     esac
 
     if [[ "$selection" =~ ^[0-9]+$ ]] && [ "$selection" -ge 1 ] && [ "$selection" -le "${#PATHS[@]}" ]; then
-        printf '%s\n' "${PATHS[$((selection - 1))]}"
+        emit_selection "$((selection - 1))"
         exit 0
     fi
 

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/shell/worktrees.sh
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/shell/worktrees.sh
@@ -1,3 +1,4 @@
+# speckit-overlay-shape: 1
 # Source this file from bash or zsh to enable Speckit worktree helpers.
 #
 # NOTE: In devBench containers, prefer the globally sourced ct helpers from
@@ -142,12 +143,86 @@ _speckit_worktree_select_worktree() {
   printf '%s\n' "$target"
 }
 
+# Load a handoff into _SPECKIT_WT_* variables. A shape-aware helper answers
+# `--env` with `KEY=value` assignments; an older or stubbed helper prints only
+# the worktree path, which is still accepted verbatim (byte-exact, including
+# any trailing newlines in the path).
+_speckit_worktree_load_env() {
+  local output _SPECKIT_WORKTREE_CAPTURED_PATH
+
+  _SPECKIT_WT_REPO_SHAPE=single
+  _SPECKIT_WT_PROJECT_ROOT=""
+  _SPECKIT_WT_BRANCH_NAME=""
+  _SPECKIT_WT_WORKTREE_PATH=""
+  _SPECKIT_WT_SPEC_WORKTREE_PATH=""
+  _SPECKIT_WT_CODE_WORKTREE_PATH=""
+  _SPECKIT_WT_FEATURE_DIR=""
+  _SPECKIT_WT_SPECIFY_FEATURE=""
+  _SPECKIT_WT_SPECIFY_FEATURE_DIRECTORY=""
+  _SPECKIT_WT_TARGET=""
+
+  _speckit_worktree_capture_path "$@" || return 1
+  output="$_SPECKIT_WORKTREE_CAPTURED_PATH"
+  [ -n "$output" ] || return 1
+
+  case "$output" in
+    REPO_SHAPE=*)
+      eval "$(printf '%s\n' "$output" | sed 's/^/_SPECKIT_WT_/')" || return 1
+      ;;
+    *)
+      _SPECKIT_WT_WORKTREE_PATH="$output"
+      ;;
+  esac
+}
+
+_speckit_worktree_select_env() {
+  if [ ! -f "$SPECKIT_WORKTREE_SELECT_WORKTREE_SCRIPT" ]; then
+    echo "worktree selector not found: $SPECKIT_WORKTREE_SELECT_WORKTREE_SCRIPT" >&2
+    return 1
+  fi
+
+  if ! _speckit_worktree_load_env bash "$SPECKIT_WORKTREE_SELECT_WORKTREE_SCRIPT" --env; then
+    _speckit_worktree_load_env bash "$SPECKIT_WORKTREE_SELECT_WORKTREE_SCRIPT" --path || return 1
+  fi
+  if [ -z "$_SPECKIT_WT_WORKTREE_PATH" ]; then
+    echo "no Speckit worktree selected" >&2
+    return 1
+  fi
+}
+
+# Where a CLI session should start: the project root in a three-leg project
+# (the only place .specify/ exists), the feature worktree otherwise. Assigns
+# rather than echoes so paths keep their exact bytes.
+_speckit_worktree_set_target() {
+  if [ "${_SPECKIT_WT_REPO_SHAPE:-single}" = "three-leg" ]; then
+    _SPECKIT_WT_TARGET="$_SPECKIT_WT_PROJECT_ROOT"
+  else
+    _SPECKIT_WT_TARGET="$_SPECKIT_WT_WORKTREE_PATH"
+  fi
+}
+
+_speckit_worktree_report_three_leg() {
+  local label="$1"
+
+  printf '%s: three-leg project; starting in %s\n' "$label" "$_SPECKIT_WT_PROJECT_ROOT" >&2
+  printf '%s: SPECIFY_FEATURE=%s\n' "$label" "$_SPECKIT_WT_SPECIFY_FEATURE" >&2
+  printf '%s: SPECIFY_FEATURE_DIRECTORY=%s\n' "$label" "$_SPECKIT_WT_SPECIFY_FEATURE_DIRECTORY" >&2
+  printf '%s: spec worktree %s\n' "$label" "$_SPECKIT_WT_SPEC_WORKTREE_PATH" >&2
+  printf '%s: code worktree %s\n' "$label" "$_SPECKIT_WT_CODE_WORKTREE_PATH" >&2
+}
+
 _speckit_worktree_start_cli() {
   local cli_command="$1"
   local target="$2"
   shift 2 || true
 
   cd "$target" || return 1
+  if [ -n "${_SPECKIT_WT_SPECIFY_FEATURE:-}" ]; then
+    env SPECIFY_FEATURE="$_SPECKIT_WT_SPECIFY_FEATURE" \
+      SPECIFY_FEATURE_DIRECTORY="$_SPECKIT_WT_SPECIFY_FEATURE_DIRECTORY" \
+      "$cli_command" "$@"
+    return $?
+  fi
   "$cli_command" "$@"
 }
 
@@ -181,15 +256,27 @@ _speckit_worktree_start_gemini() {
 }
 
 ct() {
-  local target _SPECKIT_WORKTREE_CAPTURED_PATH
+  local target
 
   if [ ! -f "$SPECKIT_WORKTREE_LAST_WORKTREE_SCRIPT" ]; then
     echo "ct: helper script not found: $SPECKIT_WORKTREE_LAST_WORKTREE_SCRIPT" >&2
     return 1
   fi
 
-  _speckit_worktree_capture_path bash "$SPECKIT_WORKTREE_LAST_WORKTREE_SCRIPT" || return 1
-  target="$_SPECKIT_WORKTREE_CAPTURED_PATH"
+  if ! _speckit_worktree_load_env bash "$SPECKIT_WORKTREE_LAST_WORKTREE_SCRIPT" --env; then
+    _speckit_worktree_load_env bash "$SPECKIT_WORKTREE_LAST_WORKTREE_SCRIPT" || return 1
+  fi
+
+  if [ "$_SPECKIT_WT_REPO_SHAPE" = "three-leg" ]; then
+    # The project root is the only place .specify/ exists, so Speckit commands
+    # run from there with the feature selected; the files live in the worktrees.
+    _speckit_worktree_report_three_leg ct
+    export SPECIFY_FEATURE="$_SPECKIT_WT_SPECIFY_FEATURE"
+    export SPECIFY_FEATURE_DIRECTORY="$_SPECKIT_WT_SPECIFY_FEATURE_DIRECTORY"
+  fi
+
+  _speckit_worktree_set_target
+  target="$_SPECKIT_WT_TARGET"
   if [ -z "$target" ]; then
     echo "ct: no Speckit worktree path returned" >&2
     return 1
@@ -208,51 +295,66 @@ ctp() {
 }
 
 cta() {
-  local target _SPECKIT_WORKTREE_CAPTURED_PATH
+  local target
 
   if ! command -v claude >/dev/null 2>&1; then
     echo "cta: Claude CLI not found on PATH" >&2
     return 1
   fi
 
-  _speckit_worktree_capture_path _speckit_worktree_select_worktree || return 1
-  target="$_SPECKIT_WORKTREE_CAPTURED_PATH"
+  _speckit_worktree_select_env || return 1
+  if [ "$_SPECKIT_WT_REPO_SHAPE" = "three-leg" ]; then
+    _speckit_worktree_report_three_leg cta
+  fi
+  _speckit_worktree_set_target
+  target="$_SPECKIT_WT_TARGET"
   _speckit_worktree_start_claude "$target" "$@"
 }
 
 ctc() {
-  local target _SPECKIT_WORKTREE_CAPTURED_PATH
+  local target
 
   if ! command -v codex >/dev/null 2>&1; then
     echo "ctc: Codex CLI not found on PATH" >&2
     return 1
   fi
 
-  _speckit_worktree_capture_path _speckit_worktree_select_worktree || return 1
-  target="$_SPECKIT_WORKTREE_CAPTURED_PATH"
+  _speckit_worktree_select_env || return 1
+  if [ "$_SPECKIT_WT_REPO_SHAPE" = "three-leg" ]; then
+    _speckit_worktree_report_three_leg ctc
+  fi
+  _speckit_worktree_set_target
+  target="$_SPECKIT_WT_TARGET"
   _speckit_worktree_start_codex "$target" "$@"
 }
 
 ctg() {
-  local target _SPECKIT_WORKTREE_CAPTURED_PATH
+  local target
 
   if ! command -v gemini >/dev/null 2>&1; then
     echo "ctg: Gemini CLI not found on PATH" >&2
     return 1
   fi
 
-  _speckit_worktree_capture_path _speckit_worktree_select_worktree || return 1
-  target="$_SPECKIT_WORKTREE_CAPTURED_PATH"
+  _speckit_worktree_select_env || return 1
+  if [ "$_SPECKIT_WT_REPO_SHAPE" = "three-leg" ]; then
+    _speckit_worktree_report_three_leg ctg
+  fi
+  _speckit_worktree_set_target
+  target="$_SPECKIT_WT_TARGET"
   _speckit_worktree_start_gemini "$target" "$@"
 }
 
 cts() {
   local target
   local cli_command
-  local _SPECKIT_WORKTREE_CAPTURED_PATH
 
-  _speckit_worktree_capture_path _speckit_worktree_select_worktree || return 1
-  target="$_SPECKIT_WORKTREE_CAPTURED_PATH"
+  _speckit_worktree_select_env || return 1
+  if [ "$_SPECKIT_WT_REPO_SHAPE" = "three-leg" ]; then
+    _speckit_worktree_report_three_leg cts
+  fi
+  _speckit_worktree_set_target
+  target="$_SPECKIT_WT_TARGET"
   cli_command=$(_speckit_worktree_prompt_cli) || return 1
   case "$cli_command" in
     claude)

--- a/devBenches/devcontainer.test/test-openspeckit-bootstrap.sh
+++ b/devBenches/devcontainer.test/test-openspeckit-bootstrap.sh
@@ -372,6 +372,7 @@ if HOME="$CANONICAL_ALIAS_HOME" \
         --no-repo-agent-pointers \
         --preserve-readmes \
         --no-skill-links \
+        --no-skill-shape-blocks \
         > "$TMPDIR_ROOT/canonical-alias.log" 2>&1; then
     pass 'compatibility alias reaches canonical setup-openspeckit'
 else
@@ -551,6 +552,7 @@ BOOTSTRAP_FLAGS=(
     --skip-init
     --no-speckit-registration
     --no-global-agent-pointers
+    --no-skill-shape-blocks
 )
 
 if ! python3 "$SETUP_SCRIPT" "${BOOTSTRAP_FLAGS[@]}" > "$FIRST_LOG" 2>&1; then
@@ -605,7 +607,7 @@ assert_contains "$WORKFLOW_PROTOCOL" 'git status -sb' 'workflow protocol checks 
 assert_contains "$WORKFLOW_PROTOCOL" 'git branch --show-current' 'workflow protocol checks the root checkout branch before specify'
 assert_contains "$WORKFLOW_PROTOCOL" 'NNN-feature-name' 'workflow protocol reserves canonical feature creation for Speckit'
 assert_file "$BOOTSTRAP_PROTOCOL" 'generated bootstrap protocol exists'
-assert_contains "$BOOTSTRAP_PROTOCOL" 'copied directories' 'bootstrap protocol describes copied skill directories'
+assert_contains "$BOOTSTRAP_PROTOCOL" '`.claude/skills`, `.codex/skills`, and `.agents/skills`' 'bootstrap protocol describes the repo-local skill homes'
 assert_not_contains "$BOOTSTRAP_PROTOCOL" 'skills links' 'bootstrap protocol does not describe repo-local skills as links'
 assert_file "$EXPLORE_COMMAND" 'generated explore command exists'
 if [[ -f "$EXPLORE_COMMAND" ]] && grep -Eiq 'executable work.{0,80}exclusively.{0,80}specs/<feature>/tasks\.md' "$EXPLORE_COMMAND"; then
@@ -1445,6 +1447,7 @@ if env -u OPSX_COMMAND_TEMPLATE_ROOT \
         --no-worktrees \
         --no-repo-agent-pointers \
         --no-skill-links \
+        --no-skill-shape-blocks \
         --no-global-agent-pointers \
         --preserve-readmes > "$TMPDIR_ROOT/opsx-precedence.log" 2>&1; then
     pass 'bootstrap resolves a default OPSX command source'
@@ -1474,6 +1477,7 @@ if HOME="$OPSX_PRECEDENCE_HOME" \
         --no-worktrees \
         --no-repo-agent-pointers \
         --no-skill-links \
+        --no-skill-shape-blocks \
         --no-global-agent-pointers \
         --preserve-readmes > "$TMPDIR_ROOT/opsx-empty-env.log" 2>&1; then
     pass 'empty OPSX override is treated as unset'
@@ -2625,6 +2629,7 @@ if ! python3 "$SETUP_SCRIPT" \
     --skip-init \
     --no-speckit-registration \
     --no-global-agent-pointers \
+    --no-skill-shape-blocks \
     --force > "$TMPDIR_ROOT/incomplete-overlay.log" 2>&1; then
     printf '%s\n' 'FAIL: incomplete-overlay bootstrap invocation failed:'
     cat "$TMPDIR_ROOT/incomplete-overlay.log"
@@ -2770,6 +2775,916 @@ if cmp -s "$DRY_RUN_PROTOCOL_MODES_BEFORE" "$DRY_RUN_PROTOCOL_MODES_AFTER"; then
 else
     fail '--dry-run changes protocol-root path types, symlinks, or modes'
 fi
+
+printf '%s\n' 'Given: manifest fixtures covering three-leg, default paths, family holders, and non-manifests'
+if python3 - "$SETUP_SCRIPT" "$TMPDIR_ROOT/manifest-parsing" <<'PY'
+from pathlib import Path
+import runpy
+import sys
+
+namespace = runpy.run_path(sys.argv[1], run_name="setup_openspeckit_test")
+detect_project_shape = namespace["detect_project_shape"]
+is_family_holder = namespace["is_family_holder"]
+fixture_root = Path(sys.argv[2])
+fixture_root.mkdir()
+failures = 0
+
+
+def check(condition, label):
+    global failures
+    if condition:
+        print(f"PASS: {label}")
+    else:
+        print(f"FAIL: {label}")
+        failures += 1
+
+
+def make_repo(name, files):
+    repo = fixture_root / name
+    repo.mkdir()
+    for relative_name, content in files.items():
+        (repo / relative_name).write_text(content, encoding="utf-8")
+    return repo
+
+
+QUOTED_MANIFEST = """schema_version: 1
+kind: project-manifest   # the manifest kind
+schema: project-repo-schema
+legs:
+  - role: assembly
+    repository: fixture/Fixture
+    path: "."
+  - role: spec
+    repository: fixture/Fixture-spec
+    path: 'spec tree'      # quoted, with a trailing comment
+    naming:
+      form: project-leg
+      role: assembly
+  - role: code
+    repository: fixture/Fixture-code
+    path: "impl"
+contracts: []
+"""
+
+DEFAULT_PATH_MANIFEST = """kind: project-manifest
+schema: project-repo-schema
+legs:
+  - role: assembly
+    path: "."
+  - role: spec
+  - role: code
+"""
+
+TRAILING_LEGS_MANIFEST = """kind: project-manifest
+schema: project-repo-schema
+legs:
+  - role: spec
+    path: spec
+  - role: code
+    path: code
+other:
+  - role: spec
+    path: decoy
+"""
+
+quoted = make_repo("quoted", {"project.yaml": QUOTED_MANIFEST})
+shape = detect_project_shape(quoted)
+check(shape is not None, "manifest: quoted three-leg manifest is detected")
+if shape is not None:
+    check(shape.spec_path == "spec tree", "manifest: quoted spec path is unquoted")
+    check(shape.code_path == "impl", "manifest: quoted code path is unquoted")
+    check(shape.spec_leg == quoted / "spec tree", "manifest: spec leg resolves under the root")
+    check(shape.code_leg == quoted / "impl", "manifest: code leg resolves under the root")
+
+defaults = make_repo("defaults", {"project.yaml": DEFAULT_PATH_MANIFEST})
+shape = detect_project_shape(defaults)
+check(shape is not None, "manifest: legs without path: are detected")
+if shape is not None:
+    check(
+        (shape.spec_path, shape.code_path) == ("spec", "code"),
+        "manifest: missing leg paths fall back to spec and code",
+    )
+
+trailing = make_repo("trailing", {"project.yaml": TRAILING_LEGS_MANIFEST})
+shape = detect_project_shape(trailing)
+check(
+    shape is not None and shape.spec_path == "spec",
+    "manifest: a later column-0 key ends the legs list",
+)
+
+wrong_kind = make_repo(
+    "wrong-kind",
+    {"project.yaml": "kind: something-else\nschema: project-repo-schema\nlegs:\n  - role: spec\n"},
+)
+check(detect_project_shape(wrong_kind) is None, "manifest: a non-project kind is a single repository")
+
+wrong_schema = make_repo(
+    "wrong-schema",
+    {"project.yaml": "kind: project-manifest\nschema: other\nlegs:\n  - role: spec\n  - role: code\n"},
+)
+check(detect_project_shape(wrong_schema) is None, "manifest: a foreign schema is a single repository")
+
+missing_code = make_repo(
+    "missing-code",
+    {"project.yaml": "kind: project-manifest\nschema: project-repo-schema\nlegs:\n  - role: spec\n"},
+)
+check(detect_project_shape(missing_code) is None, "manifest: a manifest without a code leg is a single repository")
+
+plain = make_repo("plain", {"README.md": "no manifest\n"})
+check(detect_project_shape(plain) is None, "manifest: a repository without project.yaml is a single repository")
+check(not is_family_holder(plain), "manifest: a repository without family.yaml is not a family holder")
+
+family = make_repo(
+    "family",
+    {"family.yaml": "schema_version: 1\nkind: family-manifest\nid: fixture-family\n"},
+)
+check(is_family_holder(family), "manifest: family.yaml with kind family-manifest is a family holder")
+check(detect_project_shape(family) is None, "manifest: a family holder has no three-leg shape")
+
+family_with_project = make_repo(
+    "family-with-project",
+    {
+        "family.yaml": "kind: family-manifest\n",
+        "project.yaml": "kind: project-manifest\nschema: project-repo-schema\nlegs:\n  - role: spec\n  - role: code\n",
+    },
+)
+check(
+    not is_family_holder(family_with_project),
+    "manifest: a project.yaml beside family.yaml is not a family holder",
+)
+
+escaping = make_repo(
+    "escaping",
+    {
+        "project.yaml": "kind: project-manifest\nschema: project-repo-schema\n"
+        "legs:\n  - role: spec\n    path: ../outside\n  - role: code\n    path: code\n"
+    },
+)
+try:
+    detect_project_shape(escaping)
+except SystemExit:
+    print("PASS: manifest: a leg path escaping the root is refused")
+else:
+    print("FAIL: manifest: a leg path escaping the root is refused")
+    failures += 1
+
+raise SystemExit(1 if failures else 0)
+PY
+then
+    pass 'manifest parsing detects three-leg projects, defaults, and family holders'
+else
+    fail 'manifest parsing detects three-leg projects, defaults, and family holders'
+fi
+
+git_fixture() {
+    git \
+        -c user.name='Bootstrap Test' \
+        -c user.email='bootstrap-test@example.invalid' \
+        -c protocol.file.allow=always \
+        "$@"
+}
+
+make_leg_origin() {
+    local path="$1"
+    local label="$2"
+    mkdir -p "$path"
+    git init -q -b main "$path"
+    printf '%s\n' "$label leg fixture" > "$path/README.md"
+    git_fixture -C "$path" add README.md
+    git_fixture -C "$path" commit -q -m "initial $label"
+}
+
+write_project_manifest() {
+    local root="$1"
+    cat > "$root/project.yaml" <<'EOF'
+schema_version: 1
+kind: project-manifest
+
+# The three legs. `assembly` is THIS repository and its path is `.`;
+# `spec` and `code` are submodules mounted at the paths below.
+id: fixture
+name: "Fixture Project"
+schema: project-repo-schema
+reference: "fixture reference"
+elected_by: "fixture"
+elected_on: 2026-09-08
+topic: xf-project-fixture
+visibility: private
+tracking_branch: main
+neutral_product_pins: []
+
+legs:
+  - role: assembly
+    repository: fixture/Fixture
+    path: "."
+    naming:
+      form: project-leg
+      role: assembly
+      also_matches: []
+  - role: spec
+    repository: fixture/Fixture-spec
+    path: spec        # the spec leg mount point
+    naming:
+      form: project-leg
+      role: spec
+      also_matches: []
+  - role: code
+    repository: fixture/Fixture-code
+    path: "code"
+    naming:
+      form: project-leg
+      role: code
+      also_matches: []
+
+contracts: []
+EOF
+}
+
+seed_speckit_state() {
+    local root="$1"
+    mkdir -p "$root/.specify/templates"
+    printf '%s\n' '{"integration":"claude"}' > "$root/.specify/integration.json"
+    printf '%s\n' '{"integration":"claude"}' > "$root/.specify/init-options.json"
+    printf '%s\n' '# Spec template' > "$root/.specify/templates/spec-template.md"
+}
+
+make_three_leg_root() {
+    local root="$1"
+    mkdir -p "$root"
+    git init -q -b main "$root"
+    git_fixture -C "$root" submodule add -q "$THREE_LEG_SPEC_ORIGIN" spec > /dev/null 2>&1
+    git_fixture -C "$root" submodule add -q "$THREE_LEG_CODE_ORIGIN" code > /dev/null 2>&1
+    write_project_manifest "$root"
+    seed_speckit_state "$root"
+}
+
+THREE_LEG_HOME="$TMPDIR_ROOT/three-leg-home"
+THREE_LEG_PROTOCOL_ROOT="$TMPDIR_ROOT/three-leg-protocol"
+THREE_LEG_SPEC_ORIGIN="$TMPDIR_ROOT/three-leg-origins/spec"
+THREE_LEG_CODE_ORIGIN="$TMPDIR_ROOT/three-leg-origins/code"
+THREE_LEG_OPSX_TEMPLATES="$TMPDIR_ROOT/three-leg-opsx-templates"
+THREE_LEG_ROOT="$TMPDIR_ROOT/three-leg-root"
+mkdir -p "$THREE_LEG_HOME" "$THREE_LEG_OPSX_TEMPLATES"
+cat > "$THREE_LEG_OPSX_TEMPLATES/apply.md" <<'EOF'
+---
+name: opsx-apply
+---
+
+Fixture OPSX apply command.
+EOF
+make_leg_origin "$THREE_LEG_SPEC_ORIGIN" spec
+make_leg_origin "$THREE_LEG_CODE_ORIGIN" code
+make_three_leg_root "$THREE_LEG_ROOT"
+
+if [[ -f "$THREE_LEG_ROOT/spec/README.md" && -e "$THREE_LEG_ROOT/spec/.git" ]]; then
+    pass 'Given three-leg fixture mounts a real spec submodule'
+else
+    fail 'Given three-leg fixture mounts a real spec submodule'
+fi
+if [[ -f "$THREE_LEG_ROOT/code/README.md" && -e "$THREE_LEG_ROOT/code/.git" ]]; then
+    pass 'Given three-leg fixture mounts a real code submodule'
+else
+    fail 'Given three-leg fixture mounts a real code submodule'
+fi
+
+THREE_LEG_FLAGS=(
+    --no-speckit-registration
+    --no-skill-links
+    --no-global-agent-pointers
+)
+
+printf '%s\n' 'When: bootstrap runs with --dry-run against the three-leg root'
+export HOME="$THREE_LEG_HOME"
+export AGENT_PROTOCOL_ROOT="$THREE_LEG_PROTOCOL_ROOT"
+export SPECKIT_WORKTREE_TEMPLATE_ROOT="$WORKTREE_TEMPLATE_ROOT"
+export OPSX_COMMAND_TEMPLATE_ROOT="$THREE_LEG_OPSX_TEMPLATES"
+THREE_LEG_DRY_RUN_LOG="$TMPDIR_ROOT/three-leg-dry-run.log"
+THREE_LEG_DRY_BEFORE="$TMPDIR_ROOT/three-leg-dry.before"
+THREE_LEG_DRY_AFTER="$TMPDIR_ROOT/three-leg-dry.after"
+snapshot_repo "$THREE_LEG_ROOT" > "$THREE_LEG_DRY_BEFORE"
+if ! python3 "$SETUP_SCRIPT" --repo "$THREE_LEG_ROOT" --dry-run "${THREE_LEG_FLAGS[@]}" \
+    > "$THREE_LEG_DRY_RUN_LOG" 2>&1; then
+    printf '%s\n' 'FAIL: three-leg dry-run bootstrap invocation failed:'
+    cat "$THREE_LEG_DRY_RUN_LOG"
+    exit 1
+fi
+
+printf '%s\n' 'Then: the dry run announces the shape, splits its log, and writes nothing'
+snapshot_repo "$THREE_LEG_ROOT" > "$THREE_LEG_DRY_AFTER"
+assert_contains "$THREE_LEG_DRY_RUN_LOG" 'shape: openRepoShape three-leg' 'three-leg dry run reports the detected shape'
+assert_contains "$THREE_LEG_DRY_RUN_LOG" "[spec] would write $THREE_LEG_ROOT/spec/openspec/config.yaml" 'three-leg dry run plans the OpenSpec config in the spec leg'
+assert_contains "$THREE_LEG_DRY_RUN_LOG" "[spec] would create directory $THREE_LEG_ROOT/spec/openspec/specs" 'three-leg dry run plans the OpenSpec specs directory in the spec leg'
+assert_contains "$THREE_LEG_DRY_RUN_LOG" "[root] would write $THREE_LEG_ROOT/.gitignore" 'three-leg dry run plans the root gitignore'
+assert_contains "$THREE_LEG_DRY_RUN_LOG" "[root] would write $THREE_LEG_ROOT/AGENTS.md" 'three-leg dry run plans the root agent pointer'
+assert_not_contains "$THREE_LEG_DRY_RUN_LOG" "[spec] would write $THREE_LEG_ROOT/AGENTS.md" 'three-leg dry run keeps root writes out of the spec prefix'
+assert_not_contains "$THREE_LEG_DRY_RUN_LOG" "$THREE_LEG_ROOT/code/openspec" 'three-leg dry run plans nothing in the code leg'
+if cmp -s "$THREE_LEG_DRY_BEFORE" "$THREE_LEG_DRY_AFTER"; then
+    pass 'three-leg dry run leaves the root byte-for-byte unchanged'
+else
+    fail 'three-leg dry run changes the root'
+fi
+
+printf '%s\n' 'When: bootstrap runs for real against the three-leg root'
+THREE_LEG_LOG="$TMPDIR_ROOT/three-leg.log"
+if ! python3 "$SETUP_SCRIPT" --repo "$THREE_LEG_ROOT" "${THREE_LEG_FLAGS[@]}" \
+    > "$THREE_LEG_LOG" 2>&1; then
+    printf '%s\n' 'FAIL: three-leg bootstrap invocation failed:'
+    cat "$THREE_LEG_LOG"
+    exit 1
+fi
+
+printf '%s\n' 'Then: OpenSpec scaffolding lands in the spec leg and everything else in the root'
+assert_file "$THREE_LEG_ROOT/spec/openspec/config.yaml" 'three-leg OpenSpec config lands in the spec leg'
+assert_file "$THREE_LEG_ROOT/spec/openspec/changes/archive/.gitkeep" 'three-leg archive keepfile lands in the spec leg'
+assert_file "$THREE_LEG_ROOT/spec/openspec/specs/.gitkeep" 'three-leg specs keepfile lands in the spec leg'
+assert_file "$THREE_LEG_ROOT/spec/openspec/README.md" 'three-leg OpenSpec README lands in the spec leg'
+assert_contains "$THREE_LEG_ROOT/spec/openspec/README.md" '${AGENT_PROTOCOL_ROOT:-$HOME/.agents}' 'three-leg OpenSpec README keeps the portable protocol root'
+assert_not_exists "$THREE_LEG_ROOT/openspec" 'three-leg root receives no OpenSpec directory'
+assert_regular_directory "$THREE_LEG_ROOT/.specify" 'three-leg Speckit scaffolding stays in the root'
+assert_file "$THREE_LEG_ROOT/.specify/README.md" 'three-leg Speckit README stays in the root'
+assert_file "$THREE_LEG_ROOT/AGENTS.md" 'three-leg agent pointer stays in the root'
+assert_not_exists "$THREE_LEG_ROOT/spec/AGENTS.md" 'three-leg spec leg receives no agent pointer'
+assert_not_exists "$THREE_LEG_ROOT/code/openspec" 'three-leg code leg receives no OpenSpec directory'
+assert_not_exists "$THREE_LEG_ROOT/code/.specify" 'three-leg code leg receives no Speckit scaffolding'
+assert_not_exists "$THREE_LEG_ROOT/code/AGENTS.md" 'three-leg code leg receives no agent pointer'
+
+printf '%s\n' 'Then: the worktree layout and ignore line describe the three-leg root'
+THREE_LEG_GIT_CONFIG="$THREE_LEG_ROOT/.specify/extensions/git/git-config.yml"
+assert_contains "$THREE_LEG_GIT_CONFIG" 'worktree_root: worktrees' 'three-leg worktree root defaults to worktrees'
+assert_contains "$THREE_LEG_GIT_CONFIG" 'checkout_mode: worktree' 'three-leg checkout mode stays worktree'
+assert_contains "$THREE_LEG_ROOT/.gitignore" '/worktrees/' 'three-leg root gitignore carries the worktrees line'
+assert_equal "$(grep -Fxc '/worktrees/' "$THREE_LEG_ROOT/.gitignore")" 1 'three-leg root gitignore carries the worktrees line once'
+
+printf '%s\n' 'Then: the managed agent block names the two mount paths'
+assert_contains "$THREE_LEG_ROOT/AGENTS.md" '### Repository shape: openRepoShape three-leg' 'three-leg agent block names the shape'
+assert_contains "$THREE_LEG_ROOT/AGENTS.md" '- Spec leg: `spec/`' 'three-leg agent block names the spec mount path'
+assert_contains "$THREE_LEG_ROOT/AGENTS.md" '- Code leg: `code/`' 'three-leg agent block names the code mount path'
+assert_contains "$THREE_LEG_ROOT/AGENTS.md" '`worktrees/<NNN-feature>/spec/`' 'three-leg agent block names the spec worktree path'
+assert_contains "$THREE_LEG_ROOT/CLAUDE.md" '### Repository shape: openRepoShape three-leg' 'three-leg shape reaches every agent context file'
+
+printf '%s\n' 'Then: the run closes with the spec-leg paths and the two-commit note'
+assert_contains "$THREE_LEG_LOG" 'Two Repositories Means Two Commits' 'three-leg run prints the two-commit note'
+assert_contains "$THREE_LEG_LOG" 'Written in the spec repository (spec/):' 'three-leg run lists the spec repository writes'
+assert_contains "$THREE_LEG_LOG" "  $THREE_LEG_ROOT/spec/openspec/config.yaml" 'three-leg run names the OpenSpec config as a spec-leg write'
+assert_contains "$THREE_LEG_LOG" 'contracts/spec-pin.yaml' 'three-leg run names the pin file to move'
+
+printf '%s\n' 'When: bootstrap reruns against the same three-leg root'
+THREE_LEG_FIRST_SNAPSHOT="$TMPDIR_ROOT/three-leg-first.snapshot"
+THREE_LEG_SECOND_SNAPSHOT="$TMPDIR_ROOT/three-leg-second.snapshot"
+THREE_LEG_FIRST_MODES="$TMPDIR_ROOT/three-leg-first-modes.snapshot"
+THREE_LEG_SECOND_MODES="$TMPDIR_ROOT/three-leg-second-modes.snapshot"
+snapshot_repo "$THREE_LEG_ROOT" > "$THREE_LEG_FIRST_SNAPSHOT"
+snapshot_repo_modes "$THREE_LEG_ROOT" > "$THREE_LEG_FIRST_MODES"
+if ! python3 "$SETUP_SCRIPT" --repo "$THREE_LEG_ROOT" "${THREE_LEG_FLAGS[@]}" \
+    > "$TMPDIR_ROOT/three-leg-second.log" 2>&1; then
+    printf '%s\n' 'FAIL: second three-leg bootstrap invocation failed:'
+    cat "$TMPDIR_ROOT/three-leg-second.log"
+    exit 1
+fi
+snapshot_repo "$THREE_LEG_ROOT" > "$THREE_LEG_SECOND_SNAPSHOT"
+snapshot_repo_modes "$THREE_LEG_ROOT" > "$THREE_LEG_SECOND_MODES"
+
+printf '%s\n' 'Then: the second three-leg run changes nothing'
+if cmp -s "$THREE_LEG_FIRST_SNAPSHOT" "$THREE_LEG_SECOND_SNAPSHOT"; then
+    pass 'second three-leg bootstrap preserves file hashes'
+else
+    fail 'second three-leg bootstrap changes file hashes'
+fi
+if cmp -s "$THREE_LEG_FIRST_MODES" "$THREE_LEG_SECOND_MODES"; then
+    pass 'second three-leg bootstrap preserves path types and modes'
+else
+    fail 'second three-leg bootstrap changes path types or modes'
+fi
+assert_equal "$(grep -Fc '### Repository shape: openRepoShape three-leg' "$THREE_LEG_ROOT/AGENTS.md")" 1 'second three-leg bootstrap keeps one managed shape section'
+assert_equal "$(grep -Fxc '/worktrees/' "$THREE_LEG_ROOT/.gitignore")" 1 'second three-leg bootstrap appends no duplicate ignore line'
+
+printf '%s\n' 'Given: a three-leg root whose AGENTS.md opens with the shape pointer'
+SHAPE_POINTER_ROOT="$TMPDIR_ROOT/shape-pointer-root"
+make_three_leg_root "$SHAPE_POINTER_ROOT"
+printf '%s\n' \
+    'Read AGENTS-shape.md first — the rules of this repository shape.' \
+    '' \
+    '# Agent Instructions' \
+    '' \
+    '## Repository Role' \
+    '' \
+    'fixture role' > "$SHAPE_POINTER_ROOT/AGENTS.md"
+
+printf '%s\n' 'When: bootstrap writes the managed block into that root'
+if ! python3 "$SETUP_SCRIPT" --repo "$SHAPE_POINTER_ROOT" "${THREE_LEG_FLAGS[@]}" \
+    > "$TMPDIR_ROOT/shape-pointer.log" 2>&1; then
+    printf '%s\n' 'FAIL: shape-pointer bootstrap invocation failed:'
+    cat "$TMPDIR_ROOT/shape-pointer.log"
+    exit 1
+fi
+
+printf '%s\n' 'Then: line 1 is untouched and the block lands before the first section'
+assert_equal \
+    "$(sed -n '1p' "$SHAPE_POINTER_ROOT/AGENTS.md")" \
+    'Read AGENTS-shape.md first — the rules of this repository shape.' \
+    'first-line invariant keeps the shape pointer on line 1'
+assert_contains "$SHAPE_POINTER_ROOT/AGENTS.md" '### Repository shape: openRepoShape three-leg' 'shape-pointer root still receives the managed shape section'
+assert_contains "$SHAPE_POINTER_ROOT/AGENTS.md" '## Repository Role' 'shape-pointer root keeps its hand-written section'
+
+printf '%s\n' 'Given: a root whose first line is both the shape pointer and the first section heading'
+FIRST_LINE_ROOT="$TMPDIR_ROOT/first-line-refusal-root"
+make_three_leg_root "$FIRST_LINE_ROOT"
+printf '%s\n' \
+    '## Read AGENTS-shape.md first' \
+    '' \
+    'fixture body' > "$FIRST_LINE_ROOT/AGENTS.md"
+
+printf '%s\n' 'When: the managed block would have to displace that line'
+if python3 "$SETUP_SCRIPT" --repo "$FIRST_LINE_ROOT" "${THREE_LEG_FLAGS[@]}" \
+    > "$TMPDIR_ROOT/first-line-refusal.log" 2>&1; then
+    fail 'bootstrap refuses to move a first line naming AGENTS-shape.md'
+else
+    pass 'bootstrap refuses to move a first line naming AGENTS-shape.md'
+fi
+
+printf '%s\n' 'Then: the refusal names the file and both first lines'
+assert_contains "$TMPDIR_ROOT/first-line-refusal.log" "Refusing to move the first line of $FIRST_LINE_ROOT/AGENTS.md" 'first-line refusal names the file'
+assert_contains "$TMPDIR_ROOT/first-line-refusal.log" "'## Read AGENTS-shape.md first'" 'first-line refusal quotes the existing first line'
+assert_contains "$TMPDIR_ROOT/first-line-refusal.log" "'<!-- OPENSPEC-SPECKIT-GLOBAL:START -->'" 'first-line refusal quotes the proposed first line'
+assert_contains "$FIRST_LINE_ROOT/AGENTS.md" '## Read AGENTS-shape.md first' 'first-line refusal leaves the context file unchanged'
+assert_not_contains "$FIRST_LINE_ROOT/AGENTS.md" 'OPENSPEC-SPECKIT-GLOBAL' 'first-line refusal writes no managed block'
+
+printf '%s\n' 'Given: a three-leg root whose spec leg was never fetched'
+UNFETCHED_ROOT="$TMPDIR_ROOT/unfetched-spec-root"
+mkdir -p "$UNFETCHED_ROOT/spec" "$UNFETCHED_ROOT/code"
+git init -q -b main "$UNFETCHED_ROOT"
+write_project_manifest "$UNFETCHED_ROOT"
+seed_speckit_state "$UNFETCHED_ROOT"
+
+printf '%s\n' 'When: bootstrap runs against the unfetched three-leg root'
+if python3 "$SETUP_SCRIPT" --repo "$UNFETCHED_ROOT" "${THREE_LEG_FLAGS[@]}" \
+    > "$TMPDIR_ROOT/unfetched-spec.log" 2>&1; then
+    fail 'bootstrap refuses a three-leg root whose spec leg is not initialised'
+else
+    pass 'bootstrap refuses a three-leg root whose spec leg is not initialised'
+fi
+
+printf '%s\n' 'Then: the refusal names the remedy and nothing is written'
+assert_contains "$TMPDIR_ROOT/unfetched-spec.log" 'is not an initialised git checkout' 'unfetched spec leg refusal names the cause'
+assert_contains "$TMPDIR_ROOT/unfetched-spec.log" 'git submodule update --init' 'unfetched spec leg refusal names the submodule command'
+assert_contains "$TMPDIR_ROOT/unfetched-spec.log" 'make bootstrap' 'unfetched spec leg refusal names the bootstrap target'
+assert_not_exists "$UNFETCHED_ROOT/spec/openspec" 'unfetched spec leg refusal writes nothing in the spec leg'
+assert_not_exists "$UNFETCHED_ROOT/openspec" 'unfetched spec leg refusal writes nothing in the root'
+assert_not_exists "$UNFETCHED_ROOT/AGENTS.md" 'unfetched spec leg refusal writes no agent pointer'
+
+printf '%s\n' 'Given: a three-leg root whose spec leg directory is missing entirely'
+MISSING_LEG_ROOT="$TMPDIR_ROOT/missing-spec-root"
+mkdir -p "$MISSING_LEG_ROOT/code"
+git init -q -b main "$MISSING_LEG_ROOT"
+write_project_manifest "$MISSING_LEG_ROOT"
+seed_speckit_state "$MISSING_LEG_ROOT"
+
+printf '%s\n' 'When: bootstrap runs against the root with no spec leg directory'
+if python3 "$SETUP_SCRIPT" --repo "$MISSING_LEG_ROOT" "${THREE_LEG_FLAGS[@]}" \
+    > "$TMPDIR_ROOT/missing-spec.log" 2>&1; then
+    fail 'bootstrap refuses a three-leg root whose spec leg is missing'
+else
+    pass 'bootstrap refuses a three-leg root whose spec leg is missing'
+fi
+assert_contains "$TMPDIR_ROOT/missing-spec.log" 'named by project.yaml is missing' 'missing spec leg refusal names the cause'
+assert_contains "$TMPDIR_ROOT/missing-spec.log" 'git submodule update --init' 'missing spec leg refusal names the submodule command'
+assert_contains "$TMPDIR_ROOT/missing-spec.log" 'make bootstrap' 'missing spec leg refusal names the bootstrap target'
+
+printf '%s\n' 'Given: a single repository and a family holder'
+SHAPE_ON_REPO="$TMPDIR_ROOT/shape-on-repo"
+FAMILY_HOLDER_REPO="$TMPDIR_ROOT/family-holder-repo"
+mkdir -p "$SHAPE_ON_REPO" "$FAMILY_HOLDER_REPO"
+git init -q -b main "$SHAPE_ON_REPO"
+git init -q -b main "$FAMILY_HOLDER_REPO"
+seed_speckit_state "$SHAPE_ON_REPO"
+seed_speckit_state "$FAMILY_HOLDER_REPO"
+cat > "$FAMILY_HOLDER_REPO/family.yaml" <<'EOF'
+schema_version: 1
+kind: family-manifest
+
+# A family holder pins its members' assembly roots and has no legs of its own.
+id: fixture-family
+name: "Fixture Family"
+EOF
+
+printf '%s\n' 'When: --shape on runs against the single repository'
+if python3 "$SETUP_SCRIPT" --repo "$SHAPE_ON_REPO" --shape on "${THREE_LEG_FLAGS[@]}" \
+    > "$TMPDIR_ROOT/shape-on.log" 2>&1; then
+    fail '--shape on refuses a single repository'
+else
+    pass '--shape on refuses a single repository'
+fi
+assert_contains "$TMPDIR_ROOT/shape-on.log" 'Refusing --shape on' '--shape on refusal names the flag'
+assert_contains "$TMPDIR_ROOT/shape-on.log" 'no project.yaml with kind: project-manifest' '--shape on refusal names the missing manifest'
+assert_not_exists "$SHAPE_ON_REPO/openspec" '--shape on refusal writes nothing'
+
+printf '%s\n' 'When: --shape on runs against the family holder'
+if python3 "$SETUP_SCRIPT" --repo "$FAMILY_HOLDER_REPO" --shape on "${THREE_LEG_FLAGS[@]}" \
+    > "$TMPDIR_ROOT/shape-on-family.log" 2>&1; then
+    fail '--shape on refuses a family holder'
+else
+    pass '--shape on refuses a family holder'
+fi
+assert_contains "$TMPDIR_ROOT/shape-on-family.log" 'family holder' '--shape on refusal names the family holder'
+
+printf '%s\n' 'When: the family holder is bootstrapped with the default shape handling'
+if ! python3 "$SETUP_SCRIPT" --repo "$FAMILY_HOLDER_REPO" "${THREE_LEG_FLAGS[@]}" \
+    > "$TMPDIR_ROOT/family-holder.log" 2>&1; then
+    printf '%s\n' 'FAIL: family holder bootstrap invocation failed:'
+    cat "$TMPDIR_ROOT/family-holder.log"
+    exit 1
+fi
+
+printf '%s\n' 'Then: the family holder is logged and gets the single-repository layout'
+assert_contains "$TMPDIR_ROOT/family-holder.log" 'shape: family holder' 'family holder is logged as such'
+assert_file "$FAMILY_HOLDER_REPO/openspec/config.yaml" 'family holder keeps OpenSpec in its own root'
+assert_contains "$FAMILY_HOLDER_REPO/.specify/extensions/git/git-config.yml" 'worktree_root: ../family-holder-repo-worktrees' 'family holder uses the single-repository worktree root'
+assert_not_exists "$FAMILY_HOLDER_REPO/.gitignore" 'family holder receives no worktrees ignore line'
+assert_not_contains "$FAMILY_HOLDER_REPO/AGENTS.md" '### Repository shape: openRepoShape three-leg' 'family holder agent block stays single-repository'
+
+printf '%s\n' 'Given: a three-leg root bootstrapped with --shape off'
+SHAPE_OFF_ROOT="$TMPDIR_ROOT/shape-off-root"
+make_three_leg_root "$SHAPE_OFF_ROOT"
+
+printf '%s\n' 'When: bootstrap forces the single-repository layout'
+if ! python3 "$SETUP_SCRIPT" --repo "$SHAPE_OFF_ROOT" --shape off "${THREE_LEG_FLAGS[@]}" \
+    > "$TMPDIR_ROOT/shape-off.log" 2>&1; then
+    printf '%s\n' 'FAIL: --shape off bootstrap invocation failed:'
+    cat "$TMPDIR_ROOT/shape-off.log"
+    exit 1
+fi
+
+printf '%s\n' 'Then: everything lands in the root and the legs are untouched'
+assert_contains "$TMPDIR_ROOT/shape-off.log" 'shape: single repository (forced by --shape off)' '--shape off reports the forced layout'
+assert_file "$SHAPE_OFF_ROOT/openspec/config.yaml" '--shape off keeps OpenSpec in the root'
+assert_not_exists "$SHAPE_OFF_ROOT/spec/openspec" '--shape off writes nothing in the spec leg'
+assert_contains "$SHAPE_OFF_ROOT/.specify/extensions/git/git-config.yml" 'worktree_root: ../shape-off-root-worktrees' '--shape off uses the single-repository worktree root'
+assert_not_exists "$SHAPE_OFF_ROOT/.gitignore" '--shape off adds no worktrees ignore line'
+assert_not_contains "$SHAPE_OFF_ROOT/AGENTS.md" '### Repository shape: openRepoShape three-leg' '--shape off agent block stays single-repository'
+assert_not_contains "$TMPDIR_ROOT/shape-off.log" '[spec] ' '--shape off prints no spec-leg log prefix'
+assert_not_contains "$TMPDIR_ROOT/shape-off.log" 'Two Repositories Means Two Commits' '--shape off prints no two-commit note'
+
+printf '%s\n' 'Given: skills and commands that should carry the managed shape block'
+SHAPE_BLOCK_ROOT="$TMPDIR_ROOT/shape-block-root"
+SHAPE_BLOCK_HOME="$TMPDIR_ROOT/shape-block-home"
+SHAPE_BLOCK_PROTOCOL_ROOT="$TMPDIR_ROOT/shape-block-protocol"
+SHAPE_BLOCK_EXTERNAL="$TMPDIR_ROOT/shape-block-external"
+make_three_leg_root "$SHAPE_BLOCK_ROOT"
+printf '%s\n' '# repository-specific ignores' '*.log' > "$SHAPE_BLOCK_ROOT/.gitignore"
+mkdir -p \
+    "$SHAPE_BLOCK_ROOT/.claude/skills/speckit-plan" \
+    "$SHAPE_BLOCK_ROOT/.claude/skills/ct" \
+    "$SHAPE_BLOCK_ROOT/.claude/skills/openspec-propose" \
+    "$SHAPE_BLOCK_ROOT/.agents/skills/speckit-tasks" \
+    "$SHAPE_BLOCK_ROOT/.codex/skills/speckit-tasks" \
+    "$SHAPE_BLOCK_HOME/.claude/skills/speckit-plan" \
+    "$SHAPE_BLOCK_HOME/.claude/skills/ctp" \
+    "$SHAPE_BLOCK_HOME/.agents/skills/speckit-tasks" \
+    "$SHAPE_BLOCK_HOME/.codex/skills/openspec-apply-change" \
+    "$SHAPE_BLOCK_HOME/.codex/skills/speckit-linked" \
+    "$SHAPE_BLOCK_EXTERNAL"
+cat > "$SHAPE_BLOCK_ROOT/.claude/skills/speckit-plan/SKILL.md" <<'EOF'
+---
+name: speckit-plan
+description: fixture plan skill
+---
+
+Run the planning workflow from the repo root.
+EOF
+printf '%s\n' 'fixture ct skill without frontmatter' > "$SHAPE_BLOCK_ROOT/.claude/skills/ct/SKILL.md"
+printf '%s\n' 'fixture repo-local OpenSpec wrapper' > "$SHAPE_BLOCK_ROOT/.claude/skills/openspec-propose/SKILL.md"
+cp "$SHAPE_BLOCK_ROOT/.claude/skills/speckit-plan/SKILL.md" "$SHAPE_BLOCK_ROOT/.agents/skills/speckit-tasks/SKILL.md"
+cp "$SHAPE_BLOCK_ROOT/.claude/skills/speckit-plan/SKILL.md" "$SHAPE_BLOCK_ROOT/.codex/skills/speckit-tasks/SKILL.md"
+cp "$SHAPE_BLOCK_ROOT/.claude/skills/speckit-plan/SKILL.md" "$SHAPE_BLOCK_HOME/.claude/skills/speckit-plan/SKILL.md"
+cp "$SHAPE_BLOCK_ROOT/.claude/skills/speckit-plan/SKILL.md" "$SHAPE_BLOCK_HOME/.claude/skills/ctp/SKILL.md"
+cp "$SHAPE_BLOCK_ROOT/.claude/skills/speckit-plan/SKILL.md" "$SHAPE_BLOCK_HOME/.agents/skills/speckit-tasks/SKILL.md"
+cp "$SHAPE_BLOCK_ROOT/.claude/skills/speckit-plan/SKILL.md" "$SHAPE_BLOCK_HOME/.codex/skills/openspec-apply-change/SKILL.md"
+printf '%s\n' 'external skill body' > "$SHAPE_BLOCK_EXTERNAL/SKILL.md"
+ln -s "$SHAPE_BLOCK_EXTERNAL/SKILL.md" "$SHAPE_BLOCK_HOME/.codex/skills/speckit-linked/SKILL.md"
+
+printf '%s\n' 'When: bootstrap maintains the managed shape block'
+export HOME="$SHAPE_BLOCK_HOME"
+export AGENT_PROTOCOL_ROOT="$SHAPE_BLOCK_PROTOCOL_ROOT"
+if ! python3 "$SETUP_SCRIPT" \
+    --repo "$SHAPE_BLOCK_ROOT" \
+    --no-speckit-registration \
+    --no-skill-links \
+    --preserve-readmes > "$TMPDIR_ROOT/shape-block.log" 2>&1; then
+    printf '%s\n' 'FAIL: shape-block bootstrap invocation failed:'
+    cat "$TMPDIR_ROOT/shape-block.log"
+    exit 1
+fi
+
+printf '%s\n' 'Then: an existing root gitignore keeps its content and gains the worktrees line'
+assert_contains "$SHAPE_BLOCK_ROOT/.gitignore" '# repository-specific ignores' 'existing gitignore comment survives the worktrees line'
+assert_contains "$SHAPE_BLOCK_ROOT/.gitignore" '*.log' 'existing gitignore entry survives the worktrees line'
+assert_equal "$(grep -Fxc '/worktrees/' "$SHAPE_BLOCK_ROOT/.gitignore")" 1 'existing gitignore gains exactly one worktrees line'
+
+printf '%s\n' 'Then: repo-local targets carry a relocatable block directly after the frontmatter'
+SHAPE_BLOCK_PLAN="$SHAPE_BLOCK_ROOT/.claude/skills/speckit-plan/SKILL.md"
+assert_equal "$(sed -n '4p' "$SHAPE_BLOCK_PLAN")" '---' 'managed shape block leaves the frontmatter intact'
+assert_equal "$(sed -n '5p' "$SHAPE_BLOCK_PLAN")" '' 'managed shape block leaves a blank line after the frontmatter'
+assert_equal "$(sed -n '6p' "$SHAPE_BLOCK_PLAN")" '<!-- OPENSPEC-SPECKIT-SHAPE:START -->' 'managed shape block opens directly after the frontmatter'
+assert_contains "$SHAPE_BLOCK_PLAN" '## Repository Shape (managed by setup-openspeckit)' 'managed shape block carries its heading'
+assert_contains "$SHAPE_BLOCK_PLAN" '${AGENT_PROTOCOL_ROOT:-$HOME/.agents}/protocols/openspec-speckit-workflow.md' 'repo-local shape block uses the portable protocol root'
+assert_not_contains "$SHAPE_BLOCK_PLAN" "$SHAPE_BLOCK_PROTOCOL_ROOT" 'repo-local shape block omits the absolute protocol root'
+assert_contains "$SHAPE_BLOCK_PLAN" 'Run the planning workflow from the repo root.' 'managed shape block preserves the skill body'
+assert_contains "$SHAPE_BLOCK_ROOT/.agents/skills/speckit-tasks/SKILL.md" '<!-- OPENSPEC-SPECKIT-SHAPE:START -->' 'managed shape block reaches Agents skills'
+assert_contains "$SHAPE_BLOCK_ROOT/.codex/skills/speckit-tasks/SKILL.md" '<!-- OPENSPEC-SPECKIT-SHAPE:START -->' 'managed shape block reaches Codex skills'
+assert_contains "$SHAPE_BLOCK_ROOT/.claude/skills/speckit-specify/SKILL.md" '<!-- OPENSPEC-SPECKIT-SHAPE:START -->' 'managed shape block reaches the installed worktree overlay skills'
+assert_contains "$SHAPE_BLOCK_ROOT/.claude/commands/opsx/apply.md" '<!-- OPENSPEC-SPECKIT-SHAPE:START -->' 'managed shape block reaches the OPSX commands'
+assert_equal "$(sed -n '1p' "$SHAPE_BLOCK_ROOT/.claude/skills/ct/SKILL.md")" '<!-- OPENSPEC-SPECKIT-SHAPE:START -->' 'managed shape block opens a file without frontmatter'
+assert_not_contains "$SHAPE_BLOCK_ROOT/.claude/skills/openspec-propose/SKILL.md" 'OPENSPEC-SPECKIT-SHAPE' 'managed shape block skips repo-local OpenSpec wrappers'
+
+printf '%s\n' 'Then: user-global targets carry the resolved protocol root and symlinks are skipped'
+assert_contains "$SHAPE_BLOCK_HOME/.claude/skills/speckit-plan/SKILL.md" "$SHAPE_BLOCK_PROTOCOL_ROOT/protocols/openspec-speckit-workflow.md" 'user-global shape block uses the resolved protocol root'
+assert_contains "$SHAPE_BLOCK_HOME/.claude/skills/ctp/SKILL.md" '<!-- OPENSPEC-SPECKIT-SHAPE:START -->' 'user-global shape block reaches ctp'
+assert_contains "$SHAPE_BLOCK_HOME/.agents/skills/speckit-tasks/SKILL.md" '<!-- OPENSPEC-SPECKIT-SHAPE:START -->' 'user-global shape block reaches Agents skills'
+assert_contains "$SHAPE_BLOCK_HOME/.codex/skills/openspec-apply-change/SKILL.md" '<!-- OPENSPEC-SPECKIT-SHAPE:START -->' 'user-global shape block reaches Codex OpenSpec skills'
+assert_not_contains "$SHAPE_BLOCK_EXTERNAL/SKILL.md" 'OPENSPEC-SPECKIT-SHAPE' 'managed shape block never follows a symlinked SKILL.md'
+if [[ -L "$SHAPE_BLOCK_HOME/.codex/skills/speckit-linked/SKILL.md" ]]; then
+    pass 'managed shape block leaves a symlinked SKILL.md as a symlink'
+else
+    fail 'managed shape block leaves a symlinked SKILL.md as a symlink'
+fi
+
+printf '%s\n' 'When: bootstrap reruns and then reruns with --no-skill-shape-blocks'
+SHAPE_BLOCK_FIRST="$TMPDIR_ROOT/shape-block-first.snapshot"
+SHAPE_BLOCK_SECOND="$TMPDIR_ROOT/shape-block-second.snapshot"
+snapshot_repo "$SHAPE_BLOCK_ROOT" > "$SHAPE_BLOCK_FIRST"
+if ! python3 "$SETUP_SCRIPT" \
+    --repo "$SHAPE_BLOCK_ROOT" \
+    --no-speckit-registration \
+    --no-skill-links \
+    --preserve-readmes > "$TMPDIR_ROOT/shape-block-second.log" 2>&1; then
+    printf '%s\n' 'FAIL: second shape-block bootstrap invocation failed:'
+    cat "$TMPDIR_ROOT/shape-block-second.log"
+    exit 1
+fi
+snapshot_repo "$SHAPE_BLOCK_ROOT" > "$SHAPE_BLOCK_SECOND"
+if cmp -s "$SHAPE_BLOCK_FIRST" "$SHAPE_BLOCK_SECOND"; then
+    pass 'managed shape block is idempotent'
+else
+    fail 'managed shape block changes on rerun'
+fi
+assert_equal "$(grep -Fc '<!-- OPENSPEC-SPECKIT-SHAPE:START -->' "$SHAPE_BLOCK_PLAN")" 1 'managed shape block keeps one start marker'
+assert_equal "$(grep -Fc '<!-- OPENSPEC-SPECKIT-SHAPE:END -->' "$SHAPE_BLOCK_PLAN")" 1 'managed shape block keeps one end marker'
+
+SKIPPED_BLOCK_ROOT="$TMPDIR_ROOT/skipped-block-root"
+make_three_leg_root "$SKIPPED_BLOCK_ROOT"
+mkdir -p "$SKIPPED_BLOCK_ROOT/.claude/skills/speckit-plan"
+cp "$SHAPE_BLOCK_ROOT/.claude/skills/ct/SKILL.md" "$TMPDIR_ROOT/shape-block-ct-reference"
+cat > "$SKIPPED_BLOCK_ROOT/.claude/skills/speckit-plan/SKILL.md" <<'EOF'
+---
+name: speckit-plan
+---
+
+fixture body
+EOF
+if ! python3 "$SETUP_SCRIPT" \
+    --repo "$SKIPPED_BLOCK_ROOT" \
+    --no-speckit-registration \
+    --no-skill-links \
+    --no-skill-shape-blocks \
+    --no-global-agent-pointers \
+    --preserve-readmes > "$TMPDIR_ROOT/skipped-block.log" 2>&1; then
+    printf '%s\n' 'FAIL: --no-skill-shape-blocks bootstrap invocation failed:'
+    cat "$TMPDIR_ROOT/skipped-block.log"
+    exit 1
+fi
+assert_not_contains "$SKIPPED_BLOCK_ROOT/.claude/skills/speckit-plan/SKILL.md" 'OPENSPEC-SPECKIT-SHAPE' '--no-skill-shape-blocks leaves skills alone'
+
+printf '%s\n' 'Given: overlay template trees with and without the shape compatibility marker'
+make_fake_overlay_template() {
+    local root="$1"
+    local marking="$2"
+    mkdir -p \
+        "$root/specify/extensions/git/commands" \
+        "$root/specify/extensions/git/scripts/bash" \
+        "$root/specify/extensions/git/scripts/powershell" \
+        "$root/specify/shell"
+    printf '%s\n' 'name: git' > "$root/specify/extensions/git/extension.yml"
+    for overlay_command in commit feature initialize remote validate; do
+        printf '%s\n' "# speckit.git.$overlay_command fixture" \
+            > "$root/specify/extensions/git/commands/speckit.git.$overlay_command.md"
+    done
+    for overlay_script in auto-commit create-new-feature get-last-worktree git-common initialize-repo; do
+        {
+            printf '%s\n' '#!/usr/bin/env bash'
+            printf '%s\n' 'set -euo pipefail'
+            if [[ "$marking" == 'marked' ]]; then
+                printf '%s\n' '# speckit-overlay-shape: 1'
+            fi
+            printf '%s\n' "# fixture overlay $overlay_script"
+            if [[ "$overlay_script" == 'git-common' ]]; then
+                printf '%s\n' 'load_git_worktrees() {' '    :' '}'
+            fi
+        } > "$root/specify/extensions/git/scripts/bash/$overlay_script.sh"
+    done
+    for overlay_script in auto-commit create-new-feature git-common initialize-repo; do
+        printf '%s\n' "# fixture overlay $overlay_script" \
+            > "$root/specify/extensions/git/scripts/powershell/$overlay_script.ps1"
+    done
+    printf '%s\n' 'fixture shell helper' > "$root/specify/shell/select-worktree.sh"
+    for template_agent_dir in agents claude codex; do
+        for overlay_skill in speckit-specify speckit-git-feature speckit-git-validate; do
+            mkdir -p "$root/$template_agent_dir/skills/$overlay_skill"
+            printf '%s\n' "fixture overlay skill $template_agent_dir/$overlay_skill" \
+                > "$root/$template_agent_dir/skills/$overlay_skill/SKILL.md"
+        done
+    done
+}
+
+customize_installed_overlay() {
+    local repo="$1"
+    printf '%s\n' '# repository-specific overlay customization' \
+        >> "$repo/.specify/extensions/git/scripts/bash/git-common.sh"
+    printf '%s\n' 'repository-specific shell customization' \
+        > "$repo/.specify/shell/select-worktree.sh"
+    printf '%s\n' 'repository-specific overlay skill customization' \
+        > "$repo/.claude/skills/speckit-specify/SKILL.md"
+}
+
+MARKED_TEMPLATE_ROOT="$TMPDIR_ROOT/marked-overlay-templates"
+UNMARKED_TEMPLATE_ROOT="$TMPDIR_ROOT/unmarked-overlay-templates"
+make_fake_overlay_template "$MARKED_TEMPLATE_ROOT" marked
+make_fake_overlay_template "$UNMARKED_TEMPLATE_ROOT" unmarked
+
+OVERLAY_REFRESH_FLAGS=(
+    --skip-init
+    --no-speckit-registration
+    --no-repo-agent-pointers
+    --no-skill-links
+    --no-skill-shape-blocks
+    --no-global-agent-pointers
+    --preserve-readmes
+)
+
+install_overlay_fixture() {
+    local repo="$1"
+    local template="$2"
+    mkdir -p "$repo/.specify" "$repo/.claude/skills" "$repo/.agents/skills" "$repo/.codex/skills"
+    cp -a "$template/specify/extensions" "$repo/.specify/extensions"
+    cp -a "$template/specify/shell" "$repo/.specify/shell"
+    for repo_agent_mapping in '.agents:agents' '.claude:claude' '.codex:codex'; do
+        local repo_agent_dir="${repo_agent_mapping%%:*}"
+        local template_agent_dir="${repo_agent_mapping##*:}"
+        cp -a "$template/$template_agent_dir/skills/." "$repo/$repo_agent_dir/skills/"
+    done
+    git init -q -b main "$repo"
+}
+
+printf '%s\n' 'When: a marked template meets an installed overlay without the marker'
+STALE_OVERLAY_REPO="$TMPDIR_ROOT/stale-overlay-repo"
+STALE_OVERLAY_PROTOCOL_ROOT="$TMPDIR_ROOT/stale-overlay-protocol"
+install_overlay_fixture "$STALE_OVERLAY_REPO" "$UNMARKED_TEMPLATE_ROOT"
+customize_installed_overlay "$STALE_OVERLAY_REPO"
+export AGENT_PROTOCOL_ROOT="$STALE_OVERLAY_PROTOCOL_ROOT"
+export SPECKIT_WORKTREE_TEMPLATE_ROOT="$MARKED_TEMPLATE_ROOT"
+if ! python3 "$SETUP_SCRIPT" --repo "$STALE_OVERLAY_REPO" "${OVERLAY_REFRESH_FLAGS[@]}" \
+    > "$TMPDIR_ROOT/stale-overlay.log" 2>&1; then
+    printf '%s\n' 'FAIL: stale-overlay bootstrap invocation failed:'
+    cat "$TMPDIR_ROOT/stale-overlay.log"
+    exit 1
+fi
+
+printf '%s\n' 'Then: the git extension, the shell tree, and the three skill trees are replaced'
+assert_contains "$TMPDIR_ROOT/stale-overlay.log" 'replacing incompatible Spec Kit git extension' 'unmarked overlay is reported as incompatible'
+assert_contains "$STALE_OVERLAY_REPO/.specify/extensions/git/scripts/bash/git-common.sh" '# speckit-overlay-shape: 1' 'unmarked overlay refresh installs the marked helper'
+assert_not_contains "$STALE_OVERLAY_REPO/.specify/extensions/git/scripts/bash/git-common.sh" 'repository-specific overlay customization' 'unmarked overlay refresh replaces the git extension tree'
+assert_not_contains "$STALE_OVERLAY_REPO/.specify/shell/select-worktree.sh" 'repository-specific shell customization' 'unmarked overlay refresh replaces the shell tree'
+assert_not_contains "$STALE_OVERLAY_REPO/.claude/skills/speckit-specify/SKILL.md" 'repository-specific overlay skill customization' 'unmarked overlay refresh replaces the overlay skill trees'
+assert_contains "$STALE_OVERLAY_REPO/.codex/skills/speckit-git-validate/SKILL.md" 'fixture overlay skill codex/speckit-git-validate' 'unmarked overlay refresh restores every overlay skill home'
+
+printf '%s\n' 'Given: an old-style overlay whose Agents skill destination is a symlink outside the repo'
+LINKED_OVERLAY_REPO="$TMPDIR_ROOT/linked-overlay-repo"
+LINKED_OVERLAY_HOME="$TMPDIR_ROOT/linked-overlay-home"
+LINKED_OVERLAY_PROTOCOL_ROOT="$TMPDIR_ROOT/linked-overlay-protocol"
+LINKED_OVERLAY_EXTERNAL="$TMPDIR_ROOT/linked-overlay-external"
+LINKED_OVERLAY_DESTINATION="$LINKED_OVERLAY_REPO/.agents/skills/speckit-git-validate"
+LINKED_OVERLAY_EXTERNAL_BEFORE="$TMPDIR_ROOT/linked-overlay-external.before"
+LINKED_OVERLAY_EXTERNAL_AFTER="$TMPDIR_ROOT/linked-overlay-external.after"
+LINKED_OVERLAY_EXTERNAL_MODES_BEFORE="$TMPDIR_ROOT/linked-overlay-external-modes.before"
+LINKED_OVERLAY_EXTERNAL_MODES_AFTER="$TMPDIR_ROOT/linked-overlay-external-modes.after"
+install_overlay_fixture "$LINKED_OVERLAY_REPO" "$UNMARKED_TEMPLATE_ROOT"
+mkdir -p "$LINKED_OVERLAY_HOME" "$LINKED_OVERLAY_EXTERNAL/nested"
+printf '%s\n' 'external validator skill' > "$LINKED_OVERLAY_EXTERNAL/SKILL.md"
+printf '%s\n' 'external validator helper' > "$LINKED_OVERLAY_EXTERNAL/nested/helper.txt"
+chmod 0700 "$LINKED_OVERLAY_EXTERNAL"
+chmod 0710 "$LINKED_OVERLAY_EXTERNAL/nested"
+chmod 0640 "$LINKED_OVERLAY_EXTERNAL/SKILL.md"
+chmod 0600 "$LINKED_OVERLAY_EXTERNAL/nested/helper.txt"
+rm -rf "$LINKED_OVERLAY_DESTINATION"
+ln -s "$LINKED_OVERLAY_EXTERNAL" "$LINKED_OVERLAY_DESTINATION"
+snapshot_repo "$LINKED_OVERLAY_EXTERNAL" > "$LINKED_OVERLAY_EXTERNAL_BEFORE"
+snapshot_repo_modes "$LINKED_OVERLAY_EXTERNAL" > "$LINKED_OVERLAY_EXTERNAL_MODES_BEFORE"
+
+LINKED_OVERLAY_FLAGS=(
+    --skip-init
+    --no-speckit-registration
+    --no-repo-agent-pointers
+    --no-skill-links
+    --no-global-agent-pointers
+    --preserve-readmes
+)
+
+printf '%s\n' 'When: the bootstrap plans that refresh with --dry-run'
+export HOME="$LINKED_OVERLAY_HOME"
+export AGENT_PROTOCOL_ROOT="$LINKED_OVERLAY_PROTOCOL_ROOT"
+export SPECKIT_WORKTREE_TEMPLATE_ROOT="$MARKED_TEMPLATE_ROOT"
+if ! python3 "$SETUP_SCRIPT" --repo "$LINKED_OVERLAY_REPO" --dry-run "${LINKED_OVERLAY_FLAGS[@]}" \
+    > "$TMPDIR_ROOT/linked-overlay-dry-run.log" 2>&1; then
+    printf '%s\n' 'FAIL: linked-overlay dry-run bootstrap invocation failed:'
+    cat "$TMPDIR_ROOT/linked-overlay-dry-run.log"
+    exit 1
+fi
+
+printf '%s\n' 'Then: the dry run plans the replacement without touching the link'
+assert_contains "$TMPDIR_ROOT/linked-overlay-dry-run.log" "would replace skill link $LINKED_OVERLAY_DESTINATION with worktree overlay" 'dry run plans the skill link replacement'
+if [[ -L "$LINKED_OVERLAY_DESTINATION" ]]; then
+    pass 'dry run leaves the symlinked overlay skill destination in place'
+else
+    fail 'dry run changes the symlinked overlay skill destination'
+fi
+
+printf '%s\n' 'When: the bootstrap refreshes that old-style overlay for real'
+if ! python3 "$SETUP_SCRIPT" --repo "$LINKED_OVERLAY_REPO" "${LINKED_OVERLAY_FLAGS[@]}" \
+    > "$TMPDIR_ROOT/linked-overlay.log" 2>&1; then
+    printf '%s\n' 'FAIL: linked-overlay bootstrap invocation failed:'
+    cat "$TMPDIR_ROOT/linked-overlay.log"
+    exit 1
+fi
+
+printf '%s\n' 'Then: the link is replaced by a real overlay directory and the target is untouched'
+snapshot_repo "$LINKED_OVERLAY_EXTERNAL" > "$LINKED_OVERLAY_EXTERNAL_AFTER"
+snapshot_repo_modes "$LINKED_OVERLAY_EXTERNAL" > "$LINKED_OVERLAY_EXTERNAL_MODES_AFTER"
+assert_contains "$TMPDIR_ROOT/linked-overlay.log" "replaced skill link $LINKED_OVERLAY_DESTINATION with worktree overlay" 'skill link replacement is logged'
+assert_regular_directory "$LINKED_OVERLAY_DESTINATION" 'replaced skill link becomes a regular directory'
+assert_file "$LINKED_OVERLAY_DESTINATION/SKILL.md" 'replaced skill link holds the overlay skill document'
+assert_contains "$LINKED_OVERLAY_DESTINATION/SKILL.md" 'fixture overlay skill agents/speckit-git-validate' 'replaced skill link holds the checked-in overlay content'
+assert_not_contains "$LINKED_OVERLAY_DESTINATION/SKILL.md" 'external validator skill' 'replaced skill link does not copy the link target'
+assert_contains "$LINKED_OVERLAY_EXTERNAL/SKILL.md" 'external validator skill' 'skill link target keeps its own content'
+if cmp -s "$LINKED_OVERLAY_EXTERNAL_BEFORE" "$LINKED_OVERLAY_EXTERNAL_AFTER"; then
+    pass 'skill link replacement preserves external file paths and hashes'
+else
+    fail 'skill link replacement changes external file paths or hashes'
+fi
+if cmp -s "$LINKED_OVERLAY_EXTERNAL_MODES_BEFORE" "$LINKED_OVERLAY_EXTERNAL_MODES_AFTER"; then
+    pass 'skill link replacement preserves external path types and modes'
+else
+    fail 'skill link replacement changes external path types or modes'
+fi
+assert_contains "$TMPDIR_ROOT/linked-overlay.log" 'done' 'skill link replacement run reaches the end of the bootstrap'
+assert_contains "$LINKED_OVERLAY_DESTINATION/SKILL.md" '<!-- OPENSPEC-SPECKIT-SHAPE:START -->' 'replaced skill link receives the managed shape block'
+assert_contains "$LINKED_OVERLAY_REPO/.claude/skills/speckit-specify/SKILL.md" '<!-- OPENSPEC-SPECKIT-SHAPE:START -->' 'skill link replacement run still writes the other shape blocks'
+
+printf '%s\n' 'When: a marked template meets an installed overlay that already carries the marker'
+MARKED_OVERLAY_REPO="$TMPDIR_ROOT/marked-overlay-repo"
+MARKED_OVERLAY_PROTOCOL_ROOT="$TMPDIR_ROOT/marked-overlay-protocol"
+install_overlay_fixture "$MARKED_OVERLAY_REPO" "$MARKED_TEMPLATE_ROOT"
+customize_installed_overlay "$MARKED_OVERLAY_REPO"
+export AGENT_PROTOCOL_ROOT="$MARKED_OVERLAY_PROTOCOL_ROOT"
+if ! python3 "$SETUP_SCRIPT" --repo "$MARKED_OVERLAY_REPO" "${OVERLAY_REFRESH_FLAGS[@]}" \
+    > "$TMPDIR_ROOT/marked-overlay.log" 2>&1; then
+    printf '%s\n' 'FAIL: marked-overlay bootstrap invocation failed:'
+    cat "$TMPDIR_ROOT/marked-overlay.log"
+    exit 1
+fi
+
+printf '%s\n' 'Then: a compatible marked overlay keeps its repository customizations'
+assert_not_contains "$TMPDIR_ROOT/marked-overlay.log" 'replacing incompatible Spec Kit git extension' 'marked overlay is treated as compatible'
+assert_contains "$MARKED_OVERLAY_REPO/.specify/extensions/git/scripts/bash/git-common.sh" 'repository-specific overlay customization' 'marked overlay keeps its git extension customization'
+assert_contains "$MARKED_OVERLAY_REPO/.specify/shell/select-worktree.sh" 'repository-specific shell customization' 'marked overlay keeps its shell customization'
+assert_contains "$MARKED_OVERLAY_REPO/.claude/skills/speckit-specify/SKILL.md" 'repository-specific overlay skill customization' 'marked overlay keeps its skill customization'
+
+printf '%s\n' 'When: an unmarked template meets an unmarked installed overlay'
+LEGACY_OVERLAY_REPO="$TMPDIR_ROOT/legacy-overlay-repo"
+LEGACY_OVERLAY_PROTOCOL_ROOT="$TMPDIR_ROOT/legacy-overlay-protocol"
+LEGACY_OVERLAY_LINK="$LEGACY_OVERLAY_REPO/.codex/skills/speckit-git-feature"
+install_overlay_fixture "$LEGACY_OVERLAY_REPO" "$UNMARKED_TEMPLATE_ROOT"
+customize_installed_overlay "$LEGACY_OVERLAY_REPO"
+rm -rf "$LEGACY_OVERLAY_LINK"
+ln -s "$LINKED_OVERLAY_EXTERNAL" "$LEGACY_OVERLAY_LINK"
+export AGENT_PROTOCOL_ROOT="$LEGACY_OVERLAY_PROTOCOL_ROOT"
+export SPECKIT_WORKTREE_TEMPLATE_ROOT="$UNMARKED_TEMPLATE_ROOT"
+if ! python3 "$SETUP_SCRIPT" --repo "$LEGACY_OVERLAY_REPO" "${OVERLAY_REFRESH_FLAGS[@]}" \
+    > "$TMPDIR_ROOT/legacy-overlay.log" 2>&1; then
+    printf '%s\n' 'FAIL: legacy-overlay bootstrap invocation failed:'
+    cat "$TMPDIR_ROOT/legacy-overlay.log"
+    exit 1
+fi
+
+printf '%s\n' 'Then: no marker is demanded of an overlay whose templates do not carry one'
+assert_not_contains "$TMPDIR_ROOT/legacy-overlay.log" 'replacing incompatible Spec Kit git extension' 'unmarked templates demand no marker'
+assert_contains "$LEGACY_OVERLAY_REPO/.specify/extensions/git/scripts/bash/git-common.sh" 'repository-specific overlay customization' 'unmarked templates preserve the installed overlay'
+assert_contains "$LEGACY_OVERLAY_REPO/.specify/shell/select-worktree.sh" 'repository-specific shell customization' 'unmarked templates preserve the shell tree'
+assert_regular_directory "$LEGACY_OVERLAY_LINK" 'a symlinked overlay skill is replaced even without a forced refresh'
+assert_contains "$LEGACY_OVERLAY_LINK/SKILL.md" 'fixture overlay skill codex/speckit-git-feature' 'the compatible-overlay replacement installs the overlay skill'
+assert_contains "$LINKED_OVERLAY_EXTERNAL/SKILL.md" 'external validator skill' 'the compatible-overlay replacement leaves the link target untouched'
+
+export HOME="$FIXTURE_HOME"
+export SPECKIT_WORKTREE_TEMPLATE_ROOT="$WORKTREE_TEMPLATE_ROOT"
+export OPSX_COMMAND_TEMPLATE_ROOT="$COMMAND_TEMPLATE_ROOT"
 
 if (( failures == 0 )); then
     printf '%s\n' 'GREEN: OpenSpec bootstrap regression test passed'

--- a/devBenches/devcontainer.test/test-speckit-git-feature.sh
+++ b/devBenches/devcontainer.test/test-speckit-git-feature.sh
@@ -1581,6 +1581,14 @@ initialize_three_leg_fixture() {
     init_plain_repo "$THREE_LEG_ROOT" || return 1
     add_local_submodule "$THREE_LEG_ROOT" "$THREE_LEG_SPEC_ORIGIN" spec || return 1
     add_local_submodule "$THREE_LEG_ROOT" "$THREE_LEG_CODE_ORIGIN" code || return 1
+    # A submodule checkout has its own config under .git/modules/<leg>, so the
+    # identity set on the origin does not reach it; commits made in the leg
+    # worktrees (auto-commit) need it there. CI runners have no global identity.
+    local leg
+    for leg in spec code; do
+        git -C "$THREE_LEG_ROOT/$leg" config user.name 'Spec Kit test' || return 1
+        git -C "$THREE_LEG_ROOT/$leg" config user.email 'spec-kit-test@example.invalid' || return 1
+    done
     write_three_leg_manifest "$THREE_LEG_ROOT/project.yaml" || return 1
     mkdir -p "$THREE_LEG_ROOT/.specify/extensions/git" || return 1
     printf '%s\n' "$config" > "$THREE_LEG_ROOT/.specify/extensions/git/git-config.yml" || return 1

--- a/devBenches/devcontainer.test/test-speckit-git-feature.sh
+++ b/devBenches/devcontainer.test/test-speckit-git-feature.sh
@@ -12,13 +12,14 @@ fi
 FEATURE_SCRIPT="$TEMPLATE_ROOT/specify/extensions/git/scripts/bash/create-new-feature.sh"
 GET_LAST_WORKTREE_SCRIPT="$TEMPLATE_ROOT/specify/extensions/git/scripts/bash/get-last-worktree.sh"
 GIT_COMMON_SCRIPT="$TEMPLATE_ROOT/specify/extensions/git/scripts/bash/git-common.sh"
+AUTO_COMMIT_SCRIPT="$TEMPLATE_ROOT/specify/extensions/git/scripts/bash/auto-commit.sh"
 SELECT_WORKTREE_SCRIPT="$TEMPLATE_ROOT/specify/shell/select-worktree.sh"
 REAL_GIT="$(command -v git)"
 
 FIXTURE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/speckit-git-feature.XXXXXX")"
 trap 'rm -rf "$FIXTURE_ROOT"' EXIT
 
-for required_script in "$FEATURE_SCRIPT" "$GET_LAST_WORKTREE_SCRIPT" "$GIT_COMMON_SCRIPT" "$SELECT_WORKTREE_SCRIPT"; do
+for required_script in "$FEATURE_SCRIPT" "$GET_LAST_WORKTREE_SCRIPT" "$GIT_COMMON_SCRIPT" "$AUTO_COMMIT_SCRIPT" "$SELECT_WORKTREE_SCRIPT"; do
     if [ ! -x "$required_script" ]; then
         printf 'Checked-in Speckit script is missing or not executable: %s\n' "$required_script" >&2
         exit 1
@@ -1458,6 +1459,498 @@ test_explicit_configuration() {
     assert_worktree "$branch" "$worktree_path"
 }
 
+# ---------------------------------------------------------------------------
+# openRepoShape three-leg fixtures and scenarios.
+#
+# A three-leg fixture is three local repositories: two leg "origins" plus an
+# assembly root that mounts them as real submodules at spec/ and code/, with a
+# project.yaml manifest and the root's .specify/ overlay.
+# ---------------------------------------------------------------------------
+
+THREE_LEG_ROOT=''
+THREE_LEG_SPEC_ORIGIN=''
+THREE_LEG_CODE_ORIGIN=''
+
+init_plain_repo() {
+    local repo="$1"
+
+    mkdir -p "$repo" || return 1
+    git init -q -b main "$repo" || return 1
+    git -C "$repo" config user.name 'Spec Kit test' || return 1
+    git -C "$repo" config user.email 'spec-kit-test@example.invalid' || return 1
+    printf 'fixture\n' > "$repo/README.md" || return 1
+    git -C "$repo" add README.md || return 1
+    git -C "$repo" commit -qm 'fixture commit' || return 1
+}
+
+# Newer Git refuses the file:// transport for submodules unless it is allowed
+# explicitly; older Git does not know the option at all.
+add_local_submodule() {
+    local repo="$1"
+    local source="$2"
+    local mount="$3"
+
+    if git -C "$repo" -c protocol.file.allow=always submodule add -q "$source" "$mount" 2>/dev/null; then
+        return 0
+    fi
+    git -C "$repo" submodule add -q "$source" "$mount"
+}
+
+# The manifest mirrors openRepoShape's assembly-root template with dummy
+# values. The comment block and the nested `naming:` records are deliberate:
+# a naive parser would read the commented `role:` lines, or the code leg's
+# nested `role: spec`, and mount the legs in the wrong place.
+write_three_leg_manifest() {
+    local manifest="$1"
+
+    cat > "$manifest" <<'YAML'
+schema_version: 1
+kind: project-manifest
+
+# ===========================================================================
+# project.yaml — this project's SELF-DESCRIBING MANIFEST, and the SOURCE.
+# IT CONFERS NOTHING. `schema`, `legs[].role` and `topic` are descriptive
+# navigation, for example:
+#   - role: spec
+#     path: not-a-real-leg
+# ===========================================================================
+
+id: fixture-project
+name: "Fixture Project"
+
+schema: project-repo-schema
+reference: "dummy reference"
+
+elected_by: "spec-kit-test"
+elected_on: 2026-01-01
+
+topic: xf-project-fixture
+
+visibility: private
+
+tracking_branch: main
+
+shape:
+  repository: dummy/openRepoShape
+  revision_kind: commit
+  commit: "0000000000000000000000000000000000000000"
+  digest_algorithm: sha256
+  digest_definition: sorted-ls-tree-r-v1
+  digests:
+    tree_sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+
+neutral_product_pins: []
+
+legs:
+  - role: assembly
+    repository: dummy/fixture-project
+    path: "."
+    naming:
+      form: project-leg
+      role: assembly
+      also_matches: []
+  - role: spec
+    repository: dummy/fixture-project-spec
+    path: spec
+    naming:
+      form: project-leg
+      role: spec
+      also_matches: []
+  - role: code
+    repository: dummy/fixture-project-code
+    path: code
+    naming:
+      form: project-leg
+      role: spec
+      also_matches: []
+YAML
+}
+
+initialize_three_leg_fixture() {
+    local name="$1"
+    local config="$2"
+    local base="$FIXTURE_ROOT/$name"
+
+    THREE_LEG_ROOT="$base/root"
+    THREE_LEG_SPEC_ORIGIN="$base/spec-origin"
+    THREE_LEG_CODE_ORIGIN="$base/code-origin"
+
+    mkdir -p "$base" || return 1
+    init_plain_repo "$THREE_LEG_SPEC_ORIGIN" || return 1
+    init_plain_repo "$THREE_LEG_CODE_ORIGIN" || return 1
+    init_plain_repo "$THREE_LEG_ROOT" || return 1
+    add_local_submodule "$THREE_LEG_ROOT" "$THREE_LEG_SPEC_ORIGIN" spec || return 1
+    add_local_submodule "$THREE_LEG_ROOT" "$THREE_LEG_CODE_ORIGIN" code || return 1
+    write_three_leg_manifest "$THREE_LEG_ROOT/project.yaml" || return 1
+    mkdir -p "$THREE_LEG_ROOT/.specify/extensions/git" || return 1
+    printf '%s\n' "$config" > "$THREE_LEG_ROOT/.specify/extensions/git/git-config.yml" || return 1
+    printf '/worktrees/\n' > "$THREE_LEG_ROOT/.gitignore" || return 1
+    git -C "$THREE_LEG_ROOT" add -A || return 1
+    git -C "$THREE_LEG_ROOT" commit -qm 'three-leg fixture' || return 1
+}
+
+install_three_leg_scripts() {
+    local root="$1"
+    local script_dir="$root/.specify/extensions/git/scripts/bash"
+
+    mkdir -p "$script_dir" "$root/.specify/shell" || return 1
+    cp "$GET_LAST_WORKTREE_SCRIPT" "$script_dir/get-last-worktree.sh" || return 1
+    cp "$GIT_COMMON_SCRIPT" "$script_dir/git-common.sh" || return 1
+    cp "$AUTO_COMMIT_SCRIPT" "$script_dir/auto-commit.sh" || return 1
+    cp "$SELECT_WORKTREE_SCRIPT" "$root/.specify/shell/select-worktree.sh" || return 1
+    chmod +x \
+        "$script_dir/get-last-worktree.sh" \
+        "$script_dir/auto-commit.sh" \
+        "$root/.specify/shell/select-worktree.sh"
+}
+
+invoke_three_leg_feature() {
+    local root="$1"
+    local description="$2"
+    local stderr_file="$3"
+    shift 3
+
+    FEATURE_OUTPUT=''
+    FEATURE_OUTPUT="$(cd "$root" && bash "$FEATURE_SCRIPT" --json "$@" "$description" 2>"$stderr_file")" || return 1
+}
+
+leg_branches() {
+    git -C "$1" for-each-ref --format='%(refname:short)' refs/heads | sort | tr '\n' ' '
+}
+
+worktree_record_count() {
+    git -C "$1" worktree list --porcelain | grep -c '^worktree ' || true
+}
+
+assert_no_three_leg_side_effects() {
+    local root="$1"
+    local label="$2"
+
+    if [ -e "$root/worktrees" ]; then
+        printf 'assertion failed: %s created %s\n' "$label" "$root/worktrees" >&2
+        return 1
+    fi
+    if [ -e "$root/.specify/feature.json" ]; then
+        printf 'assertion failed: %s wrote .specify/feature.json\n' "$label" >&2
+        return 1
+    fi
+    assert_equal 'main ' "$(leg_branches "$root/spec")" "$label spec leg branches" || return 1
+    assert_equal 'main ' "$(leg_branches "$root/code")" "$label code leg branches" || return 1
+    assert_equal 'main ' "$(leg_branches "$root")" "$label root branches"
+}
+
+THREE_LEG_CONFIG=$'checkout_mode: worktree\nbase_branch: main\nworktree_root: worktrees'
+
+test_three_leg_creates_both_leg_worktrees() {
+    local stderr_file="$FIXTURE_ROOT/three-leg-create.stderr"
+    local root branch worktree_path spec_worktree code_worktree feature_dir
+    local repo_shape project_root feature_json
+
+    # Given: a three-leg root whose code leg already carries a 002 branch.
+    initialize_three_leg_fixture 'three-leg-create' "$THREE_LEG_CONFIG" || return 1
+    root="$THREE_LEG_ROOT"
+    git -C "$root/code" branch 002-existing || return 1
+
+    # When: the feature hook runs from the assembly root.
+    if ! invoke_three_leg_feature "$root" 'Add routing core' "$stderr_file"; then
+        printf 'three-leg invocation failed: %s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+
+    # Then: numbering crosses both legs and the JSON carries the shape keys.
+    branch="$(json_field "$FEATURE_OUTPUT" BRANCH_NAME)" || return 1
+    repo_shape="$(json_field "$FEATURE_OUTPUT" REPO_SHAPE)" || return 1
+    project_root="$(json_field "$FEATURE_OUTPUT" PROJECT_ROOT)" || return 1
+    worktree_path="$(json_field "$FEATURE_OUTPUT" WORKTREE_PATH)" || return 1
+    spec_worktree="$(json_field "$FEATURE_OUTPUT" SPEC_WORKTREE_PATH)" || return 1
+    code_worktree="$(json_field "$FEATURE_OUTPUT" CODE_WORKTREE_PATH)" || return 1
+    feature_dir="$(json_field "$FEATURE_OUTPUT" FEATURE_DIR)" || return 1
+
+    assert_equal '003-routing-core' "$branch" 'three-leg branch number across legs' || return 1
+    assert_equal 'three-leg' "$repo_shape" 'three-leg REPO_SHAPE' || return 1
+    assert_equal "$root" "$project_root" 'three-leg PROJECT_ROOT' || return 1
+    assert_equal "$root/worktrees/003-routing-core" "$worktree_path" 'three-leg WORKTREE_PATH' || return 1
+    assert_equal "$worktree_path/spec" "$spec_worktree" 'three-leg SPEC_WORKTREE_PATH' || return 1
+    assert_equal "$worktree_path/code" "$code_worktree" 'three-leg CODE_WORKTREE_PATH' || return 1
+    assert_equal "$spec_worktree/specs/003-routing-core" "$feature_dir" 'three-leg FEATURE_DIR' || return 1
+
+    # Then: both legs hold a real worktree on the same branch.
+    assert_worktree '003-routing-core' "$spec_worktree" || return 1
+    assert_worktree '003-routing-core' "$code_worktree" || return 1
+    if [ ! -d "$feature_dir" ]; then
+        printf 'assertion failed: FEATURE_DIR was not created: %s\n' "$feature_dir" >&2
+        return 1
+    fi
+
+    # Then: the assembly root gets no branch and no worktree of its own.
+    assert_equal 'main ' "$(leg_branches "$root")" 'three-leg root branches' || return 1
+    assert_equal '1' "$(worktree_record_count "$root")" 'three-leg root worktree records' || return 1
+
+    # Then: feature.json at the ROOT points into the spec worktree.
+    feature_json="$(<"$root/.specify/feature.json")" || return 1
+    assert_equal 'worktrees/003-routing-core/spec/specs/003-routing-core' \
+        "$(json_field "$feature_json" feature_directory)" 'three-leg feature.json' || return 1
+
+    # Then: the stderr hints name both environment variables.
+    if ! grep -Fq '# To persist: export SPECIFY_FEATURE=003-routing-core' "$stderr_file"; then
+        printf 'assertion failed: missing SPECIFY_FEATURE hint\n%s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    if ! grep -Fq '#             export SPECIFY_FEATURE_DIRECTORY=worktrees/003-routing-core/spec/specs/003-routing-core' "$stderr_file"; then
+        printf 'assertion failed: missing SPECIFY_FEATURE_DIRECTORY hint\n%s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+}
+
+test_three_leg_dry_run_creates_nothing() {
+    local stderr_file="$FIXTURE_ROOT/three-leg-dry-run.stderr"
+    local root
+
+    # Given: a clean three-leg root.
+    initialize_three_leg_fixture 'three-leg-dry-run' "$THREE_LEG_CONFIG" || return 1
+    root="$THREE_LEG_ROOT"
+
+    # When: the hook runs in dry-run mode.
+    if ! invoke_three_leg_feature "$root" 'Add routing core' "$stderr_file" --dry-run; then
+        printf 'three-leg dry-run invocation failed: %s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+
+    # Then: the shape and paths are reported but nothing is created.
+    assert_equal 'three-leg' "$(json_field "$FEATURE_OUTPUT" REPO_SHAPE)" 'dry-run REPO_SHAPE' || return 1
+    assert_equal '001-routing-core' "$(json_field "$FEATURE_OUTPUT" BRANCH_NAME)" 'dry-run branch' || return 1
+    assert_equal "$root/worktrees/001-routing-core/spec/specs/001-routing-core" \
+        "$(json_field "$FEATURE_OUTPUT" FEATURE_DIR)" 'dry-run FEATURE_DIR' || return 1
+    assert_no_three_leg_side_effects "$root" 'three-leg dry run'
+}
+
+test_three_leg_refuses_branch_checkout_mode() {
+    local stderr_file="$FIXTURE_ROOT/three-leg-branch-mode.stderr"
+    local root
+
+    # Given: a three-leg root configured for branch mode.
+    initialize_three_leg_fixture 'three-leg-branch-mode' $'checkout_mode: branch\nbase_branch: main' || return 1
+    root="$THREE_LEG_ROOT"
+
+    # When: the hook runs.
+    if invoke_three_leg_feature "$root" 'Add routing core' "$stderr_file"; then
+        printf 'assertion failed: branch checkout_mode was accepted in a three-leg project\n' >&2
+        return 1
+    fi
+
+    # Then: the refusal names checkout_mode and nothing was created.
+    if ! grep -Fq 'checkout_mode: worktree' "$stderr_file"; then
+        printf 'assertion failed: refusal does not name checkout_mode\n%s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    assert_no_three_leg_side_effects "$root" 'three-leg branch mode refusal'
+}
+
+test_three_leg_refuses_uninitialised_leg() {
+    local stderr_file="$FIXTURE_ROOT/three-leg-empty-leg.stderr"
+    local root
+
+    # Given: the code leg submodule was never fetched (an empty mount point).
+    initialize_three_leg_fixture 'three-leg-empty-leg' "$THREE_LEG_CONFIG" || return 1
+    root="$THREE_LEG_ROOT"
+    rm -rf "$root/code" || return 1
+    mkdir -p "$root/code" || return 1
+
+    # When: the hook runs.
+    if invoke_three_leg_feature "$root" 'Add routing core' "$stderr_file"; then
+        printf 'assertion failed: an uninitialised leg was accepted\n' >&2
+        return 1
+    fi
+
+    # Then: the refusal tells the user how to fetch the submodule.
+    if ! grep -Fq 'git submodule update --init' "$stderr_file"; then
+        printf 'assertion failed: refusal does not name git submodule update --init\n%s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    if [ -e "$root/worktrees" ] || [ -e "$root/.specify/feature.json" ]; then
+        printf 'assertion failed: uninitialised leg refusal still created state\n' >&2
+        return 1
+    fi
+    assert_equal 'main ' "$(leg_branches "$root/spec")" 'uninitialised leg refusal spec branches'
+}
+
+test_three_leg_refuses_existing_feature_directory() {
+    local stderr_file="$FIXTURE_ROOT/three-leg-existing-dir.stderr"
+    local root
+
+    # Given: the feature directory the hook would use already exists.
+    initialize_three_leg_fixture 'three-leg-existing-dir' "$THREE_LEG_CONFIG" || return 1
+    root="$THREE_LEG_ROOT"
+    mkdir -p "$root/worktrees/001-routing-core" || return 1
+
+    # When: the hook runs.
+    if invoke_three_leg_feature "$root" 'Add routing core' "$stderr_file"; then
+        printf 'assertion failed: an existing feature directory was accepted\n' >&2
+        return 1
+    fi
+
+    # Then: it refuses without creating branches in either leg.
+    if ! grep -Fq "Feature worktree directory '$root/worktrees/001-routing-core' already exists" "$stderr_file"; then
+        printf 'assertion failed: refusal does not name the existing feature directory\n%s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    assert_equal 'main ' "$(leg_branches "$root/spec")" 'existing dir refusal spec branches' || return 1
+    assert_equal 'main ' "$(leg_branches "$root/code")" 'existing dir refusal code branches'
+}
+
+install_code_worktree_failure_shim() {
+    local shim_dir="$1"
+
+    mkdir -p "$shim_dir" || return 1
+    cat > "$shim_dir/git" <<'SH'
+#!/usr/bin/env bash
+is_worktree=false
+is_add=false
+touches_code_leg=false
+for argument in "$@"; do
+    case "$argument" in
+        worktree) is_worktree=true ;;
+        add) is_add=true ;;
+        */code|*/code/*) touches_code_leg=true ;;
+    esac
+done
+
+if $is_worktree && $is_add && $touches_code_leg; then
+    printf 'forced code leg worktree failure\n' >&2
+    exit 128
+fi
+
+exec "$SPECKIT_TEST_REAL_GIT" "$@"
+SH
+    chmod +x "$shim_dir/git"
+}
+
+test_three_leg_rolls_back_when_code_leg_fails() {
+    local stderr_file="$FIXTURE_ROOT/three-leg-rollback.stderr"
+    local shim_dir="$FIXTURE_ROOT/three-leg-rollback-bin"
+    local root
+
+    # Given: adding the code leg worktree is forced to fail.
+    initialize_three_leg_fixture 'three-leg-rollback' "$THREE_LEG_CONFIG" || return 1
+    root="$THREE_LEG_ROOT"
+    install_code_worktree_failure_shim "$shim_dir" || return 1
+
+    # When: the hook runs with the failing shim first on PATH.
+    if (cd "$root" && PATH="$shim_dir:$PATH" SPECKIT_TEST_REAL_GIT="$REAL_GIT" \
+        bash "$FEATURE_SCRIPT" --json 'Add routing core' >/dev/null 2>"$stderr_file"); then
+        printf 'assertion failed: the hook succeeded although the code leg failed\n' >&2
+        return 1
+    fi
+
+    # Then: the spec leg worktree and branch are rolled back.
+    if ! grep -Fq 'Rolling back the spec leg worktree' "$stderr_file"; then
+        printf 'assertion failed: no rollback message\n%s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    assert_equal 'main ' "$(leg_branches "$root/spec")" 'rollback spec leg branches' || return 1
+    assert_equal 'main ' "$(leg_branches "$root/code")" 'rollback code leg branches' || return 1
+    assert_equal '1' "$(worktree_record_count "$root/spec")" 'rollback spec worktree records' || return 1
+    if [ -e "$root/worktrees/001-routing-core" ]; then
+        printf 'assertion failed: rollback left the feature directory behind\n' >&2
+        return 1
+    fi
+}
+
+test_three_leg_get_last_worktree_reports_feature() {
+    local stderr_file="$FIXTURE_ROOT/three-leg-get-last.stderr"
+    local root output list_output
+
+    # Given: a created three-leg feature and the discovery scripts installed.
+    initialize_three_leg_fixture 'three-leg-get-last' "$THREE_LEG_CONFIG" || return 1
+    root="$THREE_LEG_ROOT"
+    install_three_leg_scripts "$root" || return 1
+    if ! invoke_three_leg_feature "$root" 'Add routing core' "$stderr_file"; then
+        printf 'three-leg invocation failed: %s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+
+    # When: discovery runs from the assembly root.
+    output="$(cd "$root" && bash .specify/extensions/git/scripts/bash/get-last-worktree.sh --json)" || return 1
+
+    # Then: it reports the feature directory and both leg worktrees.
+    assert_equal 'three-leg' "$(json_field "$output" REPO_SHAPE)" 'get-last REPO_SHAPE' || return 1
+    assert_equal '001-routing-core' "$(json_field "$output" BRANCH_NAME)" 'get-last branch' || return 1
+    assert_equal "$root/worktrees/001-routing-core" "$(json_field "$output" WORKTREE_PATH)" 'get-last WORKTREE_PATH' || return 1
+    assert_equal "$root/worktrees/001-routing-core/spec" "$(json_field "$output" SPEC_WORKTREE_PATH)" 'get-last SPEC_WORKTREE_PATH' || return 1
+    assert_equal "$root/worktrees/001-routing-core/code" "$(json_field "$output" CODE_WORKTREE_PATH)" 'get-last CODE_WORKTREE_PATH' || return 1
+    assert_equal "$root/worktrees/001-routing-core/spec/specs/001-routing-core" \
+        "$(json_field "$output" FEATURE_DIR)" 'get-last FEATURE_DIR' || return 1
+    assert_equal "$root" "$(json_field "$output" PROJECT_ROOT)" 'get-last PROJECT_ROOT' || return 1
+
+    # Then: the selector lists the same feature directory, not a leg checkout.
+    list_output="$(cd "$root" && bash .specify/shell/select-worktree.sh --list)" || return 1
+    if ! printf '%s\n' "$list_output" | grep -Fq "$root/worktrees/001-routing-core"; then
+        printf 'assertion failed: selector did not list the feature directory\n%s\n' "$list_output" >&2
+        return 1
+    fi
+    if printf '%s\n' "$list_output" | grep -Fq "$root/spec"; then
+        printf 'assertion failed: selector listed the pinned spec leg\n%s\n' "$list_output" >&2
+        return 1
+    fi
+}
+
+test_three_leg_auto_commit_commits_both_legs_only() {
+    local stderr_file="$FIXTURE_ROOT/three-leg-auto-commit.stderr"
+    local config=$'checkout_mode: worktree\nbase_branch: main\nworktree_root: worktrees\nauto_commit:\n  default: true'
+    local root feature_dir root_head_before spec_head_before code_head_before
+
+    # Given: a created feature with pending edits in both leg worktrees.
+    initialize_three_leg_fixture 'three-leg-auto-commit' "$config" || return 1
+    root="$THREE_LEG_ROOT"
+    install_three_leg_scripts "$root" || return 1
+    if ! invoke_three_leg_feature "$root" 'Add routing core' "$stderr_file"; then
+        printf 'three-leg invocation failed: %s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    feature_dir="$root/worktrees/001-routing-core"
+    printf 'spec\n' > "$feature_dir/spec/specs/001-routing-core/spec.md" || return 1
+    printf 'code\n' > "$feature_dir/code/implementation.txt" || return 1
+    root_head_before="$(git -C "$root" rev-parse HEAD)" || return 1
+    spec_head_before="$(git -C "$feature_dir/spec" rev-parse HEAD)" || return 1
+    code_head_before="$(git -C "$feature_dir/code" rev-parse HEAD)" || return 1
+
+    # When: the auto-commit hook runs from the assembly root.
+    if ! (cd "$root" && bash .specify/extensions/git/scripts/bash/auto-commit.sh after_specify 2>"$stderr_file"); then
+        printf 'three-leg auto-commit failed: %s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+
+    # Then: both leg worktrees advanced and the assembly root did not.
+    if [ "$spec_head_before" = "$(git -C "$feature_dir/spec" rev-parse HEAD)" ]; then
+        printf 'assertion failed: the spec worktree was not committed\n%s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    if [ "$code_head_before" = "$(git -C "$feature_dir/code" rev-parse HEAD)" ]; then
+        printf 'assertion failed: the code worktree was not committed\n%s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    assert_equal "$root_head_before" "$(git -C "$root" rev-parse HEAD)" 'auto-commit left the root HEAD alone' || return 1
+    assert_equal '001-routing-core' "$(git -C "$feature_dir/spec" branch --show-current)" 'auto-commit spec branch' || return 1
+    assert_equal '001-routing-core' "$(git -C "$feature_dir/code" branch --show-current)" 'auto-commit code branch' || return 1
+
+    # When: no feature is selected any more.
+    rm -f "$root/.specify/feature.json" || return 1
+    printf 'spec again\n' >> "$feature_dir/spec/specs/001-routing-core/spec.md" || return 1
+    spec_head_before="$(git -C "$feature_dir/spec" rev-parse HEAD)" || return 1
+    if ! (cd "$root" && env -u SPECIFY_FEATURE bash .specify/extensions/git/scripts/bash/auto-commit.sh after_plan 2>"$stderr_file"); then
+        printf 'three-leg auto-commit without a feature failed: %s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+
+    # Then: it says so and commits nothing.
+    if ! grep -Fq 'No Speckit feature is selected' "$stderr_file"; then
+        printf 'assertion failed: missing no-feature message\n%s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    assert_equal "$spec_head_before" "$(git -C "$feature_dir/spec" rev-parse HEAD)" 'no-feature auto-commit left the spec worktree alone' || return 1
+    assert_equal "$root_head_before" "$(git -C "$root" rev-parse HEAD)" 'no-feature auto-commit left the root alone'
+}
+
 failures=0
 run_scenario() {
     local name="$1"
@@ -1495,6 +1988,14 @@ run_scenario 'legacy line porcelain rejects directory and forged candidates with
 run_scenario 'Git discovery failures are not reported as zero records' test_discovery_failure_is_not_reported_as_zero_records
 run_scenario 'fallback root detection ignores decoy directories' test_fallback_root_ignores_decoy_directories
 run_scenario 'explicit decoy-only root reports no registered worktrees' test_explicit_decoy_only_root_reports_no_worktrees
+run_scenario 'three-leg feature creates a worktree in both legs and none at the root' test_three_leg_creates_both_leg_worktrees
+run_scenario 'three-leg dry run creates nothing' test_three_leg_dry_run_creates_nothing
+run_scenario 'three-leg refuses branch checkout mode' test_three_leg_refuses_branch_checkout_mode
+run_scenario 'three-leg refuses an uninitialised leg' test_three_leg_refuses_uninitialised_leg
+run_scenario 'three-leg refuses an existing feature directory' test_three_leg_refuses_existing_feature_directory
+run_scenario 'three-leg rolls back the spec leg when the code leg fails' test_three_leg_rolls_back_when_code_leg_fails
+run_scenario 'three-leg discovery reports the feature and both leg worktrees' test_three_leg_get_last_worktree_reports_feature
+run_scenario 'three-leg auto-commit commits both legs and never the root' test_three_leg_auto_commit_commits_both_legs_only
 
 if [ "$failures" -ne 0 ]; then
     printf 'RED: Speckit Git feature behavior tests failed: %d scenario(s)\n' "$failures" >&2


### PR DESCRIPTION
Lane: inkrouter-2 (InkRouter-2)
Claim: https://github.com/opensoft/workBenches/issues/22#issuecomment-5592974013

## Summary

- `setup-openspeckit` detects an openRepoShape three-leg project from `project.yaml` (`--shape auto|on|off`), writes OpenSpec scaffolding into the spec leg and everything else at the assembly root, defaults `worktree_root` to `worktrees`, ignores `/worktrees/` in the root, appends a shape section to the managed agent block while preserving the `AGENTS-shape.md` first line, prefixes dry-run output with `[root]`/`[spec]`, and ends with the two-commit note.
- It upserts a managed `OPENSPEC-SPECKIT-SHAPE` block into every Speckit and OpenSpec skill and opsx command file (repo-local and user-global), refreshes overlays lacking the `speckit-overlay-shape` marker, replaces symlinked overlay skill directories with real copies, and embeds the current protocol texts.
- The worktree overlay's bash scripts gain `load_repo_shape` and a three-leg mode: the feature hook creates the `NNN-feature` branch in both legs from their fetched base, adds paired worktrees at `worktrees/<NNN>/{spec,code}`, numbers across both legs, writes the root's `.specify/feature.json`, and never touches the root repository. Discovery, the `ct` launchers, auto-commit, and initialize-repo follow. Single-repository behaviour is unchanged.
- opsx command and skill templates and the three overlay skills carry the shape block and no longer instruct agents to write code from OpenSpec tasks.

Contract: `~/.agents/protocols/openspec-speckit-workflow.md` ("Repository Shape", "Worktree Rules") and `~/.agents/protocols/project-agent-bootstrap.md` ("Worktree Layout", "The Speckit Worktree Overlay in a Three-leg Root").

## Test plan

- [x] `test-openspeckit-bootstrap.sh`: GREEN, 742 pass (new three-leg fixtures, `--shape`, first-line invariant, spec-leg refusals, family holder, shape blocks, overlay refresh, symlinked skill replacement)
- [x] `test-speckit-git-feature.sh`: GREEN, eight new three-leg scenarios plus all existing
- [x] `test-speckit-git-compat.sh` and `test-ct-launchers.sh`: GREEN
- [x] Dry run against a real converted three-leg root (MedxEHR) and an end-to-end smoke (bootstrap, feature hook, core `check-prerequisites.sh` resolution) on a throwaway three-leg fixture

Known gap: the overlay's PowerShell scripts have no three-leg logic yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PB38NpUuypicGg5TgyFQir