### PR TITLE
Add a fail-closed WSL relay watchdog

### DIFF
--- a/docs/wsl-relay-watchdog.md
+++ b/docs/wsl-relay-watchdog.md
@@ -1,0 +1,93 @@
+# WSL Relay Watchdog
+
+The watchdog prevents Wave relay exhaustion by removing only relays that repeatedly satisfy the complete strict orphan predicate. It does not stop or restart WSL.
+
+## Safety Boundary
+
+A process is eligible only when all of these remain true:
+
+- `/proc/<pid>/comm` is exactly `Relay`.
+- Parent PID is exactly 1.
+- The command line is exactly the single argument `/init`.
+- The kernel child list is empty.
+- The process is at least 300 seconds old.
+- The same PID and start-time identity passes three scans, 30 seconds apart.
+- The identity and complete predicate pass again immediately before each signal.
+
+Signals use a Linux pidfd so PID reuse cannot redirect them. Named `Relay(<pid>)` processes, `SessionLeader` processes, relays with children, recent relays, and processes with ambiguous metadata are excluded.
+
+## Repository Dry Run
+
+From the feature checkout:
+
+```bash
+python3 scripts/wsl-relay-watchdog/wsl_relay_watchdog.py scan
+```
+
+This command never sends signals. Its JSON output includes strict, named-relay, and SessionLeader counts and identities without environment data or unrelated command lines.
+
+## Install Inactive
+
+Run from a WSL shell at the repository root. `sudo` elevates only the installer
+and does not place a password or token in command arguments:
+
+```bash
+sudo python3 scripts/wsl-relay-watchdog/install.py install --inactive
+```
+
+The installer:
+
+- Refuses a pre-existing unmanaged `[boot] command`.
+- Preserves `systemd=false` and every unrelated `/etc/wsl.conf` setting.
+- Installs root-owned files under `/usr/local`.
+- Creates a timestamped `/etc/wsl.conf` backup under `/var/lib/wsl-relay-watchdog/backups`.
+- Registers `/usr/local/sbin/wsl-relay-watchdog-boot` and starts the watchdog immediately without restarting WSL.
+
+## Status And Scan
+
+```bash
+/usr/local/sbin/wsl-relay-watchdog status
+/usr/local/sbin/wsl-relay-watchdog scan
+```
+
+`status` verifies the daemon PID plus start-time identity instead of trusting a stale PID file.
+
+The bounded log is `/var/log/wsl-relay-watchdog/watchdog.log`. Runtime identity and status files are under `/run/wsl-relay-watchdog`.
+
+## Activate
+
+After the inactive scan proves that named relays and SessionLeaders are protected:
+
+```bash
+sudo python3 scripts/wsl-relay-watchdog/install.py install --active
+```
+
+Reinstallation stops only the verified watchdog daemon, updates the root-owned configuration, and starts a fresh active daemon. It does not immediately signal a relay: candidates must first pass three consecutive observations.
+
+## Defaults
+
+The root-owned `/etc/wsl-relay-watchdog.conf` file uses these validated bounds:
+
+| Setting | Default | Accepted range |
+| --- | ---: | ---: |
+| `MIN_AGE_SECONDS` | 300 | 60-86400 |
+| `CONFIRMATIONS` | 3 | 2-20 |
+| `INTERVAL_SECONDS` | 30 | 5-3600 |
+| `BATCH_LIMIT` | 32 | 1-128 |
+| `TERM_GRACE_SECONDS` | 3 | 1-30 |
+| `LOG_MAX_BYTES` | 1048576 | 65536-10485760 |
+| `LOG_BACKUPS` | 3 | 1-10 |
+
+Unknown keys and out-of-range values make the watchdog refuse active operation.
+
+## Rollback
+
+```bash
+sudo python3 scripts/wsl-relay-watchdog/install.py uninstall
+```
+
+Rollback verifies and stops only the watchdog PID/start-time identity, removes only the managed boot command and installed files, and preserves unrelated WSL configuration. Logs and timestamped backups remain for audit. It never invokes `wsl --shutdown`.
+
+## Boot-Command Conflict
+
+If installation reports a conflicting `[boot] command`, do not overwrite it. Inspect `/etc/wsl.conf` and decide how to compose the existing boot action with the watchdog launcher; the installer deliberately makes no changes in this state.

--- a/docs/wsl-relay-watchdog.md
+++ b/docs/wsl-relay-watchdog.md
@@ -9,7 +9,7 @@ A process is eligible only when all of these remain true:
 - `/proc/<pid>/comm` is exactly `Relay`.
 - Parent PID is exactly 1.
 - The command line is exactly the single argument `/init`.
-- The kernel child list is empty.
+- The kernel child lists aggregated across every relay thread are empty.
 - The process is at least 300 seconds old.
 - The same PID and start-time identity passes three scans, 30 seconds apart.
 - The identity and complete predicate pass again immediately before each signal.
@@ -71,7 +71,7 @@ The root-owned `/etc/wsl-relay-watchdog.conf` file uses these validated bounds:
 | Setting | Default | Accepted range |
 | --- | ---: | ---: |
 | `MIN_AGE_SECONDS` | 300 | 60-86400 |
-| `CONFIRMATIONS` | 3 | 2-20 |
+| `CONFIRMATIONS` | 3 | 3-20 |
 | `INTERVAL_SECONDS` | 30 | 5-3600 |
 | `BATCH_LIMIT` | 32 | 1-128 |
 | `TERM_GRACE_SECONDS` | 3 | 1-30 |

--- a/openspec/changes/add-wsl-relay-watchdog/.openspec.yaml
+++ b/openspec/changes/add-wsl-relay-watchdog/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-06

--- a/openspec/changes/add-wsl-relay-watchdog/design.md
+++ b/openspec/changes/add-wsl-relay-watchdog/design.md
@@ -25,6 +25,10 @@ The installer adds a root-owned Python engine and wrappers under `/usr/local`. T
 Installer lifecycle operations also refuse a held singleton lock without
 verifiable PID metadata, clear stale status before startup, and restore an
 originally absent `wsl.conf` to absence on uninstall.
+Immediately before each signal, the cleanup engine reads only the target
+process and all of its task children instead of relying on a cached full-table
+scan. Replacement startup waits for both verified process exit and singleton
+lock release after TERM or KILL.
 
 Systemd was rejected because it is intentionally disabled and would require a WSL restart. Windows polling was rejected because it would repeatedly cross the same WSL session boundary that becomes exhausted. Cron is not guaranteed to run, and Wave-launcher edits would not protect other creation paths.
 

--- a/openspec/changes/add-wsl-relay-watchdog/design.md
+++ b/openspec/changes/add-wsl-relay-watchdog/design.md
@@ -21,7 +21,7 @@ Wave can leave hundreds of root-owned processes with the narrow signature `Relay
 
 ### WSL boot watchdog
 
-The installer adds a root-owned Python engine and wrappers under `/usr/local`. The existing `[boot]` section registers a short detached launcher, and `flock` prevents duplicate daemon instances. The installer preserves all settings, backs up `wsl.conf`, refuses unmanaged boot-command conflicts, starts immediately, and never restarts WSL.
+The installer adds a root-owned Python engine and wrappers under `/usr/local`. The existing `[boot]` section registers a short detached launcher, and `flock` prevents duplicate daemon instances. The installer preserves all settings, backs up `wsl.conf`, refuses unmanaged boot-command conflicts and occupied reserved paths, records digests for every managed file, starts immediately, and never restarts WSL.
 
 Systemd was rejected because it is intentionally disabled and would require a WSL restart. Windows polling was rejected because it would repeatedly cross the same WSL session boundary that becomes exhausted. Cron is not guaranteed to run, and Wave-launcher edits would not protect other creation paths.
 

--- a/openspec/changes/add-wsl-relay-watchdog/design.md
+++ b/openspec/changes/add-wsl-relay-watchdog/design.md
@@ -29,6 +29,9 @@ Immediately before each signal, the cleanup engine reads only the target
 process and all of its task children instead of relying on a cached full-table
 scan. Replacement startup waits for both verified process exit and singleton
 lock release after TERM or KILL.
+Procfs names and command lines are validated as raw bytes with their exact
+newline and NUL delimiters, and stale identity metadata is never discarded
+while the singleton lock is held.
 
 Systemd was rejected because it is intentionally disabled and would require a WSL restart. Windows polling was rejected because it would repeatedly cross the same WSL session boundary that becomes exhausted. Cron is not guaranteed to run, and Wave-launcher edits would not protect other creation paths.
 

--- a/openspec/changes/add-wsl-relay-watchdog/design.md
+++ b/openspec/changes/add-wsl-relay-watchdog/design.md
@@ -27,7 +27,7 @@ Systemd was rejected because it is intentionally disabled and would require a WS
 
 ### Exact fail-closed classification
 
-A strict candidate requires exact `Relay` process name, PPID 1, a single `/init` argument, an empty kernel child list, and at least 300 seconds of age. Missing or malformed metadata makes the process ineligible. Exact naming excludes `Relay(<pid>)` and `SessionLeader`.
+A strict candidate requires exact `Relay` process name, PPID 1, a single `/init` argument, empty kernel child lists across every relay thread, and at least 300 seconds of age. Missing or malformed metadata makes the process ineligible. Exact naming excludes `Relay(<pid>)` and `SessionLeader`.
 
 ### Consecutive identity confirmation
 

--- a/openspec/changes/add-wsl-relay-watchdog/design.md
+++ b/openspec/changes/add-wsl-relay-watchdog/design.md
@@ -22,6 +22,9 @@ Wave can leave hundreds of root-owned processes with the narrow signature `Relay
 ### WSL boot watchdog
 
 The installer adds a root-owned Python engine and wrappers under `/usr/local`. The existing `[boot]` section registers a short detached launcher, and `flock` prevents duplicate daemon instances. The installer preserves all settings, backs up `wsl.conf`, refuses unmanaged boot-command conflicts and occupied reserved paths, records digests for every managed file, starts immediately, and never restarts WSL.
+Installer lifecycle operations also refuse a held singleton lock without
+verifiable PID metadata, clear stale status before startup, and restore an
+originally absent `wsl.conf` to absence on uninstall.
 
 Systemd was rejected because it is intentionally disabled and would require a WSL restart. Windows polling was rejected because it would repeatedly cross the same WSL session boundary that becomes exhausted. Cron is not guaranteed to run, and Wave-launcher edits would not protect other creation paths.
 

--- a/openspec/changes/add-wsl-relay-watchdog/design.md
+++ b/openspec/changes/add-wsl-relay-watchdog/design.md
@@ -1,0 +1,62 @@
+## Context
+
+Wave can leave hundreds of root-owned processes with the narrow signature `Relay`, parent PID 1, exact `/init` command line, no children, and substantial age. Named `Relay(<pid>)` processes attached to live `SessionLeader` processes are valid and must remain untouched. Ubuntu 24.04 intentionally has `systemd=false`, and the root checkout contains unrelated work that this change must not overlap.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Prevent strict orphan relays from exhausting WSL session creation.
+- Preserve every live, recent, named, child-bearing, or ambiguous relay.
+- Run with root authority without enabling systemd or stopping WSL.
+- Provide bounded logs, verified status, dry-run qualification, and reversible installation.
+
+**Non-Goals:**
+
+- Restarting or reconfiguring WSL itself.
+- Editing Wave launchers or Docker bench lifecycle scripts.
+- Killing generic `/init`, parent-PID-1, or name-matched processes.
+
+## Decisions
+
+### WSL boot watchdog
+
+The installer adds a root-owned Python engine and wrappers under `/usr/local`. The existing `[boot]` section registers a short detached launcher, and `flock` prevents duplicate daemon instances. The installer preserves all settings, backs up `wsl.conf`, refuses unmanaged boot-command conflicts, starts immediately, and never restarts WSL.
+
+Systemd was rejected because it is intentionally disabled and would require a WSL restart. Windows polling was rejected because it would repeatedly cross the same WSL session boundary that becomes exhausted. Cron is not guaranteed to run, and Wave-launcher edits would not protect other creation paths.
+
+### Exact fail-closed classification
+
+A strict candidate requires exact `Relay` process name, PPID 1, a single `/init` argument, an empty kernel child list, and at least 300 seconds of age. Missing or malformed metadata makes the process ineligible. Exact naming excludes `Relay(<pid>)` and `SessionLeader`.
+
+### Consecutive identity confirmation
+
+The identity tuple is PID plus procfs start-time ticks. It must pass three scans, 30 seconds apart. Any failed scan or PID reuse clears confirmation state.
+
+### Pidfd signaling with repeated revalidation
+
+The daemon opens a Linux pidfd, revalidates the identity and complete predicate, sends `TERM` through the pidfd, waits three seconds, and revalidates before any pidfd `KILL`. Pidfds prevent PID reuse from redirecting a signal. Each cycle handles at most 32 oldest confirmed candidates.
+
+### Bounded observability and strict configuration
+
+Scan mode never signals. Active daemon mode requires root and `ACTIVE=true`. Unknown or out-of-range configuration refuses operation. Rotating logs contain only decision metadata, and atomic status includes strict/protected counts and signal results.
+
+## Risks / Trade-offs
+
+- **Valid relay temporarily resembles an orphan** → Minimum age, three observations, kernel child list, identity checks, pidfd, and pre-signal revalidation.
+- **Large backlog pressures WSL** → Drain only 32 oldest per cycle.
+- **Daemon keeps the distro active** → Use a sleeping process with negligible steady-state work.
+- **Boot command conflicts** → Refuse installation without mutation and report the exact conflict.
+- **Root implementation defect** → Root-owned fixed files, no shell-evaluated configuration, dry-run gate, and synthetic procfs tests.
+
+## Migration Plan
+
+1. Implement and test in an isolated worktree.
+2. Compare a live non-mutating scan with the established manual predicate.
+3. Install inactive and verify ownership, `systemd=false`, singleton identity, status, and logs.
+4. Activate only after protected-process verification, then observe multiple cycles.
+5. Roll back by stopping only the verified watchdog identity and removing only managed files and configuration; never stop WSL.
+
+## Open Questions
+
+- Qualify the production defaults against the first live dry-run and active cycles.

--- a/openspec/changes/add-wsl-relay-watchdog/proposal.md
+++ b/openspec/changes/add-wsl-relay-watchdog/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Wave terminal relays can accumulate as root-owned, childless `/init` processes until WSL session creation fails or the workstation becomes unresponsive. Manual cleanup requires an already-open privileged shell, so prevention must happen automatically while preserving every live or ambiguous relay.
+
+## What Changes
+
+- Add a root-owned WSL relay watchdog that detects only strict orphan relays: plain `Relay`, parent PID 1, exact `/init` command, no children, and older than a configured minimum age.
+- Require the same process identity to satisfy the strict predicate across multiple observations before it becomes eligible for cleanup.
+- Revalidate every eligible process immediately before `TERM`, wait a bounded grace period, and revalidate survivors before `KILL`.
+- Limit cleanup work per cycle, serialize watchdog instances, and fail closed when process metadata is missing, malformed, or ambiguous.
+- Preserve all named `Relay(<pid>)` processes, all `SessionLeader` processes, relays with children, and relays below the minimum age.
+- Provide audit logging, dry-run inspection, status output, and reversible install/uninstall commands.
+- Register the watchdog without enabling systemd and without shutting down WSL.
+
+## Capabilities
+
+### New Capabilities
+
+- `wsl-relay-watchdog`: Safely identify, confirm, clean, report, install, and remove strict orphan WSL relays.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds focused scripts and tests under the workBenches repository.
+- Installation places a root-owned watchdog entry point and state/log directories inside Ubuntu 24.04, and updates only the WSL boot command while preserving the existing `wsl.conf` settings.
+- Uses Python 3, Linux procfs, pidfds, standard process signals, and `flock`; it does not require systemd, modify Wave launchers, recycle Docker benches, or stop WSL.

--- a/openspec/changes/add-wsl-relay-watchdog/specs/wsl-relay-watchdog/spec.md
+++ b/openspec/changes/add-wsl-relay-watchdog/specs/wsl-relay-watchdog/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: Strict orphan classification
-The watchdog SHALL classify a process as a strict orphan relay only when its process name is exactly `Relay`, its parent PID is 1, its command line is exactly the single argument `/init`, its kernel child list is empty, and its age meets the configured minimum.
+The watchdog SHALL classify a process as a strict orphan relay only when its process name is exactly `Relay`, its parent PID is 1, its command line is exactly the single argument `/init`, the aggregated kernel child lists for every relay thread are empty, and its age meets the configured minimum.
 
 #### Scenario: Plain childless relay qualifies
 - **WHEN** a process satisfies every strict predicate field and meets the minimum age
@@ -16,7 +16,7 @@ The watchdog SHALL classify a process as a strict orphan relay only when its pro
 - **THEN** the watchdog excludes it from candidate and signal sets regardless of age or parent
 
 #### Scenario: Relay with a child is preserved
-- **WHEN** an otherwise matching relay has at least one current child process
+- **WHEN** an otherwise matching relay has at least one current child process owned by any of its threads
 - **THEN** the watchdog excludes it from candidate and signal sets
 
 #### Scenario: Ambiguous metadata fails closed

--- a/openspec/changes/add-wsl-relay-watchdog/specs/wsl-relay-watchdog/spec.md
+++ b/openspec/changes/add-wsl-relay-watchdog/specs/wsl-relay-watchdog/spec.md
@@ -95,7 +95,7 @@ The watchdog SHALL provide non-mutating scan and verified status commands, requi
 - **THEN** atomic status and bounded logs report counts and decisions without environment values or unrelated command lines
 
 ### Requirement: Reversible non-destructive installation
-The installer SHALL preserve unrelated WSL configuration, refuse unmanaged boot conflicts, use root-owned components, and roll back without stopping WSL.
+The installer SHALL preserve unrelated WSL configuration, refuse unmanaged boot conflicts, refuse existing reserved files without matching recorded digests, use root-owned components, and roll back without stopping WSL.
 
 #### Scenario: Compatible installation
 - **WHEN** validation passes and no boot command conflicts
@@ -104,6 +104,14 @@ The installer SHALL preserve unrelated WSL configuration, refuse unmanaged boot 
 #### Scenario: Boot command conflicts
 - **WHEN** a non-watchdog boot command exists
 - **THEN** installation makes no configuration change and reports the conflict
+
+#### Scenario: A reserved install path is already occupied
+- **WHEN** a first install finds an existing engine, command, boot-wrapper, or configuration file without managed install state
+- **THEN** installation preserves the file, makes no managed-file change, and reports the conflict
+
+#### Scenario: A managed file changed after installation
+- **WHEN** an upgrade finds a reserved file whose digest differs from the recorded install state
+- **THEN** installation preserves the changed file and refuses to overwrite it
 
 #### Scenario: Uninstall runs
 - **WHEN** uninstall is invoked

--- a/openspec/changes/add-wsl-relay-watchdog/specs/wsl-relay-watchdog/spec.md
+++ b/openspec/changes/add-wsl-relay-watchdog/specs/wsl-relay-watchdog/spec.md
@@ -1,0 +1,110 @@
+## ADDED Requirements
+
+### Requirement: Strict orphan classification
+The watchdog SHALL classify a process as a strict orphan relay only when its process name is exactly `Relay`, its parent PID is 1, its command line is exactly the single argument `/init`, its kernel child list is empty, and its age meets the configured minimum.
+
+#### Scenario: Plain childless relay qualifies
+- **WHEN** a process satisfies every strict predicate field and meets the minimum age
+- **THEN** the watchdog records it as a strict orphan candidate
+
+#### Scenario: Named relay is preserved
+- **WHEN** a process name is `Relay(<pid>)` or any value other than exactly `Relay`
+- **THEN** the watchdog excludes it from candidate and signal sets
+
+#### Scenario: SessionLeader is preserved
+- **WHEN** a process name is `SessionLeader`
+- **THEN** the watchdog excludes it from candidate and signal sets regardless of age or parent
+
+#### Scenario: Relay with a child is preserved
+- **WHEN** an otherwise matching relay has at least one current child process
+- **THEN** the watchdog excludes it from candidate and signal sets
+
+#### Scenario: Ambiguous metadata fails closed
+- **WHEN** any required procfs value is missing, malformed, unreadable, truncated, or contradictory
+- **THEN** the watchdog excludes the process and records a non-fatal inspection error
+
+### Requirement: Consecutive identity confirmation
+The watchdog SHALL require the same PID and procfs start-time ticks to satisfy the complete predicate in at least three consecutive scans before cleanup eligibility.
+
+#### Scenario: Candidate remains strict across scans
+- **WHEN** the same identity satisfies the predicate for the configured consecutive scans
+- **THEN** the watchdog marks that identity eligible
+
+#### Scenario: Predicate becomes false
+- **WHEN** a candidate fails any predicate during confirmation
+- **THEN** the watchdog discards its observation count
+
+#### Scenario: PID is reused
+- **WHEN** a PID reappears with different start-time ticks
+- **THEN** it receives no inherited observations
+
+### Requirement: Revalidated pidfd signal sequence
+The watchdog SHALL open a pidfd, revalidate identity and the complete predicate before every signal, send `TERM` before `KILL`, and preserve a process whenever revalidation fails.
+
+#### Scenario: Candidate exits after TERM
+- **WHEN** a revalidated candidate exits during the TERM grace period
+- **THEN** the watchdog records it resolved and sends no KILL
+
+#### Scenario: Candidate survives TERM
+- **WHEN** a candidate survives TERM and passes a second full revalidation
+- **THEN** the watchdog sends KILL through the same pidfd
+
+#### Scenario: Identity or predicate changes
+- **WHEN** identity or any predicate changes before TERM or KILL
+- **THEN** no further signal is sent
+
+### Requirement: Bounded cleanup cycles
+The watchdog SHALL process no more than the configured limit per cycle, oldest first, and SHALL reject invalid limits.
+
+#### Scenario: Backlog exceeds limit
+- **WHEN** confirmed candidates exceed the limit
+- **THEN** only the oldest limited set is processed
+
+#### Scenario: Limit is invalid
+- **WHEN** the limit is missing, zero, negative, non-numeric, or excessive
+- **THEN** active mode is refused without signals
+
+### Requirement: Singleton root watchdog
+The installed watchdog SHALL run as root, allow one daemon instance, and operate without systemd.
+
+#### Scenario: Distro starts
+- **WHEN** WSL executes the managed boot command
+- **THEN** one detached root daemon begins scanning without blocking startup
+
+#### Scenario: Duplicate launch
+- **WHEN** another daemon starts while the lock is held
+- **THEN** it exits without scanning or signaling
+
+#### Scenario: Systemd remains disabled
+- **WHEN** the watchdog is installed or runs
+- **THEN** it does not change systemd or invoke WSL shutdown or restart
+
+### Requirement: Safe modes and reporting
+The watchdog SHALL provide non-mutating scan and verified status commands, require explicit valid active configuration, and maintain bounded secret-free reporting.
+
+#### Scenario: Scan runs
+- **WHEN** scan mode is invoked
+- **THEN** it reports strict and protected processes without signals
+
+#### Scenario: Active setting is absent
+- **WHEN** `ACTIVE=true` is absent
+- **THEN** the daemon sends no signals and reports inactive mode
+
+#### Scenario: Cycle completes
+- **WHEN** a monitoring cycle finishes
+- **THEN** atomic status and bounded logs report counts and decisions without environment values or unrelated command lines
+
+### Requirement: Reversible non-destructive installation
+The installer SHALL preserve unrelated WSL configuration, refuse unmanaged boot conflicts, use root-owned components, and roll back without stopping WSL.
+
+#### Scenario: Compatible installation
+- **WHEN** validation passes and no boot command conflicts
+- **THEN** the installer backs up configuration, installs files, registers boot, and starts without WSL restart
+
+#### Scenario: Boot command conflicts
+- **WHEN** a non-watchdog boot command exists
+- **THEN** installation makes no configuration change and reports the conflict
+
+#### Scenario: Uninstall runs
+- **WHEN** uninstall is invoked
+- **THEN** only the verified watchdog identity and watchdog-owned files and configuration are removed

--- a/openspec/changes/add-wsl-relay-watchdog/tasks.md
+++ b/openspec/changes/add-wsl-relay-watchdog/tasks.md
@@ -35,6 +35,7 @@
 - [x] 5.4 Add batch-limit, configuration rejection, singleton lock, bounded logging, install-conflict, and rollback-preservation tests
 - [x] 5.5 Add missing-identity lock, fresh-start status, and absent-configuration rollback coverage
 - [x] 5.6 Add target-scoped pre-signal child revalidation and daemon lock-release waiting
+- [x] 5.7 Add raw procfs delimiter and stale-identity lock regression coverage
 - [x] 5.5 Run focused tests and shell syntax/static checks, fixing only watchdog-related failures
 
 ## 6. Live Dry-Run Qualification

--- a/openspec/changes/add-wsl-relay-watchdog/tasks.md
+++ b/openspec/changes/add-wsl-relay-watchdog/tasks.md
@@ -34,6 +34,7 @@
 - [x] 5.3 Add signal-order and revalidation tests proving TERM-before-KILL and no signal after identity or predicate changes
 - [x] 5.4 Add batch-limit, configuration rejection, singleton lock, bounded logging, install-conflict, and rollback-preservation tests
 - [x] 5.5 Add missing-identity lock, fresh-start status, and absent-configuration rollback coverage
+- [x] 5.6 Add target-scoped pre-signal child revalidation and daemon lock-release waiting
 - [x] 5.5 Run focused tests and shell syntax/static checks, fixing only watchdog-related failures
 
 ## 6. Live Dry-Run Qualification

--- a/openspec/changes/add-wsl-relay-watchdog/tasks.md
+++ b/openspec/changes/add-wsl-relay-watchdog/tasks.md
@@ -36,7 +36,7 @@
 - [x] 5.5 Add missing-identity lock, fresh-start status, and absent-configuration rollback coverage
 - [x] 5.6 Add target-scoped pre-signal child revalidation and daemon lock-release waiting
 - [x] 5.7 Add raw procfs delimiter and stale-identity lock regression coverage
-- [x] 5.5 Run focused tests and shell syntax/static checks, fixing only watchdog-related failures
+- [x] 5.8 Run focused tests and shell syntax/static checks, fixing only watchdog-related failures
 
 ## 6. Live Dry-Run Qualification
 

--- a/openspec/changes/add-wsl-relay-watchdog/tasks.md
+++ b/openspec/changes/add-wsl-relay-watchdog/tasks.md
@@ -1,0 +1,44 @@
+## 1. Isolated Implementation Setup
+
+- [x] 1.1 Create a clean Speckit feature worktree without modifying or discarding the unrelated dirty root checkout
+- [x] 1.2 Confirm no active lane owns the proposed watchdog paths and record the implementation boundary
+- [x] 1.3 Add the watchdog, installer, test, and documentation file skeletons in new non-overlapping paths
+
+## 2. Strict Relay Inspection Engine
+
+- [x] 2.1 Implement procfs readers for exact process name, parent PID, start-time identity, command-line arguments, elapsed age, and child relationships
+- [x] 2.2 Implement the fail-closed strict orphan predicate and explicit protected classifications for named relays and SessionLeaders
+- [x] 2.3 Implement consecutive observation tracking keyed by PID and start-time ticks, clearing state on predicate failure or identity change
+- [x] 2.4 Implement oldest-first eligibility selection with validated configurable age, observation, interval, grace, and batch bounds
+
+## 3. Revalidated Cleanup and Daemon Lifecycle
+
+- [x] 3.1 Implement immediate full identity revalidation before TERM and before any KILL
+- [x] 3.2 Implement bounded TERM, grace-period, survivor revalidation, and KILL handling with structured outcomes
+- [x] 3.3 Implement singleton daemon startup using fixed paths, a non-blocking flock, and atomic runtime state updates
+- [x] 3.4 Implement scan, status, daemon, and explicitly activated run-once modes without shell-evaluated configuration
+- [x] 3.5 Implement bounded secret-free event logging and fixed log rotation
+
+## 4. Installation and Rollback
+
+- [x] 4.1 Implement prerequisite, root-authority, ownership, path, and configuration validation
+- [x] 4.2 Implement root-owned file installation and a detached WSL boot launcher compatible with `systemd=false`
+- [x] 4.3 Implement surgical `wsl.conf` backup and boot-command registration that refuses unmanaged command conflicts
+- [x] 4.4 Implement immediate watchdog startup without WSL restart and verify the daemon PID plus start-time identity
+- [x] 4.5 Implement uninstall that stops only the verified watchdog identity and removes only watchdog-owned files and configuration
+
+## 5. Automated Safety Tests
+
+- [x] 5.1 Add synthetic procfs fixtures covering strict orphans, named relays, SessionLeaders, child-bearing relays, recent relays, and malformed metadata
+- [x] 5.2 Add tests for consecutive observations, interrupted observations, PID reuse, disappearing processes, and child races
+- [x] 5.3 Add signal-order and revalidation tests proving TERM-before-KILL and no signal after identity or predicate changes
+- [x] 5.4 Add batch-limit, configuration rejection, singleton lock, bounded logging, install-conflict, and rollback-preservation tests
+- [x] 5.5 Run focused tests and shell syntax/static checks, fixing only watchdog-related failures
+
+## 6. Live Dry-Run Qualification
+
+- [x] 6.1 Compare non-mutating live scan counts with the established strict manual predicate
+- [x] 6.2 Verify live named relays and SessionLeaders are reported as protected and absent from all signal sets
+- [x] 6.3 Install in inactive mode, verify root ownership, singleton status, bounded logs, and preserved `systemd=false` without restarting WSL
+- [x] 6.4 Enable active cleanup with approved production defaults and verify multiple cycles remain healthy without terminating protected processes
+- [x] 6.5 Document operation, status inspection, tuning bounds, conflict recovery, and no-WSL-shutdown rollback

--- a/openspec/changes/add-wsl-relay-watchdog/tasks.md
+++ b/openspec/changes/add-wsl-relay-watchdog/tasks.md
@@ -33,6 +33,7 @@
 - [x] 5.2 Add tests for consecutive observations, interrupted observations, PID reuse, disappearing processes, and child races
 - [x] 5.3 Add signal-order and revalidation tests proving TERM-before-KILL and no signal after identity or predicate changes
 - [x] 5.4 Add batch-limit, configuration rejection, singleton lock, bounded logging, install-conflict, and rollback-preservation tests
+- [x] 5.5 Add missing-identity lock, fresh-start status, and absent-configuration rollback coverage
 - [x] 5.5 Run focused tests and shell syntax/static checks, fixing only watchdog-related failures
 
 ## 6. Live Dry-Run Qualification

--- a/scripts/wsl-relay-watchdog/install.py
+++ b/scripts/wsl-relay-watchdog/install.py
@@ -246,11 +246,20 @@ def stop_watchdog(root: Path, timeout_seconds: float = 5.0) -> None:
         signal.pidfd_send_signal(pidfd, signal.SIGTERM, None, 0)
         deadline = time.monotonic() + timeout_seconds
         while time.monotonic() < deadline:
-            if not verified_watchdog(identity):
+            if not verified_watchdog(identity) and not watchdog_lock_is_held(root):
                 return
             time.sleep(0.1)
         if verified_watchdog(identity):
-            signal.pidfd_send_signal(pidfd, signal.SIGKILL, None, 0)
+            try:
+                signal.pidfd_send_signal(pidfd, signal.SIGKILL, None, 0)
+            except ProcessLookupError:
+                pass
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            if not verified_watchdog(identity) and not watchdog_lock_is_held(root):
+                return
+            time.sleep(0.1)
+        raise InstallError("watchdog did not release its singleton lock after termination")
     finally:
         os.close(pidfd)
 

--- a/scripts/wsl-relay-watchdog/install.py
+++ b/scripts/wsl-relay-watchdog/install.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import fcntl
 import hashlib
 import json
 import os
@@ -203,11 +204,26 @@ def verified_watchdog(identity: dict[str, object], proc_root: Path = Path("/proc
     return ENGINE_PATH in decoded and "daemon" in decoded
 
 
+def watchdog_lock_is_held(root: Path) -> bool:
+    lock_path = rooted(root, f"{RUN_DIR}/watchdog.lock")
+    if not lock_path.exists():
+        return False
+    with lock_path.open("a+", encoding="utf-8") as lock_file:
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            return True
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+    return False
+
+
 def stop_watchdog(root: Path, timeout_seconds: float = 5.0) -> None:
-    if root != Path("/"):
-        return
     pid_path = rooted(root, f"{RUN_DIR}/watchdog.pid.json")
     if not pid_path.exists():
+        if watchdog_lock_is_held(root):
+            raise InstallError("watchdog lock is held but its identity file is missing")
+        return
+    if root != Path("/"):
         return
     try:
         identity = json.loads(pid_path.read_text(encoding="utf-8"))
@@ -239,12 +255,21 @@ def stop_watchdog(root: Path, timeout_seconds: float = 5.0) -> None:
         os.close(pidfd)
 
 
+def clear_runtime_status(root: Path) -> None:
+    status_path = rooted(root, f"{RUN_DIR}/status.json")
+    try:
+        status_path.unlink()
+    except FileNotFoundError:
+        pass
+
+
 def start_watchdog(root: Path, timeout_seconds: float = 10.0) -> dict[str, object] | None:
     if root != Path("/"):
         return None
-    subprocess.run([BOOT_PATH], check=True)
     pid_path = rooted(root, f"{RUN_DIR}/watchdog.pid.json")
     status_path = rooted(root, f"{RUN_DIR}/status.json")
+    clear_runtime_status(root)
+    subprocess.run([BOOT_PATH], check=True)
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
         if pid_path.exists() and status_path.exists():
@@ -321,7 +346,8 @@ def install(root: Path, source_path: Path, active: bool, start: bool) -> dict[st
                 raise InstallError(f"refusing modified managed file: {existing_path}")
 
     wsl_config_path = rooted(root, WSL_CONFIG_PATH)
-    original_wsl_config = wsl_config_path.read_text(encoding="utf-8") if wsl_config_path.exists() else ""
+    wsl_config_existed = wsl_config_path.exists()
+    original_wsl_config = wsl_config_path.read_text(encoding="utf-8") if wsl_config_existed else ""
     updated_wsl_config, boot_section_created = install_boot_command(original_wsl_config)
 
     state_dir = rooted(root, STATE_DIR)
@@ -331,6 +357,7 @@ def install(root: Path, source_path: Path, active: bool, start: bool) -> dict[st
     if previous_state is not None:
         backup_path = previous_state.get("initial_wsl_config_backup")  # type: ignore[assignment]
         boot_section_created = bool(previous_state.get("boot_section_created", boot_section_created))
+        wsl_config_existed = bool(previous_state.get("wsl_config_existed", True))
     else:
         timestamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
         backup = backup_dir / f"wsl.conf.{timestamp}.bak"
@@ -361,6 +388,7 @@ def install(root: Path, source_path: Path, active: bool, start: bool) -> dict[st
             for managed_path, content in desired_content.items()
         },
         "initial_wsl_config_backup": backup_path,
+        "wsl_config_existed": wsl_config_existed,
         "boot_section_created": boot_section_created,
         "managed_boot_command": MANAGED_BOOT_COMMAND,
     }
@@ -405,7 +433,13 @@ def uninstall(root: Path) -> dict[str, object]:
         current_wsl_config,
         boot_section_created=bool(state.get("boot_section_created", False)),
     )
-    atomic_write(wsl_config_path, updated_wsl_config.encode("utf-8"), 0o644)
+    if not bool(state.get("wsl_config_existed", True)) and not updated_wsl_config:
+        try:
+            wsl_config_path.unlink()
+        except FileNotFoundError:
+            pass
+    else:
+        atomic_write(wsl_config_path, updated_wsl_config.encode("utf-8"), 0o644)
 
     for managed_path in (ENGINE_PATH, COMMAND_PATH, BOOT_PATH, CONFIG_PATH):
         target = rooted(root, managed_path)

--- a/scripts/wsl-relay-watchdog/install.py
+++ b/scripts/wsl-relay-watchdog/install.py
@@ -264,6 +264,10 @@ def source_digest(source_path: Path) -> str:
     return hashlib.sha256(source_path.read_bytes()).hexdigest()
 
 
+def content_digest(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
 def install(root: Path, source_path: Path, active: bool, start: bool) -> dict[str, object]:
     if root == Path("/") and os.geteuid() != 0:
         raise InstallError("installation into / requires root")
@@ -285,8 +289,36 @@ def install(root: Path, source_path: Path, active: bool, start: bool) -> dict[st
             previous_state = json.loads(state_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as error:
             raise InstallError(f"cannot read existing install state: {error}") from error
-    elif rooted(root, CONFIG_PATH).exists():
-        raise InstallError(f"refusing unmanaged existing configuration: {rooted(root, CONFIG_PATH)}")
+
+    source_content = source_path.read_bytes()
+    desired_content = {
+        ENGINE_PATH: source_content,
+        COMMAND_PATH: command_wrapper(),
+        BOOT_PATH: boot_wrapper(),
+        CONFIG_PATH: config_content(active),
+    }
+    if previous_state is None:
+        for managed_path in desired_content:
+            existing_path = rooted(root, managed_path)
+            if existing_path.exists():
+                raise InstallError(f"refusing unmanaged existing file: {existing_path}")
+    else:
+        recorded_digests = previous_state.get("managed_path_sha256", {})
+        if not isinstance(recorded_digests, dict):
+            raise InstallError("existing install state has invalid managed path digests")
+        legacy_digests = {
+            ENGINE_PATH: previous_state.get("engine_sha256"),
+            COMMAND_PATH: content_digest(command_wrapper()),
+            BOOT_PATH: content_digest(boot_wrapper()),
+            CONFIG_PATH: content_digest(config_content(bool(previous_state.get("active", False)))),
+        }
+        for managed_path in desired_content:
+            existing_path = rooted(root, managed_path)
+            if not existing_path.exists():
+                continue
+            expected_digest = recorded_digests.get(managed_path, legacy_digests.get(managed_path))
+            if not isinstance(expected_digest, str) or source_digest(existing_path) != expected_digest:
+                raise InstallError(f"refusing modified managed file: {existing_path}")
 
     wsl_config_path = rooted(root, WSL_CONFIG_PATH)
     original_wsl_config = wsl_config_path.read_text(encoding="utf-8") if wsl_config_path.exists() else ""
@@ -313,10 +345,10 @@ def install(root: Path, source_path: Path, active: bool, start: bool) -> dict[st
 
     if start:
         stop_watchdog(root)
-    atomic_write(rooted(root, ENGINE_PATH), source_path.read_bytes(), 0o755)
-    atomic_write(rooted(root, COMMAND_PATH), command_wrapper(), 0o755)
-    atomic_write(rooted(root, BOOT_PATH), boot_wrapper(), 0o755)
-    atomic_write(rooted(root, CONFIG_PATH), config_content(active), 0o644)
+    atomic_write(rooted(root, ENGINE_PATH), desired_content[ENGINE_PATH], 0o755)
+    atomic_write(rooted(root, COMMAND_PATH), desired_content[COMMAND_PATH], 0o755)
+    atomic_write(rooted(root, BOOT_PATH), desired_content[BOOT_PATH], 0o755)
+    atomic_write(rooted(root, CONFIG_PATH), desired_content[CONFIG_PATH], 0o644)
     atomic_write(wsl_config_path, updated_wsl_config.encode("utf-8"), 0o644)
 
     state: dict[str, object] = {
@@ -324,6 +356,10 @@ def install(root: Path, source_path: Path, active: bool, start: bool) -> dict[st
         "installed_at": dt.datetime.now(dt.timezone.utc).isoformat(),
         "active": active,
         "engine_sha256": source_digest(source_path),
+        "managed_path_sha256": {
+            managed_path: content_digest(content)
+            for managed_path, content in desired_content.items()
+        },
         "initial_wsl_config_backup": backup_path,
         "boot_section_created": boot_section_created,
         "managed_boot_command": MANAGED_BOOT_COMMAND,
@@ -344,6 +380,24 @@ def uninstall(root: Path) -> dict[str, object]:
     except (OSError, json.JSONDecodeError) as error:
         raise InstallError(f"cannot read install state: {error}") from error
 
+    recorded_digests = state.get("managed_path_sha256", {})
+    if not isinstance(recorded_digests, dict):
+        raise InstallError("install state has invalid managed path digests")
+    legacy_digests = {
+        ENGINE_PATH: state.get("engine_sha256"),
+        COMMAND_PATH: content_digest(command_wrapper()),
+        BOOT_PATH: content_digest(boot_wrapper()),
+        CONFIG_PATH: content_digest(config_content(bool(state.get("active", False)))),
+    }
+    for managed_path in (ENGINE_PATH, COMMAND_PATH, BOOT_PATH, CONFIG_PATH):
+        target = rooted(root, managed_path)
+        ensure_regular_or_absent(target)
+        if not target.exists():
+            continue
+        expected_digest = recorded_digests.get(managed_path, legacy_digests.get(managed_path))
+        if not isinstance(expected_digest, str) or source_digest(target) != expected_digest:
+            raise InstallError(f"refusing removal of modified managed file: {target}")
+
     stop_watchdog(root)
     wsl_config_path = rooted(root, WSL_CONFIG_PATH)
     current_wsl_config = wsl_config_path.read_text(encoding="utf-8") if wsl_config_path.exists() else ""
@@ -355,7 +409,6 @@ def uninstall(root: Path) -> dict[str, object]:
 
     for managed_path in (ENGINE_PATH, COMMAND_PATH, BOOT_PATH, CONFIG_PATH):
         target = rooted(root, managed_path)
-        ensure_regular_or_absent(target)
         try:
             target.unlink()
         except FileNotFoundError:

--- a/scripts/wsl-relay-watchdog/install.py
+++ b/scripts/wsl-relay-watchdog/install.py
@@ -223,8 +223,6 @@ def stop_watchdog(root: Path, timeout_seconds: float = 5.0) -> None:
         if watchdog_lock_is_held(root):
             raise InstallError("watchdog lock is held but its identity file is missing")
         return
-    if root != Path("/"):
-        return
     try:
         identity = json.loads(pid_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as error:
@@ -232,7 +230,11 @@ def stop_watchdog(root: Path, timeout_seconds: float = 5.0) -> None:
     pid = int(identity["pid"])
     current_start = read_start_time_ticks(pid)
     if current_start is None:
+        if watchdog_lock_is_held(root):
+            raise InstallError("watchdog lock is held but its recorded identity is stale")
         pid_path.unlink()
+        return
+    if root != Path("/"):
         return
     if not verified_watchdog(identity):
         raise InstallError("refusing to stop an unverified watchdog identity")

--- a/scripts/wsl-relay-watchdog/install.py
+++ b/scripts/wsl-relay-watchdog/install.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+
+
+MANAGED_BOOT_COMMAND = "/usr/local/sbin/wsl-relay-watchdog-boot"
+ENGINE_PATH = "/usr/local/libexec/wsl-relay-watchdog/wsl_relay_watchdog.py"
+COMMAND_PATH = "/usr/local/sbin/wsl-relay-watchdog"
+BOOT_PATH = MANAGED_BOOT_COMMAND
+CONFIG_PATH = "/etc/wsl-relay-watchdog.conf"
+WSL_CONFIG_PATH = "/etc/wsl.conf"
+STATE_DIR = "/var/lib/wsl-relay-watchdog"
+STATE_PATH = f"{STATE_DIR}/install.json"
+RUN_DIR = "/run/wsl-relay-watchdog"
+LOG_DIR = "/var/log/wsl-relay-watchdog"
+
+
+class InstallError(RuntimeError):
+    pass
+
+
+def rooted(root: Path, absolute_path: str) -> Path:
+    return root / absolute_path.lstrip("/")
+
+
+def atomic_write(path: Path, content: bytes, mode: int) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    file_descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(file_descriptor, "wb") as temporary_file:
+            temporary_file.write(content)
+            temporary_file.flush()
+            os.fsync(temporary_file.fileno())
+        os.chmod(temporary_name, mode)
+        if os.geteuid() == 0:
+            os.chown(temporary_name, 0, 0)
+        os.replace(temporary_name, path)
+    finally:
+        try:
+            os.unlink(temporary_name)
+        except FileNotFoundError:
+            pass
+
+
+def ensure_regular_or_absent(path: Path) -> None:
+    if path.is_symlink():
+        raise InstallError(f"refusing symbolic link at managed path: {path}")
+    if path.exists() and not path.is_file():
+        raise InstallError(f"managed path is not a regular file: {path}")
+
+
+def section_bounds(lines: list[str], section_name: str) -> tuple[int, int] | None:
+    section_pattern = re.compile(r"^\s*\[([^]]+)\]\s*$")
+    start: int | None = None
+    for index, line in enumerate(lines):
+        match = section_pattern.match(line)
+        if not match:
+            continue
+        if start is not None:
+            return start, index
+        if match.group(1).strip().lower() == section_name.lower():
+            start = index
+    if start is None:
+        return None
+    return start, len(lines)
+
+
+def install_boot_command(content: str) -> tuple[str, bool]:
+    lines = content.splitlines()
+    bounds = section_bounds(lines, "boot")
+    command_pattern = re.compile(r"^\s*command\s*=\s*(.*?)\s*$", re.IGNORECASE)
+    if bounds is None:
+        if lines and lines[-1].strip():
+            lines.append("")
+        lines.extend(["[boot]", f"command={MANAGED_BOOT_COMMAND}"])
+        return "\n".join(lines) + "\n", True
+
+    start, end = bounds
+    command_indexes: list[int] = []
+    command_values: list[str] = []
+    for index in range(start + 1, end):
+        match = command_pattern.match(lines[index])
+        if match:
+            command_indexes.append(index)
+            command_values.append(match.group(1))
+    if len(command_indexes) > 1:
+        raise InstallError("/etc/wsl.conf contains multiple [boot] command values")
+    if command_indexes:
+        if command_values[0] != MANAGED_BOOT_COMMAND:
+            raise InstallError(f"conflicting [boot] command: {command_values[0]}")
+        return "\n".join(lines) + "\n", False
+
+    lines.insert(start + 1, f"command={MANAGED_BOOT_COMMAND}")
+    return "\n".join(lines) + "\n", False
+
+
+def uninstall_boot_command(content: str, boot_section_created: bool) -> str:
+    lines = content.splitlines()
+    bounds = section_bounds(lines, "boot")
+    if bounds is None:
+        return "\n".join(lines) + ("\n" if lines else "")
+    start, end = bounds
+    command_pattern = re.compile(r"^\s*command\s*=\s*(.*?)\s*$", re.IGNORECASE)
+    managed_indexes: list[int] = []
+    conflicting_commands: list[str] = []
+    for index in range(start + 1, end):
+        match = command_pattern.match(lines[index])
+        if not match:
+            continue
+        if match.group(1) == MANAGED_BOOT_COMMAND:
+            managed_indexes.append(index)
+        else:
+            conflicting_commands.append(match.group(1))
+    if conflicting_commands:
+        raise InstallError(f"refusing to alter changed [boot] command: {conflicting_commands[0]}")
+    if len(managed_indexes) > 1:
+        raise InstallError("/etc/wsl.conf contains duplicate managed boot commands")
+    if managed_indexes:
+        del lines[managed_indexes[0]]
+
+    if boot_section_created:
+        bounds = section_bounds(lines, "boot")
+        if bounds is not None:
+            start, end = bounds
+            if all(not line.strip() or line.lstrip().startswith("#") for line in lines[start + 1 : end]):
+                del lines[start:end]
+                while lines and not lines[-1].strip():
+                    lines.pop()
+    return "\n".join(lines) + ("\n" if lines else "")
+
+
+def config_content(active: bool) -> bytes:
+    return (
+        "# Managed by workBenches wsl-relay-watchdog.\n"
+        f"ACTIVE={'true' if active else 'false'}\n"
+        "MIN_AGE_SECONDS=300\n"
+        "CONFIRMATIONS=3\n"
+        "INTERVAL_SECONDS=30\n"
+        "BATCH_LIMIT=32\n"
+        "TERM_GRACE_SECONDS=3\n"
+        "LOG_MAX_BYTES=1048576\n"
+        "LOG_BACKUPS=3\n"
+    ).encode("utf-8")
+
+
+def command_wrapper() -> bytes:
+    return (
+        "#!/bin/sh\n"
+        "set -eu\n"
+        f"exec /usr/bin/python3 {ENGINE_PATH} \"$@\"\n"
+    ).encode("utf-8")
+
+
+def boot_wrapper() -> bytes:
+    return (
+        "#!/bin/sh\n"
+        "set -eu\n"
+        "umask 027\n"
+        f"/usr/bin/setsid --fork {COMMAND_PATH} daemon </dev/null >/dev/null 2>&1\n"
+        "exit 0\n"
+    ).encode("utf-8")
+
+
+def read_start_time_ticks(pid: int, proc_root: Path = Path("/proc")) -> int | None:
+    try:
+        raw_stat = (proc_root / str(pid) / "stat").read_text(encoding="utf-8")
+        close_paren = raw_stat.rfind(")")
+        fields = raw_stat[close_paren + 1 :].strip().split()
+        return int(fields[19])
+    except (FileNotFoundError, PermissionError, OSError, ValueError, IndexError):
+        return None
+
+
+def verified_watchdog(identity: dict[str, object], proc_root: Path = Path("/proc")) -> bool:
+    try:
+        pid = int(identity["pid"])
+        expected_start = int(identity["start_time_ticks"])
+    except (KeyError, TypeError, ValueError):
+        return False
+    if read_start_time_ticks(pid, proc_root) != expected_start:
+        return False
+    try:
+        command_line = (proc_root / str(pid) / "cmdline").read_bytes().split(b"\0")
+    except (FileNotFoundError, PermissionError, OSError):
+        return False
+    decoded = [part.decode("utf-8", errors="replace") for part in command_line if part]
+    return ENGINE_PATH in decoded and "daemon" in decoded
+
+
+def stop_watchdog(root: Path, timeout_seconds: float = 5.0) -> None:
+    if root != Path("/"):
+        return
+    pid_path = rooted(root, f"{RUN_DIR}/watchdog.pid.json")
+    if not pid_path.exists():
+        return
+    try:
+        identity = json.loads(pid_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise InstallError(f"cannot read watchdog identity: {error}") from error
+    pid = int(identity["pid"])
+    current_start = read_start_time_ticks(pid)
+    if current_start is None:
+        pid_path.unlink()
+        return
+    if not verified_watchdog(identity):
+        raise InstallError("refusing to stop an unverified watchdog identity")
+    try:
+        pidfd = os.pidfd_open(pid)
+    except (ProcessLookupError, PermissionError, OSError) as error:
+        raise InstallError(f"cannot open watchdog pidfd: {type(error).__name__}") from error
+    try:
+        if not verified_watchdog(identity):
+            raise InstallError("watchdog identity changed before stop")
+        signal.pidfd_send_signal(pidfd, signal.SIGTERM, None, 0)
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            if not verified_watchdog(identity):
+                return
+            time.sleep(0.1)
+        if verified_watchdog(identity):
+            signal.pidfd_send_signal(pidfd, signal.SIGKILL, None, 0)
+    finally:
+        os.close(pidfd)
+
+
+def start_watchdog(root: Path, timeout_seconds: float = 10.0) -> dict[str, object] | None:
+    if root != Path("/"):
+        return None
+    subprocess.run([BOOT_PATH], check=True)
+    pid_path = rooted(root, f"{RUN_DIR}/watchdog.pid.json")
+    status_path = rooted(root, f"{RUN_DIR}/status.json")
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if pid_path.exists() and status_path.exists():
+            try:
+                identity = json.loads(pid_path.read_text(encoding="utf-8"))
+                status = json.loads(status_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                time.sleep(0.1)
+                continue
+            if verified_watchdog(identity):
+                return status
+        time.sleep(0.1)
+    raise InstallError("watchdog did not publish a verified running identity within 10 seconds")
+
+
+def source_digest(source_path: Path) -> str:
+    return hashlib.sha256(source_path.read_bytes()).hexdigest()
+
+
+def install(root: Path, source_path: Path, active: bool, start: bool) -> dict[str, object]:
+    if root == Path("/") and os.geteuid() != 0:
+        raise InstallError("installation into / requires root")
+    if not source_path.is_file():
+        raise InstallError(f"watchdog engine source is missing: {source_path}")
+    if root == Path("/"):
+        for prerequisite in ("/usr/bin/python3", "/usr/bin/setsid"):
+            if not Path(prerequisite).is_file():
+                raise InstallError(f"required executable is missing: {prerequisite}")
+
+    managed_paths = [ENGINE_PATH, COMMAND_PATH, BOOT_PATH, CONFIG_PATH, WSL_CONFIG_PATH, STATE_PATH]
+    for managed_path in managed_paths:
+        ensure_regular_or_absent(rooted(root, managed_path))
+
+    state_path = rooted(root, STATE_PATH)
+    previous_state: dict[str, object] | None = None
+    if state_path.exists():
+        try:
+            previous_state = json.loads(state_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise InstallError(f"cannot read existing install state: {error}") from error
+    elif rooted(root, CONFIG_PATH).exists():
+        raise InstallError(f"refusing unmanaged existing configuration: {rooted(root, CONFIG_PATH)}")
+
+    wsl_config_path = rooted(root, WSL_CONFIG_PATH)
+    original_wsl_config = wsl_config_path.read_text(encoding="utf-8") if wsl_config_path.exists() else ""
+    updated_wsl_config, boot_section_created = install_boot_command(original_wsl_config)
+
+    state_dir = rooted(root, STATE_DIR)
+    backup_dir = state_dir / "backups"
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    backup_path: str | None = None
+    if previous_state is not None:
+        backup_path = previous_state.get("initial_wsl_config_backup")  # type: ignore[assignment]
+        boot_section_created = bool(previous_state.get("boot_section_created", boot_section_created))
+    else:
+        timestamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        backup = backup_dir / f"wsl.conf.{timestamp}.bak"
+        atomic_write(backup, original_wsl_config.encode("utf-8"), 0o600)
+        backup_path = str(backup)
+
+    for directory, mode in ((state_dir, 0o750), (rooted(root, RUN_DIR), 0o755), (rooted(root, LOG_DIR), 0o750)):
+        directory.mkdir(parents=True, exist_ok=True)
+        os.chmod(directory, mode)
+        if os.geteuid() == 0:
+            os.chown(directory, 0, 0)
+
+    if start:
+        stop_watchdog(root)
+    atomic_write(rooted(root, ENGINE_PATH), source_path.read_bytes(), 0o755)
+    atomic_write(rooted(root, COMMAND_PATH), command_wrapper(), 0o755)
+    atomic_write(rooted(root, BOOT_PATH), boot_wrapper(), 0o755)
+    atomic_write(rooted(root, CONFIG_PATH), config_content(active), 0o644)
+    atomic_write(wsl_config_path, updated_wsl_config.encode("utf-8"), 0o644)
+
+    state: dict[str, object] = {
+        "version": 1,
+        "installed_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "active": active,
+        "engine_sha256": source_digest(source_path),
+        "initial_wsl_config_backup": backup_path,
+        "boot_section_created": boot_section_created,
+        "managed_boot_command": MANAGED_BOOT_COMMAND,
+    }
+    atomic_write(state_path, (json.dumps(state, indent=2, sort_keys=True) + "\n").encode("utf-8"), 0o600)
+    status = start_watchdog(root) if start else None
+    return {"installed": True, "active": active, "status": status, "state": state}
+
+
+def uninstall(root: Path) -> dict[str, object]:
+    if root == Path("/") and os.geteuid() != 0:
+        raise InstallError("uninstallation from / requires root")
+    state_path = rooted(root, STATE_PATH)
+    if not state_path.exists():
+        raise InstallError("watchdog install state is absent; refusing unmanaged removal")
+    try:
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise InstallError(f"cannot read install state: {error}") from error
+
+    stop_watchdog(root)
+    wsl_config_path = rooted(root, WSL_CONFIG_PATH)
+    current_wsl_config = wsl_config_path.read_text(encoding="utf-8") if wsl_config_path.exists() else ""
+    updated_wsl_config = uninstall_boot_command(
+        current_wsl_config,
+        boot_section_created=bool(state.get("boot_section_created", False)),
+    )
+    atomic_write(wsl_config_path, updated_wsl_config.encode("utf-8"), 0o644)
+
+    for managed_path in (ENGINE_PATH, COMMAND_PATH, BOOT_PATH, CONFIG_PATH):
+        target = rooted(root, managed_path)
+        ensure_regular_or_absent(target)
+        try:
+            target.unlink()
+        except FileNotFoundError:
+            pass
+    try:
+        state_path.unlink()
+    except FileNotFoundError:
+        pass
+    return {"uninstalled": True, "logs_retained": str(rooted(root, LOG_DIR))}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Install or remove the strict WSL relay watchdog")
+    parser.add_argument("--root", type=Path, default=Path("/"), help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=Path(__file__).with_name("wsl_relay_watchdog.py"),
+        help=argparse.SUPPRESS,
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    install_parser = subparsers.add_parser("install")
+    mode_group = install_parser.add_mutually_exclusive_group(required=True)
+    mode_group.add_argument("--active", action="store_true")
+    mode_group.add_argument("--inactive", action="store_true")
+    install_parser.add_argument("--no-start", action="store_true", help=argparse.SUPPRESS)
+    subparsers.add_parser("uninstall")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = build_parser().parse_args(argv)
+    root = arguments.root.resolve()
+    try:
+        if arguments.command == "install":
+            if arguments.no_start and root == Path("/"):
+                raise InstallError("--no-start is limited to test roots")
+            result = install(root, arguments.source.resolve(), arguments.active, not arguments.no_start)
+        else:
+            result = uninstall(root)
+        json.dump(result, sys.stdout, indent=2, sort_keys=True)
+        sys.stdout.write("\n")
+        return 0
+    except (InstallError, OSError, subprocess.SubprocessError) as error:
+        print(f"install-wsl-relay-watchdog: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/wsl-relay-watchdog/install.py
+++ b/scripts/wsl-relay-watchdog/install.py
@@ -438,6 +438,7 @@ def uninstall(root: Path) -> dict[str, object]:
             raise InstallError(f"refusing removal of modified managed file: {target}")
 
     wsl_config_path = rooted(root, WSL_CONFIG_PATH)
+    ensure_regular_or_absent(wsl_config_path)
     current_wsl_config = wsl_config_path.read_text(encoding="utf-8") if wsl_config_path.exists() else ""
     updated_wsl_config = uninstall_boot_command(
         current_wsl_config,

--- a/scripts/wsl-relay-watchdog/install.py
+++ b/scripts/wsl-relay-watchdog/install.py
@@ -65,18 +65,20 @@ def ensure_regular_or_absent(path: Path) -> None:
 
 def section_bounds(lines: list[str], section_name: str) -> tuple[int, int] | None:
     section_pattern = re.compile(r"^\s*\[([^]]+)\]\s*$")
-    start: int | None = None
+    section_headers: list[tuple[int, str]] = []
     for index, line in enumerate(lines):
         match = section_pattern.match(line)
-        if not match:
-            continue
-        if start is not None:
-            return start, index
-        if match.group(1).strip().lower() == section_name.lower():
-            start = index
-    if start is None:
+        if match:
+            section_headers.append((index, match.group(1).strip().lower()))
+
+    matching_indexes = [index for index, name in section_headers if name == section_name.lower()]
+    if len(matching_indexes) > 1:
+        raise InstallError(f"/etc/wsl.conf contains multiple [{section_name}] sections")
+    if not matching_indexes:
         return None
-    return start, len(lines)
+    start = matching_indexes[0]
+    end = next((index for index, _name in section_headers if index > start), len(lines))
+    return start, end
 
 
 def install_boot_command(content: str) -> tuple[str, bool]:

--- a/scripts/wsl-relay-watchdog/install.py
+++ b/scripts/wsl-relay-watchdog/install.py
@@ -437,13 +437,13 @@ def uninstall(root: Path) -> dict[str, object]:
         if not isinstance(expected_digest, str) or source_digest(target) != expected_digest:
             raise InstallError(f"refusing removal of modified managed file: {target}")
 
-    stop_watchdog(root)
     wsl_config_path = rooted(root, WSL_CONFIG_PATH)
     current_wsl_config = wsl_config_path.read_text(encoding="utf-8") if wsl_config_path.exists() else ""
     updated_wsl_config = uninstall_boot_command(
         current_wsl_config,
         boot_section_created=bool(state.get("boot_section_created", False)),
     )
+    stop_watchdog(root)
     if not bool(state.get("wsl_config_existed", True)) and not updated_wsl_config:
         try:
             wsl_config_path.unlink()

--- a/scripts/wsl-relay-watchdog/install.py
+++ b/scripts/wsl-relay-watchdog/install.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import re
 import shutil
 import signal
+import stat
 import subprocess
 import sys
 import tempfile
@@ -38,7 +39,12 @@ def rooted(root: Path, absolute_path: str) -> Path:
     return root / absolute_path.lstrip("/")
 
 
-def atomic_write(path: Path, content: bytes, mode: int) -> None:
+def atomic_write(
+    path: Path,
+    content: bytes,
+    mode: int,
+    owner: tuple[int, int] | None = None,
+) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     file_descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
     try:
@@ -48,7 +54,7 @@ def atomic_write(path: Path, content: bytes, mode: int) -> None:
             os.fsync(temporary_file.fileno())
         os.chmod(temporary_name, mode)
         if os.geteuid() == 0:
-            os.chown(temporary_name, 0, 0)
+            os.chown(temporary_name, *(owner or (0, 0)))
         os.replace(temporary_name, path)
     finally:
         try:
@@ -57,11 +63,37 @@ def atomic_write(path: Path, content: bytes, mode: int) -> None:
             pass
 
 
-def ensure_regular_or_absent(path: Path) -> None:
+def ensure_safe_ancestors(root: Path, path: Path) -> None:
+    try:
+        relative_path = path.relative_to(root)
+    except ValueError as error:
+        raise InstallError(f"managed path escapes installation root: {path}") from error
+
+    if root.is_symlink() or not root.is_dir():
+        raise InstallError(f"installation root is not a real directory: {root}")
+    current = root
+    for component in relative_path.parts[:-1]:
+        current /= component
+        if current.is_symlink():
+            raise InstallError(f"refusing symbolic link in managed path: {current}")
+        if current.exists() and not current.is_dir():
+            raise InstallError(f"managed path ancestor is not a directory: {current}")
+
+
+def ensure_regular_or_absent(root: Path, path: Path) -> None:
+    ensure_safe_ancestors(root, path)
     if path.is_symlink():
         raise InstallError(f"refusing symbolic link at managed path: {path}")
     if path.exists() and not path.is_file():
         raise InstallError(f"managed path is not a regular file: {path}")
+
+
+def ensure_directory_or_absent(root: Path, path: Path) -> None:
+    ensure_safe_ancestors(root, path)
+    if path.is_symlink():
+        raise InstallError(f"refusing symbolic link at managed directory: {path}")
+    if path.exists() and not path.is_dir():
+        raise InstallError(f"managed directory path is not a directory: {path}")
 
 
 def section_bounds(lines: list[str], section_name: str) -> tuple[int, int] | None:
@@ -316,7 +348,9 @@ def install(root: Path, source_path: Path, active: bool, start: bool) -> dict[st
 
     managed_paths = [ENGINE_PATH, COMMAND_PATH, BOOT_PATH, CONFIG_PATH, WSL_CONFIG_PATH, STATE_PATH]
     for managed_path in managed_paths:
-        ensure_regular_or_absent(rooted(root, managed_path))
+        ensure_regular_or_absent(root, rooted(root, managed_path))
+    for managed_directory in (STATE_DIR, f"{STATE_DIR}/backups", RUN_DIR, LOG_DIR):
+        ensure_directory_or_absent(root, rooted(root, managed_directory))
 
     state_path = rooted(root, STATE_PATH)
     previous_state: dict[str, object] | None = None
@@ -358,6 +392,7 @@ def install(root: Path, source_path: Path, active: bool, start: bool) -> dict[st
 
     wsl_config_path = rooted(root, WSL_CONFIG_PATH)
     wsl_config_existed = wsl_config_path.exists()
+    wsl_config_metadata = wsl_config_path.stat() if wsl_config_existed else None
     original_wsl_config = wsl_config_path.read_text(encoding="utf-8") if wsl_config_existed else ""
     updated_wsl_config, boot_section_created = install_boot_command(original_wsl_config)
 
@@ -387,7 +422,16 @@ def install(root: Path, source_path: Path, active: bool, start: bool) -> dict[st
     atomic_write(rooted(root, COMMAND_PATH), desired_content[COMMAND_PATH], 0o755)
     atomic_write(rooted(root, BOOT_PATH), desired_content[BOOT_PATH], 0o755)
     atomic_write(rooted(root, CONFIG_PATH), desired_content[CONFIG_PATH], 0o644)
-    atomic_write(wsl_config_path, updated_wsl_config.encode("utf-8"), 0o644)
+    wsl_config_mode = stat.S_IMODE(wsl_config_metadata.st_mode) if wsl_config_metadata else 0o644
+    wsl_config_owner = (
+        (wsl_config_metadata.st_uid, wsl_config_metadata.st_gid) if wsl_config_metadata else None
+    )
+    atomic_write(
+        wsl_config_path,
+        updated_wsl_config.encode("utf-8"),
+        wsl_config_mode,
+        owner=wsl_config_owner,
+    )
 
     state: dict[str, object] = {
         "version": 1,
@@ -411,7 +455,10 @@ def install(root: Path, source_path: Path, active: bool, start: bool) -> dict[st
 def uninstall(root: Path) -> dict[str, object]:
     if root == Path("/") and os.geteuid() != 0:
         raise InstallError("uninstallation from / requires root")
+    for managed_directory in (STATE_DIR, RUN_DIR, LOG_DIR):
+        ensure_directory_or_absent(root, rooted(root, managed_directory))
     state_path = rooted(root, STATE_PATH)
+    ensure_regular_or_absent(root, state_path)
     if not state_path.exists():
         raise InstallError("watchdog install state is absent; refusing unmanaged removal")
     try:
@@ -430,7 +477,7 @@ def uninstall(root: Path) -> dict[str, object]:
     }
     for managed_path in (ENGINE_PATH, COMMAND_PATH, BOOT_PATH, CONFIG_PATH):
         target = rooted(root, managed_path)
-        ensure_regular_or_absent(target)
+        ensure_regular_or_absent(root, target)
         if not target.exists():
             continue
         expected_digest = recorded_digests.get(managed_path, legacy_digests.get(managed_path))
@@ -438,20 +485,30 @@ def uninstall(root: Path) -> dict[str, object]:
             raise InstallError(f"refusing removal of modified managed file: {target}")
 
     wsl_config_path = rooted(root, WSL_CONFIG_PATH)
-    ensure_regular_or_absent(wsl_config_path)
-    current_wsl_config = wsl_config_path.read_text(encoding="utf-8") if wsl_config_path.exists() else ""
+    ensure_regular_or_absent(root, wsl_config_path)
+    wsl_config_present = wsl_config_path.exists()
+    wsl_config_metadata = wsl_config_path.stat() if wsl_config_present else None
+    current_wsl_config = wsl_config_path.read_text(encoding="utf-8") if wsl_config_present else ""
     updated_wsl_config = uninstall_boot_command(
         current_wsl_config,
         boot_section_created=bool(state.get("boot_section_created", False)),
     )
     stop_watchdog(root)
-    if not bool(state.get("wsl_config_existed", True)) and not updated_wsl_config:
+    if not wsl_config_present:
+        pass
+    elif not bool(state.get("wsl_config_existed", True)) and not updated_wsl_config:
         try:
             wsl_config_path.unlink()
         except FileNotFoundError:
             pass
     else:
-        atomic_write(wsl_config_path, updated_wsl_config.encode("utf-8"), 0o644)
+        assert wsl_config_metadata is not None
+        atomic_write(
+            wsl_config_path,
+            updated_wsl_config.encode("utf-8"),
+            stat.S_IMODE(wsl_config_metadata.st_mode),
+            owner=(wsl_config_metadata.st_uid, wsl_config_metadata.st_gid),
+        )
 
     for managed_path in (ENGINE_PATH, COMMAND_PATH, BOOT_PATH, CONFIG_PATH):
         target = rooted(root, managed_path)

--- a/scripts/wsl-relay-watchdog/qualify-live.sh
+++ b/scripts/wsl-relay-watchdog/qualify-live.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+ENGINE=${1:-"${SCRIPT_DIR}/wsl_relay_watchdog.py"}
+MIN_AGE_SECONDS=${MIN_AGE_SECONDS:-300}
+
+temporary_directory=$(mktemp -d)
+trap 'rm -rf -- "${temporary_directory}"' EXIT
+
+engine_json="${temporary_directory}/engine.json"
+engine_pids="${temporary_directory}/engine-pids"
+manual_pids="${temporary_directory}/manual-pids"
+protected_pids="${temporary_directory}/protected-pids"
+
+python3 "${ENGINE}" scan >"${engine_json}"
+python3 - "${engine_json}" "${engine_pids}" "${protected_pids}" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+strict = sorted(int(item["pid"]) for item in payload["strict_candidates"])
+protected = sorted(
+    int(item["pid"])
+    for key in ("protected_named_relays", "protected_session_leaders")
+    for item in payload[key]
+)
+Path(sys.argv[2]).write_text("".join(f"{pid}\n" for pid in strict), encoding="ascii")
+Path(sys.argv[3]).write_text("".join(f"{pid}\n" for pid in protected), encoding="ascii")
+print(f"ENGINE_STRICT={len(strict)}")
+print(f"PROTECTED_NAMED={payload['protected_named_relay_count']}")
+print(f"PROTECTED_SESSION_LEADERS={payload['protected_session_leader_count']}")
+print(f"ENGINE_INSPECTION_ERRORS={len(payload['inspection_errors'])}")
+PY
+
+: >"${manual_pids}"
+clock_ticks=$(getconf CLK_TCK)
+uptime_seconds=$(cut -d ' ' -f 1 /proc/uptime)
+for process_dir in /proc/[0-9]*; do
+    pid=${process_dir##*/}
+    if ! IFS= read -r process_name <"${process_dir}/comm" 2>/dev/null; then
+        continue
+    fi
+    [[ "${process_name}" == "Relay" ]] || continue
+
+    if ! IFS= read -r stat_line <"${process_dir}/stat" 2>/dev/null; then
+        continue
+    fi
+    read -r -a stat_fields <<<"${stat_line}"
+    [[ ${#stat_fields[@]} -ge 22 ]] || continue
+    [[ "${stat_fields[3]}" == "1" ]] || continue
+    start_time_ticks=${stat_fields[21]}
+    [[ "${start_time_ticks}" =~ ^[0-9]+$ ]] || continue
+
+    command_line=()
+    if ! mapfile -d '' -t command_line <"${process_dir}/cmdline" 2>/dev/null; then
+        continue
+    fi
+    [[ ${#command_line[@]} -eq 1 && "${command_line[0]}" == "/init" ]] || continue
+
+    if ! children=$(cat "${process_dir}/task/${pid}/children" 2>/dev/null); then
+        continue
+    fi
+    [[ -z "${children//[[:space:]]/}" ]] || continue
+
+    if awk -v uptime="${uptime_seconds}" -v start="${start_time_ticks}" -v hz="${clock_ticks}" -v minimum="${MIN_AGE_SECONDS}" 'BEGIN { exit !((uptime - start / hz) >= minimum) }'; then
+        printf '%s\n' "${pid}" >>"${manual_pids}"
+    fi
+done
+sort -n -o "${manual_pids}" "${manual_pids}"
+
+printf 'MANUAL_STRICT=%s\n' "$(wc -l <"${manual_pids}")"
+if cmp -s "${engine_pids}" "${manual_pids}"; then
+    echo "STRICT_SET_MATCH=true"
+else
+    echo "STRICT_SET_MATCH=false"
+    echo "Strict PID differences:" >&2
+    diff -u "${manual_pids}" "${engine_pids}" >&2 || true
+    exit 1
+fi
+
+protected_overlap=$(awk 'NR == FNR { protected[$1] = 1; next } protected[$1] { count++ } END { print count + 0 }' "${protected_pids}" "${engine_pids}")
+printf 'PROTECTED_OVERLAP=%s\n' "${protected_overlap}"
+[[ "${protected_overlap}" == "0" ]]

--- a/scripts/wsl-relay-watchdog/qualify-live.sh
+++ b/scripts/wsl-relay-watchdog/qualify-live.sh
@@ -41,10 +41,13 @@ clock_ticks=$(getconf CLK_TCK)
 uptime_seconds=$(cut -d ' ' -f 1 /proc/uptime)
 for process_dir in /proc/[0-9]*; do
     pid=${process_dir##*/}
-    if ! IFS= read -r process_name <"${process_dir}/comm" 2>/dev/null; then
+    if ! IFS= read -r process_name 2>/dev/null <"${process_dir}/comm"; then
         continue
     fi
-    [[ "${process_name}" == "Relay" ]] || continue
+    if ! process_name_size=$(wc -c 2>/dev/null <"${process_dir}/comm"); then
+        continue
+    fi
+    [[ "${process_name}" == "Relay" && "${process_name_size}" == "6" ]] || continue
 
     if ! IFS= read -r stat_line <"${process_dir}/stat" 2>/dev/null; then
         continue
@@ -61,10 +64,22 @@ for process_dir in /proc/[0-9]*; do
     fi
     [[ ${#command_line[@]} -eq 1 && "${command_line[0]}" == "/init" ]] || continue
 
-    if ! children=$(cat "${process_dir}/task/${pid}/children" 2>/dev/null); then
-        continue
-    fi
-    [[ -z "${children//[[:space:]]/}" ]] || continue
+    task_entries_found=false
+    child_found=false
+    task_scan_complete=true
+    for children_file in "${process_dir}"/task/[0-9]*/children; do
+        [[ -f "${children_file}" ]] || continue
+        task_entries_found=true
+        if ! children=$(cat "${children_file}" 2>/dev/null); then
+            task_scan_complete=false
+            break
+        fi
+        if [[ -n "${children//[[:space:]]/}" ]]; then
+            child_found=true
+        fi
+    done
+    [[ "${task_entries_found}" == true && "${task_scan_complete}" == true ]] || continue
+    [[ "${child_found}" == false ]] || continue
 
     if awk -v uptime="${uptime_seconds}" -v start="${start_time_ticks}" -v hz="${clock_ticks}" -v minimum="${MIN_AGE_SECONDS}" 'BEGIN { exit !((uptime - start / hz) >= minimum) }'; then
         printf '%s\n' "${pid}" >>"${manual_pids}"

--- a/scripts/wsl-relay-watchdog/qualify-live.sh
+++ b/scripts/wsl-relay-watchdog/qualify-live.sh
@@ -12,8 +12,10 @@ engine_json="${temporary_directory}/engine.json"
 engine_pids="${temporary_directory}/engine-pids"
 manual_pids="${temporary_directory}/manual-pids"
 protected_pids="${temporary_directory}/protected-pids"
+engine_config="${temporary_directory}/engine.conf"
 
-python3 "${ENGINE}" scan >"${engine_json}"
+printf 'MIN_AGE_SECONDS=%s\n' "${MIN_AGE_SECONDS}" >"${engine_config}"
+python3 "${ENGINE}" --config "${engine_config}" scan >"${engine_json}"
 python3 - "${engine_json}" "${engine_pids}" "${protected_pids}" <<'PY'
 import json
 from pathlib import Path

--- a/scripts/wsl-relay-watchdog/qualify-live.sh
+++ b/scripts/wsl-relay-watchdog/qualify-live.sh
@@ -59,6 +59,9 @@ for process_dir in /proc/[0-9]*; do
     [[ "${start_time_ticks}" =~ ^[0-9]+$ ]] || continue
 
     command_line=()
+    if ! tail -c 1 "${process_dir}/cmdline" 2>/dev/null | od -An -tu1 | grep -Eq '^[[:space:]]*0[[:space:]]*$'; then
+        continue
+    fi
     if ! mapfile -d '' -t command_line <"${process_dir}/cmdline" 2>/dev/null; then
         continue
     fi

--- a/scripts/wsl-relay-watchdog/tests/test_watchdog.py
+++ b/scripts/wsl-relay-watchdog/tests/test_watchdog.py
@@ -588,6 +588,37 @@ class InstallerTests(unittest.TestCase):
             self.assertEqual(original, wsl_config.read_text(encoding="utf-8"))
             self.assertFalse(installer.rooted(root, installer.ENGINE_PATH).exists())
 
+    def test_install_refuses_symlinked_managed_path_ancestor(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            engine_directory = installer.rooted(root, installer.ENGINE_PATH).parent
+            engine_directory.parent.mkdir(parents=True)
+            unmanaged_directory = root / "unmanaged-target"
+            unmanaged_directory.mkdir()
+            engine_directory.symlink_to(unmanaged_directory, target_is_directory=True)
+
+            with self.assertRaises(installer.InstallError):
+                installer.install(root, MODULE_DIR / "wsl_relay_watchdog.py", active=False, start=False)
+
+            self.assertEqual([], list(unmanaged_directory.iterdir()))
+            self.assertTrue(engine_directory.is_symlink())
+
+    def test_install_preserves_existing_wsl_config_metadata(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            wsl_config = installer.rooted(root, installer.WSL_CONFIG_PATH)
+            wsl_config.parent.mkdir(parents=True)
+            wsl_config.write_text("[boot]\nsystemd=false\n", encoding="utf-8")
+            wsl_config.chmod(0o640)
+            original_metadata = wsl_config.stat()
+
+            installer.install(root, MODULE_DIR / "wsl_relay_watchdog.py", active=False, start=False)
+
+            installed_metadata = wsl_config.stat()
+            self.assertEqual(0o640, stat.S_IMODE(installed_metadata.st_mode))
+            self.assertEqual(original_metadata.st_uid, installed_metadata.st_uid)
+            self.assertEqual(original_metadata.st_gid, installed_metadata.st_gid)
+
     def test_first_install_refuses_unmanaged_reserved_file(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
@@ -657,6 +688,19 @@ class InstallerTests(unittest.TestCase):
             self.assertTrue(wsl_config.is_symlink())
             self.assertEqual("[boot]\nsystemd=true\n", replacement.read_text(encoding="utf-8"))
             self.assertTrue(installer.rooted(root, installer.ENGINE_PATH).exists())
+
+    def test_uninstall_keeps_externally_deleted_wsl_config_absent(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            wsl_config = installer.rooted(root, installer.WSL_CONFIG_PATH)
+            wsl_config.parent.mkdir(parents=True)
+            wsl_config.write_text("[boot]\nsystemd=false\n", encoding="utf-8")
+            installer.install(root, MODULE_DIR / "wsl_relay_watchdog.py", active=False, start=False)
+            wsl_config.unlink()
+
+            installer.uninstall(root)
+
+            self.assertFalse(wsl_config.exists())
 
 
 if __name__ == "__main__":

--- a/scripts/wsl-relay-watchdog/tests/test_watchdog.py
+++ b/scripts/wsl-relay-watchdog/tests/test_watchdog.py
@@ -155,6 +155,17 @@ class ProcScannerTests(unittest.TestCase):
 
             self.assertEqual((), result.strict_candidates)
 
+    def test_relay_name_with_embedded_newline_is_never_strict(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            proc_root = Path(temporary_directory) / "proc"
+            fixture = ProcFixture(proc_root)
+            fixture.add_process(10, "Relay\n", 1, command_line=("/init",))
+
+            result = watchdog.ProcScanner(proc_root, clock_ticks=100).scan(min_age_seconds=300)
+
+            self.assertEqual((), result.strict_candidates)
+            self.assertTrue(any(error.startswith("pid=10: ValueError") for error in result.inspection_errors))
+
 
 class ObservationTests(unittest.TestCase):
     def test_requires_consecutive_observations(self):
@@ -431,6 +442,39 @@ class InstallerTests(unittest.TestCase):
 
             self.assertEqual(original, wsl_config.read_text(encoding="utf-8"))
             self.assertFalse(installer.rooted(root, installer.ENGINE_PATH).exists())
+
+    def test_first_install_refuses_unmanaged_reserved_file(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            etc_dir = root / "etc"
+            etc_dir.mkdir()
+            (etc_dir / "wsl.conf").write_text("[boot]\nsystemd=false\n", encoding="utf-8")
+            command_path = installer.rooted(root, installer.COMMAND_PATH)
+            command_path.parent.mkdir(parents=True)
+            command_path.write_text("unmanaged\n", encoding="utf-8")
+
+            with self.assertRaises(installer.InstallError):
+                installer.install(root, MODULE_DIR / "wsl_relay_watchdog.py", active=False, start=False)
+
+            self.assertEqual("unmanaged\n", command_path.read_text(encoding="utf-8"))
+
+    def test_upgrade_refuses_modified_recorded_file(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            etc_dir = root / "etc"
+            etc_dir.mkdir()
+            (etc_dir / "wsl.conf").write_text("[boot]\nsystemd=false\n", encoding="utf-8")
+            installer.install(root, MODULE_DIR / "wsl_relay_watchdog.py", active=False, start=False)
+            command_path = installer.rooted(root, installer.COMMAND_PATH)
+            command_path.write_text("modified\n", encoding="utf-8")
+
+            with self.assertRaises(installer.InstallError):
+                installer.install(root, MODULE_DIR / "wsl_relay_watchdog.py", active=False, start=False)
+
+            with self.assertRaises(installer.InstallError):
+                installer.uninstall(root)
+
+            self.assertEqual("modified\n", command_path.read_text(encoding="utf-8"))
 
     def test_uninstall_refuses_changed_boot_command(self):
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/scripts/wsl-relay-watchdog/tests/test_watchdog.py
+++ b/scripts/wsl-relay-watchdog/tests/test_watchdog.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import contextlib
 import fcntl
 import importlib.util
+import io
 import json
 import logging
 from pathlib import Path
@@ -64,6 +66,14 @@ class ProcFixture:
         if parent_children.exists():
             existing = parent_children.read_text(encoding="ascii").strip()
             parent_children.write_text(f"{existing} {pid}".strip(), encoding="ascii")
+
+    def add_thread_children(self, pid: int, thread_id: int, child_pids: tuple[int, ...]) -> None:
+        task_dir = self.root / str(pid) / "task" / str(thread_id)
+        task_dir.mkdir(parents=True)
+        task_dir.joinpath("children").write_text(
+            " ".join(str(child_pid) for child_pid in child_pids),
+            encoding="ascii",
+        )
 
 
 def process_info(pid: int, start_time_ticks: int = 100, age_seconds: float = 900.0):
@@ -128,6 +138,18 @@ class ProcScannerTests(unittest.TestCase):
             fixture = ProcFixture(proc_root)
             fixture.add_process(10, "Relay", 1, command_line=("/init",))
             (proc_root / "10" / "cmdline").unlink()
+
+            result = watchdog.ProcScanner(proc_root, clock_ticks=100).scan(min_age_seconds=300)
+
+            self.assertEqual((), result.strict_candidates)
+            self.assertTrue(any(error == "pid=10: FileNotFoundError" for error in result.inspection_errors))
+
+    def test_relay_child_owned_by_non_leader_thread_is_preserved(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            proc_root = Path(temporary_directory) / "proc"
+            fixture = ProcFixture(proc_root)
+            fixture.add_process(10, "Relay", 1, command_line=("/init",))
+            fixture.add_thread_children(10, 101, (14,))
 
             result = watchdog.ProcScanner(proc_root, clock_ticks=100).scan(min_age_seconds=300)
 
@@ -246,6 +268,13 @@ class ConfigTests(unittest.TestCase):
             with self.assertRaises(watchdog.ConfigError):
                 watchdog.Config.load(config_path)
 
+    def test_confirmation_count_cannot_drop_below_three(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            config_path = Path(temporary_directory) / "watchdog.conf"
+            config_path.write_text("CONFIRMATIONS=2\n", encoding="utf-8")
+            with self.assertRaises(watchdog.ConfigError):
+                watchdog.Config.load(config_path)
+
     def test_inactive_is_default(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             config = watchdog.Config.load(Path(temporary_directory) / "missing.conf")
@@ -289,6 +318,55 @@ class DaemonTests(unittest.TestCase):
             self.assertTrue(all(path.stat().st_size <= 200 for path in log_files))
 
 
+class StatusTests(unittest.TestCase):
+    def test_corrupt_status_file_reports_unavailable(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            run_dir = root / "run"
+            run_dir.mkdir()
+            run_dir.joinpath("status.json").write_text("{", encoding="utf-8")
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                result = watchdog.main(
+                    [
+                        "--config",
+                        str(root / "missing.conf"),
+                        "--run-dir",
+                        str(run_dir),
+                        "status",
+                    ]
+                )
+
+            payload = json.loads(output.getvalue())
+            self.assertEqual(3, result)
+            self.assertFalse(payload["running"])
+            self.assertEqual("unavailable", payload["status"])
+
+    def test_corrupt_identity_file_reports_not_running(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            run_dir = root / "run"
+            run_dir.mkdir()
+            run_dir.joinpath("status.json").write_text('{"health":"healthy"}', encoding="utf-8")
+            run_dir.joinpath("watchdog.pid.json").write_text("{", encoding="utf-8")
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                result = watchdog.main(
+                    [
+                        "--config",
+                        str(root / "missing.conf"),
+                        "--run-dir",
+                        str(run_dir),
+                        "status",
+                    ]
+                )
+
+            payload = json.loads(output.getvalue())
+            self.assertEqual(3, result)
+            self.assertFalse(payload["running"])
+            self.assertEqual("JSONDecodeError", payload["watchdog_identity_error"])
+
+
 class InstallerTests(unittest.TestCase):
     def test_boot_command_preserves_systemd_and_other_sections(self):
         original = "[boot]\nsystemd=false\n\n[interop]\nappendWindowsPath=false\n"
@@ -301,6 +379,13 @@ class InstallerTests(unittest.TestCase):
     def test_conflicting_boot_command_is_refused(self):
         with self.assertRaises(installer.InstallError):
             installer.install_boot_command("[boot]\ncommand=service docker start\nsystemd=false\n")
+
+    def test_duplicate_boot_sections_are_refused(self):
+        duplicate = "[boot]\nsystemd=false\n\n[network]\ngenerateResolvConf=true\n\n[boot]\ncommand=service docker start\n"
+        with self.assertRaises(installer.InstallError):
+            installer.install_boot_command(duplicate)
+        with self.assertRaises(installer.InstallError):
+            installer.uninstall_boot_command(duplicate, boot_section_created=False)
 
     def test_install_and_uninstall_preserve_unrelated_configuration(self):
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/scripts/wsl-relay-watchdog/tests/test_watchdog.py
+++ b/scripts/wsl-relay-watchdog/tests/test_watchdog.py
@@ -379,6 +379,42 @@ class StatusTests(unittest.TestCase):
 
 
 class InstallerTests(unittest.TestCase):
+    def test_startup_clears_stale_runtime_status(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            status_path = installer.rooted(root, f"{installer.RUN_DIR}/status.json")
+            status_path.parent.mkdir(parents=True)
+            status_path.write_text('{"mode":"stale"}\n', encoding="utf-8")
+
+            installer.clear_runtime_status(root)
+
+            self.assertFalse(status_path.exists())
+
+    def test_missing_identity_with_held_lock_is_refused(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            run_dir = installer.rooted(root, installer.RUN_DIR)
+            run_dir.mkdir(parents=True)
+            lock_file = (run_dir / "watchdog.lock").open("a+", encoding="utf-8")
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            try:
+                with self.assertRaises(installer.InstallError):
+                    installer.stop_watchdog(root)
+            finally:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                lock_file.close()
+
+    def test_uninstall_restores_absent_wsl_config_to_absence(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            installer.install(root, MODULE_DIR / "wsl_relay_watchdog.py", active=False, start=False)
+            wsl_config = installer.rooted(root, installer.WSL_CONFIG_PATH)
+            self.assertTrue(wsl_config.exists())
+
+            installer.uninstall(root)
+
+            self.assertFalse(wsl_config.exists())
+
     def test_boot_command_preserves_systemd_and_other_sections(self):
         original = "[boot]\nsystemd=false\n\n[interop]\nappendWindowsPath=false\n"
         updated, created = installer.install_boot_command(original)

--- a/scripts/wsl-relay-watchdog/tests/test_watchdog.py
+++ b/scripts/wsl-relay-watchdog/tests/test_watchdog.py
@@ -161,6 +161,18 @@ class ProcScannerTests(unittest.TestCase):
             self.assertEqual((), result.strict_candidates)
             self.assertTrue(any(error == "pid=10: FileNotFoundError" for error in result.inspection_errors))
 
+    def test_truncated_relay_cmdline_fails_closed(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            proc_root = Path(temporary_directory) / "proc"
+            fixture = ProcFixture(proc_root)
+            fixture.add_process(10, "Relay", 1, command_line=("/init",))
+            (proc_root / "10" / "cmdline").write_bytes(b"/init")
+
+            result = watchdog.ProcScanner(proc_root, clock_ticks=100).scan(min_age_seconds=300)
+
+            self.assertEqual((), result.strict_candidates)
+            self.assertTrue(any(error == "pid=10: ValueError" for error in result.inspection_errors))
+
     def test_relay_child_owned_by_non_leader_thread_is_preserved(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             proc_root = Path(temporary_directory) / "proc"
@@ -177,6 +189,17 @@ class ProcScannerTests(unittest.TestCase):
             proc_root = Path(temporary_directory) / "proc"
             fixture = ProcFixture(proc_root)
             fixture.add_process(10, "Relay\n", 1, command_line=("/init",))
+
+            result = watchdog.ProcScanner(proc_root, clock_ticks=100).scan(min_age_seconds=300)
+
+            self.assertEqual((), result.strict_candidates)
+            self.assertTrue(any(error.startswith("pid=10: ValueError") for error in result.inspection_errors))
+
+    def test_relay_name_with_carriage_return_is_never_strict(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            proc_root = Path(temporary_directory) / "proc"
+            fixture = ProcFixture(proc_root)
+            fixture.add_process(10, "Relay\r", 1, command_line=("/init",))
 
             result = watchdog.ProcScanner(proc_root, clock_ticks=100).scan(min_age_seconds=300)
 
@@ -396,6 +419,23 @@ class StatusTests(unittest.TestCase):
 
 
 class InstallerTests(unittest.TestCase):
+    def test_stale_identity_with_held_lock_is_refused(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            run_dir = installer.rooted(root, installer.RUN_DIR)
+            run_dir.mkdir(parents=True)
+            run_dir.joinpath("watchdog.pid.json").write_text(
+                '{"pid":2147483647,"start_time_ticks":1}\n', encoding="utf-8"
+            )
+            lock_file = (run_dir / "watchdog.lock").open("a+", encoding="utf-8")
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            try:
+                with self.assertRaises(installer.InstallError):
+                    installer.stop_watchdog(root)
+            finally:
+                fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                lock_file.close()
+
     def test_startup_clears_stale_runtime_status(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)

--- a/scripts/wsl-relay-watchdog/tests/test_watchdog.py
+++ b/scripts/wsl-relay-watchdog/tests/test_watchdog.py
@@ -107,8 +107,25 @@ class SequenceScanner:
             self.last_result = self.results.pop(0)
         return self.last_result
 
+    def inspect_strict_candidate(self, identity, min_age_seconds):
+        result = self.scan(min_age_seconds)
+        return next((candidate for candidate in result.strict_candidates if candidate.identity == identity), None)
+
 
 class ProcScannerTests(unittest.TestCase):
+    def test_targeted_revalidation_observes_new_child(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            proc_root = Path(temporary_directory) / "proc"
+            fixture = ProcFixture(proc_root)
+            fixture.add_process(10, "Relay", 1, command_line=("/init",))
+            scanner = watchdog.ProcScanner(proc_root, clock_ticks=100)
+            candidate = scanner.scan(min_age_seconds=300).strict_candidates[0]
+            fixture.add_thread_children(10, 101, (14,))
+
+            revalidated = scanner.inspect_strict_candidate(candidate.identity, min_age_seconds=300)
+
+            self.assertIsNone(revalidated)
+
     def test_strict_classifier_preserves_protected_and_ambiguous_processes(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             proc_root = Path(temporary_directory) / "proc"

--- a/scripts/wsl-relay-watchdog/tests/test_watchdog.py
+++ b/scripts/wsl-relay-watchdog/tests/test_watchdog.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+import fcntl
+import importlib.util
+import json
+import logging
+from pathlib import Path
+import signal
+import stat
+import tempfile
+import unittest
+
+
+MODULE_DIR = Path(__file__).resolve().parents[1]
+
+
+def load_module(name: str, path: Path):
+    specification = importlib.util.spec_from_file_location(name, path)
+    if specification is None or specification.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(specification)
+    import sys
+
+    sys.modules[name] = module
+    specification.loader.exec_module(module)
+    return module
+
+
+watchdog = load_module("wsl_relay_watchdog", MODULE_DIR / "wsl_relay_watchdog.py")
+installer = load_module("wsl_relay_watchdog_installer", MODULE_DIR / "install.py")
+
+
+class ProcFixture:
+    def __init__(self, root: Path, uptime_seconds: float = 1_000.0, clock_ticks: int = 100) -> None:
+        self.root = root
+        self.clock_ticks = clock_ticks
+        self.root.mkdir(parents=True)
+        (self.root / "uptime").write_text(f"{uptime_seconds} 0.0\n", encoding="ascii")
+
+    def add_process(
+        self,
+        pid: int,
+        name: str,
+        parent_pid: int,
+        start_time_ticks: int = 10_000,
+        command_line: tuple[str, ...] = (),
+    ) -> None:
+        process_dir = self.root / str(pid)
+        process_dir.mkdir()
+        stat_fields = ["S", str(parent_pid), *(["0"] * 17), str(start_time_ticks), *(["0"] * 5)]
+        (process_dir / "stat").write_text(
+            f"{pid} ({name}) {' '.join(stat_fields)}\n",
+            encoding="utf-8",
+        )
+        (process_dir / "comm").write_text(f"{name}\n", encoding="utf-8")
+        command_bytes = b"\0".join(part.encode("utf-8") for part in command_line)
+        if command_line:
+            command_bytes += b"\0"
+        (process_dir / "cmdline").write_bytes(command_bytes)
+        task_dir = process_dir / "task" / str(pid)
+        task_dir.mkdir(parents=True)
+        (task_dir / "children").write_text("", encoding="ascii")
+        parent_children = self.root / str(parent_pid) / "task" / str(parent_pid) / "children"
+        if parent_children.exists():
+            existing = parent_children.read_text(encoding="ascii").strip()
+            parent_children.write_text(f"{existing} {pid}".strip(), encoding="ascii")
+
+
+def process_info(pid: int, start_time_ticks: int = 100, age_seconds: float = 900.0):
+    return watchdog.ProcessInfo(
+        identity=watchdog.ProcessIdentity(pid, start_time_ticks),
+        parent_pid=1,
+        name="Relay",
+        command_line=("/init",),
+        age_seconds=age_seconds,
+        child_count=0,
+    )
+
+
+def scan_result(*processes):
+    return watchdog.ScanResult(
+        timestamp=1.0,
+        strict_candidates=tuple(processes),
+        named_relays=(),
+        session_leaders=(),
+        inspection_errors=(),
+    )
+
+
+class SequenceScanner:
+    def __init__(self, results):
+        self.results = list(results)
+        self.last_result = self.results[-1] if self.results else scan_result()
+
+    def scan(self, _min_age_seconds):
+        if self.results:
+            self.last_result = self.results.pop(0)
+        return self.last_result
+
+
+class ProcScannerTests(unittest.TestCase):
+    def test_strict_classifier_preserves_protected_and_ambiguous_processes(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            proc_root = Path(temporary_directory) / "proc"
+            fixture = ProcFixture(proc_root)
+            fixture.add_process(10, "Relay", 1, command_line=("/init",))
+            fixture.add_process(11, "Relay(200)", 20, command_line=("/init",))
+            fixture.add_process(12, "SessionLeader", 1)
+            fixture.add_process(13, "Relay", 1, command_line=("/init",))
+            fixture.add_process(14, "bash", 13)
+            fixture.add_process(15, "Relay", 1, command_line=("/init", "--extra"))
+            fixture.add_process(16, "Relay", 1, start_time_ticks=95_000, command_line=("/init",))
+            malformed_dir = proc_root / "17"
+            malformed_dir.mkdir()
+            (malformed_dir / "stat").write_text("malformed\n", encoding="utf-8")
+            (malformed_dir / "comm").write_text("Relay\n", encoding="utf-8")
+
+            result = watchdog.ProcScanner(proc_root, clock_ticks=100).scan(min_age_seconds=300)
+
+            self.assertEqual([10], [item.identity.pid for item in result.strict_candidates])
+            self.assertEqual([11], [item.identity.pid for item in result.named_relays])
+            self.assertEqual([12], [item.identity.pid for item in result.session_leaders])
+            self.assertTrue(any(error.startswith("pid=17:") for error in result.inspection_errors))
+
+    def test_missing_relay_cmdline_fails_closed(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            proc_root = Path(temporary_directory) / "proc"
+            fixture = ProcFixture(proc_root)
+            fixture.add_process(10, "Relay", 1, command_line=("/init",))
+            (proc_root / "10" / "cmdline").unlink()
+
+            result = watchdog.ProcScanner(proc_root, clock_ticks=100).scan(min_age_seconds=300)
+
+            self.assertEqual((), result.strict_candidates)
+
+
+class ObservationTests(unittest.TestCase):
+    def test_requires_consecutive_observations(self):
+        tracker = watchdog.ObservationTracker()
+        candidate = process_info(10, 100)
+        self.assertEqual(1, tracker.update([candidate])[candidate.identity])
+        self.assertEqual({}, tracker.update([]))
+        self.assertEqual(1, tracker.update([candidate])[candidate.identity])
+
+    def test_pid_reuse_does_not_inherit_count(self):
+        tracker = watchdog.ObservationTracker()
+        original = process_info(10, 100)
+        reused = process_info(10, 200)
+        tracker.update([original])
+        tracker.update([original])
+        counts = tracker.update([reused])
+        self.assertEqual({reused.identity: 1}, counts)
+
+
+class CleanupTests(unittest.TestCase):
+    def setUp(self):
+        self.config = watchdog.Config(batch_limit=2, term_grace_seconds=1)
+
+    def test_term_precedes_kill_after_two_revalidations(self):
+        candidate = process_info(10)
+        scanner = SequenceScanner([scan_result(candidate), scan_result(candidate)])
+        signals = []
+        engine = watchdog.CleanupEngine(
+            scanner,
+            self.config,
+            open_pidfd=lambda pid: pid,
+            send_pidfd_signal=lambda pidfd, signal_number: signals.append((pidfd, signal_number)),
+            close_pidfd=lambda _pidfd: None,
+            sleep=lambda _seconds: None,
+        )
+
+        decisions = engine.clean([candidate])
+
+        self.assertEqual([(10, signal.SIGTERM), (10, signal.SIGKILL)], signals)
+        self.assertTrue(decisions[0].term_sent)
+        self.assertTrue(decisions[0].kill_sent)
+
+    def test_pre_term_identity_change_sends_no_signal(self):
+        candidate = process_info(10)
+        scanner = SequenceScanner([scan_result(process_info(10, start_time_ticks=200))])
+        signals = []
+        engine = watchdog.CleanupEngine(
+            scanner,
+            self.config,
+            open_pidfd=lambda pid: pid,
+            send_pidfd_signal=lambda pidfd, signal_number: signals.append((pidfd, signal_number)),
+            close_pidfd=lambda _pidfd: None,
+            sleep=lambda _seconds: None,
+        )
+
+        decisions = engine.clean([candidate])
+
+        self.assertEqual([], signals)
+        self.assertEqual("preserved-pre-term-revalidation", decisions[0].decision)
+
+    def test_post_term_predicate_change_prevents_kill(self):
+        candidate = process_info(10)
+        scanner = SequenceScanner([scan_result(candidate), scan_result()])
+        signals = []
+        engine = watchdog.CleanupEngine(
+            scanner,
+            self.config,
+            open_pidfd=lambda pid: pid,
+            send_pidfd_signal=lambda pidfd, signal_number: signals.append((pidfd, signal_number)),
+            close_pidfd=lambda _pidfd: None,
+            sleep=lambda _seconds: None,
+        )
+
+        decisions = engine.clean([candidate])
+
+        self.assertEqual([(10, signal.SIGTERM)], signals)
+        self.assertEqual("resolved-after-term", decisions[0].decision)
+        self.assertFalse(decisions[0].kill_sent)
+
+    def test_batch_limit_selects_oldest(self):
+        candidates = [process_info(10, age_seconds=400), process_info(11, age_seconds=900), process_info(12, age_seconds=600)]
+        scanner = SequenceScanner([scan_result(*candidates)])
+        signals = []
+        engine = watchdog.CleanupEngine(
+            scanner,
+            self.config,
+            open_pidfd=lambda pid: pid,
+            send_pidfd_signal=lambda pidfd, signal_number: signals.append((pidfd, signal_number)),
+            close_pidfd=lambda _pidfd: None,
+            sleep=lambda _seconds: None,
+        )
+
+        engine.clean(candidates)
+
+        term_pids = [pid for pid, signal_number in signals if signal_number == signal.SIGTERM]
+        self.assertEqual([11, 12], term_pids)
+
+
+class ConfigTests(unittest.TestCase):
+    def test_unknown_key_refuses_configuration(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            config_path = Path(temporary_directory) / "watchdog.conf"
+            config_path.write_text("ACTIVE=true\nUNSAFE=yes\n", encoding="utf-8")
+            with self.assertRaises(watchdog.ConfigError):
+                watchdog.Config.load(config_path)
+
+    def test_invalid_batch_limit_refuses_configuration(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            config_path = Path(temporary_directory) / "watchdog.conf"
+            config_path.write_text("BATCH_LIMIT=0\n", encoding="utf-8")
+            with self.assertRaises(watchdog.ConfigError):
+                watchdog.Config.load(config_path)
+
+    def test_inactive_is_default(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            config = watchdog.Config.load(Path(temporary_directory) / "missing.conf")
+            self.assertFalse(config.active)
+
+
+class DaemonTests(unittest.TestCase):
+    def test_existing_lock_prevents_duplicate_daemon(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            run_dir = Path(temporary_directory) / "run"
+            log_dir = Path(temporary_directory) / "log"
+            run_dir.mkdir()
+            lock_file = (run_dir / "watchdog.lock").open("a+", encoding="utf-8")
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            daemon = watchdog.WatchdogDaemon(
+                watchdog.Config(),
+                SequenceScanner([scan_result()]),
+                run_dir,
+                log_dir,
+                sleep=lambda _seconds: None,
+            )
+
+            self.assertEqual(0, daemon.run(max_cycles=1))
+            self.assertFalse((run_dir / "status.json").exists())
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+            lock_file.close()
+
+    def test_rotating_log_is_bounded(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            log_dir = Path(temporary_directory)
+            config = watchdog.Config(log_max_bytes=100, log_backups=2)
+            logger = watchdog.configure_logger(log_dir, config)
+            for index in range(50):
+                logger.info("bounded-message-%d-xxxxxxxxxxxxxxxx", index)
+            for handler in logger.handlers:
+                handler.close()
+            logger.handlers.clear()
+
+            log_files = sorted(log_dir.glob("watchdog.log*"))
+            self.assertLessEqual(len(log_files), 3)
+            self.assertTrue(all(path.stat().st_size <= 200 for path in log_files))
+
+
+class InstallerTests(unittest.TestCase):
+    def test_boot_command_preserves_systemd_and_other_sections(self):
+        original = "[boot]\nsystemd=false\n\n[interop]\nappendWindowsPath=false\n"
+        updated, created = installer.install_boot_command(original)
+        self.assertFalse(created)
+        self.assertIn("systemd=false", updated)
+        self.assertIn("appendWindowsPath=false", updated)
+        self.assertIn(f"command={installer.MANAGED_BOOT_COMMAND}", updated)
+
+    def test_conflicting_boot_command_is_refused(self):
+        with self.assertRaises(installer.InstallError):
+            installer.install_boot_command("[boot]\ncommand=service docker start\nsystemd=false\n")
+
+    def test_install_and_uninstall_preserve_unrelated_configuration(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            etc_dir = root / "etc"
+            etc_dir.mkdir()
+            wsl_config = etc_dir / "wsl.conf"
+            wsl_config.write_text(
+                "[boot]\nsystemd=false\n\n[interop]\nappendWindowsPath=false\n",
+                encoding="utf-8",
+            )
+
+            result = installer.install(root, MODULE_DIR / "wsl_relay_watchdog.py", active=False, start=False)
+
+            self.assertTrue(result["installed"])
+            self.assertIn("systemd=false", wsl_config.read_text(encoding="utf-8"))
+            command_path = installer.rooted(root, installer.COMMAND_PATH)
+            self.assertEqual(0o755, stat.S_IMODE(command_path.stat().st_mode))
+            config_path = installer.rooted(root, installer.CONFIG_PATH)
+            self.assertIn("ACTIVE=false", config_path.read_text(encoding="utf-8"))
+
+            current = wsl_config.read_text(encoding="utf-8")
+            wsl_config.write_text(current + "\n[network]\ngenerateResolvConf=true\n", encoding="utf-8")
+            installer.uninstall(root)
+
+            final_config = wsl_config.read_text(encoding="utf-8")
+            self.assertIn("systemd=false", final_config)
+            self.assertIn("generateResolvConf=true", final_config)
+            self.assertNotIn(installer.MANAGED_BOOT_COMMAND, final_config)
+            self.assertFalse(command_path.exists())
+
+    def test_install_conflict_makes_no_managed_file_changes(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            etc_dir = root / "etc"
+            etc_dir.mkdir()
+            wsl_config = etc_dir / "wsl.conf"
+            original = "[boot]\ncommand=service docker start\nsystemd=false\n"
+            wsl_config.write_text(original, encoding="utf-8")
+
+            with self.assertRaises(installer.InstallError):
+                installer.install(root, MODULE_DIR / "wsl_relay_watchdog.py", active=False, start=False)
+
+            self.assertEqual(original, wsl_config.read_text(encoding="utf-8"))
+            self.assertFalse(installer.rooted(root, installer.ENGINE_PATH).exists())
+
+    def test_uninstall_refuses_changed_boot_command(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            etc_dir = root / "etc"
+            etc_dir.mkdir()
+            wsl_config = etc_dir / "wsl.conf"
+            wsl_config.write_text("[boot]\nsystemd=false\n", encoding="utf-8")
+            installer.install(root, MODULE_DIR / "wsl_relay_watchdog.py", active=False, start=False)
+            wsl_config.write_text("[boot]\ncommand=changed-command\nsystemd=false\n", encoding="utf-8")
+
+            with self.assertRaises(installer.InstallError):
+                installer.uninstall(root)
+
+            self.assertTrue(installer.rooted(root, installer.ENGINE_PATH).exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/wsl-relay-watchdog/tests/test_watchdog.py
+++ b/scripts/wsl-relay-watchdog/tests/test_watchdog.py
@@ -333,6 +333,32 @@ class ConfigTests(unittest.TestCase):
             self.assertFalse(config.active)
 
 
+class CliSafetyTests(unittest.TestCase):
+    def test_custom_proc_root_is_refused_for_signaling_commands(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config_path = root / "watchdog.conf"
+            config_path.write_text("ACTIVE=true\n", encoding="utf-8")
+            proc_root = root / "proc"
+
+            for command in (("daemon", "--max-cycles", "1"), ("run-once", "--active")):
+                with self.subTest(command=command):
+                    errors = io.StringIO()
+                    with contextlib.redirect_stderr(errors):
+                        result = watchdog.main(
+                            [
+                                "--config",
+                                str(config_path),
+                                "--proc-root",
+                                str(proc_root),
+                                *command,
+                            ]
+                        )
+
+                    self.assertEqual(2, result)
+                    self.assertIn("custom --proc-root", errors.getvalue())
+
+
 class DaemonTests(unittest.TestCase):
     def test_existing_lock_prevents_duplicate_daemon(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -611,6 +637,25 @@ class InstallerTests(unittest.TestCase):
 
             stop_watchdog.assert_not_called()
 
+            self.assertTrue(installer.rooted(root, installer.ENGINE_PATH).exists())
+
+    def test_uninstall_refuses_replaced_wsl_config_symlink(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            installer.install(root, MODULE_DIR / "wsl_relay_watchdog.py", active=False, start=False)
+            wsl_config = installer.rooted(root, installer.WSL_CONFIG_PATH)
+            replacement = root / "unmanaged-wsl.conf"
+            replacement.write_text("[boot]\nsystemd=true\n", encoding="utf-8")
+            wsl_config.unlink()
+            wsl_config.symlink_to(replacement)
+
+            with mock.patch.object(installer, "stop_watchdog") as stop_watchdog:
+                with self.assertRaises(installer.InstallError):
+                    installer.uninstall(root)
+
+            stop_watchdog.assert_not_called()
+            self.assertTrue(wsl_config.is_symlink())
+            self.assertEqual("[boot]\nsystemd=true\n", replacement.read_text(encoding="utf-8"))
             self.assertTrue(installer.rooted(root, installer.ENGINE_PATH).exists())
 
 

--- a/scripts/wsl-relay-watchdog/tests/test_watchdog.py
+++ b/scripts/wsl-relay-watchdog/tests/test_watchdog.py
@@ -11,6 +11,7 @@ import signal
 import stat
 import tempfile
 import unittest
+from unittest import mock
 
 
 MODULE_DIR = Path(__file__).resolve().parents[1]
@@ -370,6 +371,31 @@ class DaemonTests(unittest.TestCase):
 
 
 class StatusTests(unittest.TestCase):
+    def test_status_ignores_invalid_configuration(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            config_path = root / "invalid.conf"
+            config_path.write_text("ACTIVE=maybe\n", encoding="utf-8")
+            run_dir = root / "run"
+            run_dir.mkdir()
+            run_dir.joinpath("status.json").write_text('{"health":"healthy"}', encoding="utf-8")
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                result = watchdog.main(
+                    [
+                        "--config",
+                        str(config_path),
+                        "--run-dir",
+                        str(run_dir),
+                        "status",
+                    ]
+                )
+
+            payload = json.loads(output.getvalue())
+            self.assertEqual(3, result)
+            self.assertFalse(payload["running"])
+            self.assertEqual("healthy", payload["health"])
+
     def test_corrupt_status_file_reports_unavailable(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
@@ -579,8 +605,11 @@ class InstallerTests(unittest.TestCase):
             installer.install(root, MODULE_DIR / "wsl_relay_watchdog.py", active=False, start=False)
             wsl_config.write_text("[boot]\ncommand=changed-command\nsystemd=false\n", encoding="utf-8")
 
-            with self.assertRaises(installer.InstallError):
-                installer.uninstall(root)
+            with mock.patch.object(installer, "stop_watchdog") as stop_watchdog:
+                with self.assertRaises(installer.InstallError):
+                    installer.uninstall(root)
+
+            stop_watchdog.assert_not_called()
 
             self.assertTrue(installer.rooted(root, installer.ENGINE_PATH).exists())
 

--- a/scripts/wsl-relay-watchdog/wsl_relay_watchdog.py
+++ b/scripts/wsl-relay-watchdog/wsl_relay_watchdog.py
@@ -78,7 +78,7 @@ class Config:
         config = cls(
             active=active,
             min_age_seconds=cls._parse_int(values, "MIN_AGE_SECONDS", 300, 60, 86_400),
-            confirmations=cls._parse_int(values, "CONFIRMATIONS", 3, 2, 20),
+            confirmations=cls._parse_int(values, "CONFIRMATIONS", 3, 3, 20),
             interval_seconds=cls._parse_int(values, "INTERVAL_SECONDS", 30, 5, 3_600),
             batch_limit=cls._parse_int(values, "BATCH_LIMIT", 32, 1, 128),
             term_grace_seconds=cls._parse_int(values, "TERM_GRACE_SECONDS", 3, 1, 30),
@@ -213,12 +213,23 @@ class ProcScanner:
                 child_count = 0
                 if name == "Relay":
                     command_line = self._parse_command_line((process_dir / "cmdline").read_bytes())
-                    raw_children = (process_dir / "task" / str(pid) / "children").read_text(encoding="ascii").strip()
-                    if raw_children:
-                        child_pids = [int(child_pid) for child_pid in raw_children.split()]
-                        if any(child_pid <= 0 for child_pid in child_pids):
+                    task_dirs = tuple(
+                        task_dir
+                        for task_dir in (process_dir / "task").iterdir()
+                        if task_dir.name.isdigit()
+                    )
+                    if not task_dirs:
+                        raise ValueError("relay has no readable task entries")
+                    child_pids: set[int] = set()
+                    for task_dir in task_dirs:
+                        raw_children = (task_dir / "children").read_text(encoding="ascii").strip()
+                        if not raw_children:
+                            continue
+                        task_child_pids = [int(child_pid) for child_pid in raw_children.split()]
+                        if any(child_pid <= 0 for child_pid in task_child_pids):
                             raise ValueError("children contains an invalid PID")
-                        child_count = len(child_pids)
+                        child_pids.update(task_child_pids)
+                    child_count = len(child_pids)
                 age_seconds = uptime_seconds - (start_time_ticks / self.clock_ticks)
                 if age_seconds < 0:
                     raise ValueError("process start time is after uptime")
@@ -230,9 +241,7 @@ class ProcScanner:
                     age_seconds,
                     child_count,
                 )
-            except FileNotFoundError:
-                continue
-            except (PermissionError, OSError, UnicodeError, ValueError) as error:
+            except (FileNotFoundError, PermissionError, OSError, UnicodeError, ValueError) as error:
                 if len(inspection_errors) < 50:
                     inspection_errors.append(f"pid={pid}: {type(error).__name__}")
 
@@ -582,6 +591,7 @@ def scan_payload(scan_result: ScanResult, config: Config) -> dict[str, object]:
         "timestamp": scan_result.timestamp,
         "mode": "scan",
         "active_configuration": config.active,
+        "minimum_age_seconds": config.min_age_seconds,
         "strict_count": len(scan_result.strict_candidates),
         "strict_candidates": [process_summary(process) for process in scan_result.strict_candidates],
         "protected_named_relay_count": len(scan_result.named_relays),
@@ -664,17 +674,36 @@ def main(argv: list[str] | None = None) -> int:
             if not status_path.exists():
                 print_json({"running": False, "status": "unavailable"})
                 return 3
-            status_payload = json.loads(status_path.read_text(encoding="utf-8"))
+            try:
+                status_payload = json.loads(status_path.read_text(encoding="utf-8"))
+                if not isinstance(status_payload, dict):
+                    raise ValueError("status payload is not an object")
+            except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as error:
+                print_json(
+                    {
+                        "running": False,
+                        "status": "unavailable",
+                        "status_error": type(error).__name__,
+                    }
+                )
+                return 3
             pid_path = arguments.run_dir / "watchdog.pid.json"
             running = False
             if pid_path.exists():
-                identity_payload = json.loads(pid_path.read_text(encoding="utf-8"))
-                expected_identity = ProcessIdentity(
-                    pid=int(identity_payload["pid"]),
-                    start_time_ticks=int(identity_payload["start_time_ticks"]),
-                )
-                running = scanner.read_identity(expected_identity.pid) == expected_identity
-                status_payload["watchdog_identity"] = dataclasses.asdict(expected_identity)
+                try:
+                    identity_payload = json.loads(pid_path.read_text(encoding="utf-8"))
+                    if not isinstance(identity_payload, dict):
+                        raise ValueError("identity payload is not an object")
+                    expected_identity = ProcessIdentity(
+                        pid=int(identity_payload["pid"]),
+                        start_time_ticks=int(identity_payload["start_time_ticks"]),
+                    )
+                    if expected_identity.pid <= 0 or expected_identity.start_time_ticks < 0:
+                        raise ValueError("identity values are out of range")
+                    running = scanner.read_identity(expected_identity.pid) == expected_identity
+                    status_payload["watchdog_identity"] = dataclasses.asdict(expected_identity)
+                except (OSError, UnicodeError, json.JSONDecodeError, KeyError, TypeError, ValueError) as error:
+                    status_payload["watchdog_identity_error"] = type(error).__name__
             status_payload["running"] = running
             print_json(status_payload)
             return 0 if running else 3

--- a/scripts/wsl-relay-watchdog/wsl_relay_watchdog.py
+++ b/scripts/wsl-relay-watchdog/wsl_relay_watchdog.py
@@ -717,6 +717,12 @@ def main(argv: list[str] | None = None) -> int:
     arguments = parser.parse_args(argv)
     try:
         config = None if arguments.command == "status" else Config.load(arguments.config)
+        signaling_enabled = config is not None and config.active and (
+            arguments.command == "daemon"
+            or (arguments.command == "run-once" and getattr(arguments, "active", False))
+        )
+        if signaling_enabled and arguments.proc_root != Path("/proc"):
+            raise WatchdogError("custom --proc-root is permitted only in non-signaling modes")
         scanner = ProcScanner(arguments.proc_root)
         if arguments.command == "validate-config":
             assert config is not None

--- a/scripts/wsl-relay-watchdog/wsl_relay_watchdog.py
+++ b/scripts/wsl-relay-watchdog/wsl_relay_watchdog.py
@@ -1,0 +1,694 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import fcntl
+import json
+import logging
+from logging.handlers import RotatingFileHandler
+import os
+from pathlib import Path
+import re
+import signal
+import sys
+import tempfile
+import time
+from typing import Callable, Iterable
+
+
+VERSION = "1.0.0"
+DEFAULT_CONFIG_PATH = Path("/etc/wsl-relay-watchdog.conf")
+DEFAULT_RUN_DIR = Path("/run/wsl-relay-watchdog")
+DEFAULT_LOG_DIR = Path("/var/log/wsl-relay-watchdog")
+MANAGED_PROCESS_NAMES = {"Relay", "SessionLeader"}
+NAMED_RELAY_PATTERN = re.compile(r"^Relay\([0-9]+\)$")
+
+
+class WatchdogError(RuntimeError):
+    pass
+
+
+class ConfigError(WatchdogError):
+    pass
+
+
+@dataclasses.dataclass(frozen=True)
+class Config:
+    active: bool = False
+    min_age_seconds: int = 300
+    confirmations: int = 3
+    interval_seconds: int = 30
+    batch_limit: int = 32
+    term_grace_seconds: int = 3
+    log_max_bytes: int = 1_048_576
+    log_backups: int = 3
+
+    @classmethod
+    def load(cls, path: Path) -> "Config":
+        values: dict[str, str] = {}
+        if path.exists():
+            for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if "=" not in line:
+                    raise ConfigError(f"{path}:{line_number}: expected KEY=VALUE")
+                key, value = (part.strip() for part in line.split("=", 1))
+                if key in values:
+                    raise ConfigError(f"{path}:{line_number}: duplicate key {key}")
+                values[key] = value
+
+        allowed = {
+            "ACTIVE",
+            "MIN_AGE_SECONDS",
+            "CONFIRMATIONS",
+            "INTERVAL_SECONDS",
+            "BATCH_LIMIT",
+            "TERM_GRACE_SECONDS",
+            "LOG_MAX_BYTES",
+            "LOG_BACKUPS",
+        }
+        unknown = sorted(set(values) - allowed)
+        if unknown:
+            raise ConfigError(f"unsupported configuration keys: {', '.join(unknown)}")
+
+        active = cls._parse_bool("ACTIVE", values.get("ACTIVE", "false"))
+        config = cls(
+            active=active,
+            min_age_seconds=cls._parse_int(values, "MIN_AGE_SECONDS", 300, 60, 86_400),
+            confirmations=cls._parse_int(values, "CONFIRMATIONS", 3, 2, 20),
+            interval_seconds=cls._parse_int(values, "INTERVAL_SECONDS", 30, 5, 3_600),
+            batch_limit=cls._parse_int(values, "BATCH_LIMIT", 32, 1, 128),
+            term_grace_seconds=cls._parse_int(values, "TERM_GRACE_SECONDS", 3, 1, 30),
+            log_max_bytes=cls._parse_int(values, "LOG_MAX_BYTES", 1_048_576, 65_536, 10_485_760),
+            log_backups=cls._parse_int(values, "LOG_BACKUPS", 3, 1, 10),
+        )
+        return config
+
+    @staticmethod
+    def _parse_bool(key: str, value: str) -> bool:
+        normalized = value.lower()
+        if normalized == "true":
+            return True
+        if normalized == "false":
+            return False
+        raise ConfigError(f"{key} must be true or false")
+
+    @staticmethod
+    def _parse_int(values: dict[str, str], key: str, default: int, minimum: int, maximum: int) -> int:
+        raw_value = values.get(key, str(default))
+        if not re.fullmatch(r"[0-9]+", raw_value):
+            raise ConfigError(f"{key} must be an integer between {minimum} and {maximum}")
+        value = int(raw_value)
+        if value < minimum or value > maximum:
+            raise ConfigError(f"{key} must be between {minimum} and {maximum}")
+        return value
+
+
+@dataclasses.dataclass(frozen=True, order=True)
+class ProcessIdentity:
+    pid: int
+    start_time_ticks: int
+
+
+@dataclasses.dataclass(frozen=True)
+class ProcessInfo:
+    identity: ProcessIdentity
+    parent_pid: int
+    name: str
+    command_line: tuple[str, ...] | None
+    age_seconds: float
+    child_count: int
+
+
+@dataclasses.dataclass(frozen=True)
+class ScanResult:
+    timestamp: float
+    strict_candidates: tuple[ProcessInfo, ...]
+    named_relays: tuple[ProcessInfo, ...]
+    session_leaders: tuple[ProcessInfo, ...]
+    inspection_errors: tuple[str, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class SignalDecision:
+    identity: ProcessIdentity
+    age_seconds: float | None
+    decision: str
+    term_sent: bool = False
+    kill_sent: bool = False
+    error: str | None = None
+
+
+class ProcScanner:
+    def __init__(self, proc_root: Path = Path("/proc"), clock_ticks: int | None = None) -> None:
+        self.proc_root = proc_root
+        self.clock_ticks = clock_ticks or int(os.sysconf("SC_CLK_TCK"))
+
+    @staticmethod
+    def _parse_stat(raw_stat: str) -> tuple[int, int]:
+        close_paren = raw_stat.rfind(")")
+        open_paren = raw_stat.find("(")
+        if open_paren <= 0 or close_paren <= open_paren:
+            raise ValueError("malformed stat process name")
+        fields = raw_stat[close_paren + 1 :].strip().split()
+        if len(fields) <= 19:
+            raise ValueError("stat has too few fields")
+        parent_pid = int(fields[1])
+        start_time_ticks = int(fields[19])
+        if parent_pid < 0 or start_time_ticks < 0:
+            raise ValueError("stat contains negative identity values")
+        return parent_pid, start_time_ticks
+
+    @staticmethod
+    def _parse_command_line(raw_command_line: bytes) -> tuple[str, ...]:
+        if not raw_command_line:
+            return ()
+        parts = raw_command_line.split(b"\0")
+        if parts and parts[-1] == b"":
+            parts.pop()
+        return tuple(part.decode("utf-8", errors="strict") for part in parts)
+
+    def _uptime_seconds(self) -> float:
+        raw_uptime = (self.proc_root / "uptime").read_text(encoding="ascii").split()
+        if not raw_uptime:
+            raise ValueError("uptime is empty")
+        return float(raw_uptime[0])
+
+    def read_identity(self, pid: int) -> ProcessIdentity | None:
+        try:
+            _, start_time_ticks = self._parse_stat(
+                (self.proc_root / str(pid) / "stat").read_text(encoding="utf-8")
+            )
+            return ProcessIdentity(pid=pid, start_time_ticks=start_time_ticks)
+        except (FileNotFoundError, PermissionError, OSError, UnicodeError, ValueError):
+            return None
+
+    def scan(self, min_age_seconds: int) -> ScanResult:
+        timestamp = time.time()
+        inspection_errors: list[str] = []
+        try:
+            uptime_seconds = self._uptime_seconds()
+        except (FileNotFoundError, PermissionError, OSError, ValueError) as error:
+            raise WatchdogError(f"cannot read procfs uptime: {error}") from error
+
+        partial_records: dict[int, tuple[int, int, str, tuple[str, ...] | None, float, int]] = {}
+        try:
+            process_dirs = tuple(self.proc_root.iterdir())
+        except OSError as error:
+            raise WatchdogError(f"cannot enumerate {self.proc_root}: {error}") from error
+
+        for process_dir in process_dirs:
+            if not process_dir.name.isdigit():
+                continue
+            pid = int(process_dir.name)
+            try:
+                parent_pid, start_time_ticks = self._parse_stat(
+                    (process_dir / "stat").read_text(encoding="utf-8")
+                )
+                name = (process_dir / "comm").read_text(encoding="utf-8").rstrip("\n")
+                command_line = None
+                child_count = 0
+                if name == "Relay":
+                    command_line = self._parse_command_line((process_dir / "cmdline").read_bytes())
+                    raw_children = (process_dir / "task" / str(pid) / "children").read_text(encoding="ascii").strip()
+                    if raw_children:
+                        child_pids = [int(child_pid) for child_pid in raw_children.split()]
+                        if any(child_pid <= 0 for child_pid in child_pids):
+                            raise ValueError("children contains an invalid PID")
+                        child_count = len(child_pids)
+                age_seconds = uptime_seconds - (start_time_ticks / self.clock_ticks)
+                if age_seconds < 0:
+                    raise ValueError("process start time is after uptime")
+                partial_records[pid] = (
+                    parent_pid,
+                    start_time_ticks,
+                    name,
+                    command_line,
+                    age_seconds,
+                    child_count,
+                )
+            except FileNotFoundError:
+                continue
+            except (PermissionError, OSError, UnicodeError, ValueError) as error:
+                if len(inspection_errors) < 50:
+                    inspection_errors.append(f"pid={pid}: {type(error).__name__}")
+
+        strict_candidates: list[ProcessInfo] = []
+        named_relays: list[ProcessInfo] = []
+        session_leaders: list[ProcessInfo] = []
+        for pid, (parent_pid, start_time_ticks, name, command_line, age_seconds, child_count) in partial_records.items():
+            info = ProcessInfo(
+                identity=ProcessIdentity(pid=pid, start_time_ticks=start_time_ticks),
+                parent_pid=parent_pid,
+                name=name,
+                command_line=command_line,
+                age_seconds=age_seconds,
+                child_count=child_count,
+            )
+            if NAMED_RELAY_PATTERN.fullmatch(name):
+                named_relays.append(info)
+            elif name == "SessionLeader":
+                session_leaders.append(info)
+            elif (
+                name == "Relay"
+                and parent_pid == 1
+                and command_line == ("/init",)
+                and info.child_count == 0
+                and age_seconds >= min_age_seconds
+            ):
+                strict_candidates.append(info)
+
+        strict_candidates.sort(key=lambda item: (-item.age_seconds, item.identity.pid))
+        named_relays.sort(key=lambda item: item.identity.pid)
+        session_leaders.sort(key=lambda item: item.identity.pid)
+        return ScanResult(
+            timestamp=timestamp,
+            strict_candidates=tuple(strict_candidates),
+            named_relays=tuple(named_relays),
+            session_leaders=tuple(session_leaders),
+            inspection_errors=tuple(inspection_errors),
+        )
+
+
+class ObservationTracker:
+    def __init__(self) -> None:
+        self._counts: dict[ProcessIdentity, int] = {}
+
+    def update(self, candidates: Iterable[ProcessInfo]) -> dict[ProcessIdentity, int]:
+        next_counts: dict[ProcessIdentity, int] = {}
+        for candidate in candidates:
+            identity = candidate.identity
+            next_counts[identity] = self._counts.get(identity, 0) + 1
+        self._counts = next_counts
+        return dict(self._counts)
+
+
+class CleanupEngine:
+    def __init__(
+        self,
+        scanner: ProcScanner,
+        config: Config,
+        open_pidfd: Callable[[int], int] = os.pidfd_open,
+        send_pidfd_signal: Callable[[int, int], None] | None = None,
+        close_pidfd: Callable[[int], None] = os.close,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self.scanner = scanner
+        self.config = config
+        self.open_pidfd = open_pidfd
+        self.send_pidfd_signal = send_pidfd_signal or (
+            lambda pidfd, signal_number: signal.pidfd_send_signal(pidfd, signal_number, None, 0)
+        )
+        self.close_pidfd = close_pidfd
+        self.sleep = sleep
+
+    def _revalidate(self, identity: ProcessIdentity) -> tuple[ProcessInfo | None, tuple[str, ...]]:
+        scan_result = self.scanner.scan(self.config.min_age_seconds)
+        for candidate in scan_result.strict_candidates:
+            if candidate.identity == identity:
+                return candidate, scan_result.inspection_errors
+        return None, scan_result.inspection_errors
+
+    def clean(self, eligible: Iterable[ProcessInfo]) -> tuple[SignalDecision, ...]:
+        ordered = sorted(eligible, key=lambda item: (-item.age_seconds, item.identity.pid))
+        decisions: list[SignalDecision] = []
+        for original in ordered[: self.config.batch_limit]:
+            identity = original.identity
+            try:
+                pidfd = self.open_pidfd(identity.pid)
+            except (ProcessLookupError, PermissionError, OSError) as error:
+                decisions.append(
+                    SignalDecision(
+                        identity=identity,
+                        age_seconds=None,
+                        decision="pidfd-open-error",
+                        error=type(error).__name__,
+                    )
+                )
+                continue
+            try:
+                current, _ = self._revalidate(identity)
+                if current is None:
+                    decisions.append(
+                        SignalDecision(identity=identity, age_seconds=None, decision="preserved-pre-term-revalidation")
+                    )
+                    continue
+                try:
+                    self.send_pidfd_signal(pidfd, signal.SIGTERM)
+                except ProcessLookupError:
+                    decisions.append(
+                        SignalDecision(identity=identity, age_seconds=current.age_seconds, decision="resolved-before-term")
+                    )
+                    continue
+                except (PermissionError, OSError) as error:
+                    decisions.append(
+                        SignalDecision(
+                            identity=identity,
+                            age_seconds=current.age_seconds,
+                            decision="term-error",
+                            error=type(error).__name__,
+                        )
+                    )
+                    continue
+
+                self.sleep(self.config.term_grace_seconds)
+                survivor, _ = self._revalidate(identity)
+                if survivor is None:
+                    decisions.append(
+                        SignalDecision(
+                            identity=identity,
+                            age_seconds=current.age_seconds,
+                            decision="resolved-after-term",
+                            term_sent=True,
+                        )
+                    )
+                    continue
+                try:
+                    self.send_pidfd_signal(pidfd, signal.SIGKILL)
+                    decisions.append(
+                        SignalDecision(
+                            identity=identity,
+                            age_seconds=survivor.age_seconds,
+                            decision="kill-sent",
+                            term_sent=True,
+                            kill_sent=True,
+                        )
+                    )
+                except ProcessLookupError:
+                    decisions.append(
+                        SignalDecision(
+                            identity=identity,
+                            age_seconds=survivor.age_seconds,
+                            decision="resolved-before-kill",
+                            term_sent=True,
+                        )
+                    )
+                except (PermissionError, OSError) as error:
+                    decisions.append(
+                        SignalDecision(
+                            identity=identity,
+                            age_seconds=survivor.age_seconds,
+                            decision="kill-error",
+                            term_sent=True,
+                            error=type(error).__name__,
+                        )
+                    )
+            finally:
+                self.close_pidfd(pidfd)
+        return tuple(decisions)
+
+
+def atomic_write_json(path: Path, payload: dict[str, object], mode: int = 0o644) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    file_descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(file_descriptor, "w", encoding="utf-8") as temporary_file:
+            json.dump(payload, temporary_file, sort_keys=True)
+            temporary_file.write("\n")
+            temporary_file.flush()
+            os.fsync(temporary_file.fileno())
+        os.chmod(temporary_name, mode)
+        os.replace(temporary_name, path)
+    finally:
+        try:
+            os.unlink(temporary_name)
+        except FileNotFoundError:
+            pass
+
+
+def configure_logger(log_dir: Path, config: Config) -> logging.Logger:
+    log_dir.mkdir(parents=True, exist_ok=True)
+    logger = logging.getLogger("wsl-relay-watchdog")
+    logger.handlers.clear()
+    logger.setLevel(logging.INFO)
+    handler = RotatingFileHandler(
+        log_dir / "watchdog.log",
+        maxBytes=config.log_max_bytes,
+        backupCount=config.log_backups,
+        encoding="utf-8",
+    )
+    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+    logger.addHandler(handler)
+    logger.propagate = False
+    return logger
+
+
+def process_summary(process: ProcessInfo) -> dict[str, object]:
+    return {
+        "pid": process.identity.pid,
+        "start_time_ticks": process.identity.start_time_ticks,
+        "age_seconds": round(process.age_seconds, 3),
+    }
+
+
+class WatchdogDaemon:
+    def __init__(
+        self,
+        config: Config,
+        scanner: ProcScanner,
+        run_dir: Path,
+        log_dir: Path,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self.config = config
+        self.scanner = scanner
+        self.run_dir = run_dir
+        self.log_dir = log_dir
+        self.sleep = sleep
+        self.tracker = ObservationTracker()
+        self.cleanup_engine = CleanupEngine(scanner, config, sleep=sleep)
+        self.stop_requested = False
+        self.logger: logging.Logger | None = None
+
+    def _request_stop(self, _signal_number: int, _frame: object) -> None:
+        self.stop_requested = True
+
+    def _write_process_identity(self) -> None:
+        identity = self.scanner.read_identity(os.getpid())
+        if identity is None:
+            raise WatchdogError("cannot verify watchdog process identity")
+        atomic_write_json(
+            self.run_dir / "watchdog.pid.json",
+            {
+                "pid": identity.pid,
+                "start_time_ticks": identity.start_time_ticks,
+                "version": VERSION,
+            },
+            mode=0o644,
+        )
+
+    def _log_decision(self, decision: SignalDecision) -> None:
+        if self.logger is None:
+            return
+        self.logger.info(
+            "pid=%d start_time_ticks=%d age_seconds=%s decision=%s term_sent=%s kill_sent=%s error=%s",
+            decision.identity.pid,
+            decision.identity.start_time_ticks,
+            "unknown" if decision.age_seconds is None else f"{decision.age_seconds:.3f}",
+            decision.decision,
+            str(decision.term_sent).lower(),
+            str(decision.kill_sent).lower(),
+            decision.error or "none",
+        )
+
+    def run_cycle(self) -> dict[str, object]:
+        scan_result = self.scanner.scan(self.config.min_age_seconds)
+        observations = self.tracker.update(scan_result.strict_candidates)
+        eligible = tuple(
+            process
+            for process in scan_result.strict_candidates
+            if observations.get(process.identity, 0) >= self.config.confirmations
+        )
+        decisions: tuple[SignalDecision, ...] = ()
+        if self.config.active:
+            decisions = self.cleanup_engine.clean(eligible)
+            for decision in decisions:
+                self._log_decision(decision)
+
+        term_sent = sum(1 for decision in decisions if decision.term_sent)
+        kill_sent = sum(1 for decision in decisions if decision.kill_sent)
+        signal_errors = sum(1 for decision in decisions if decision.error is not None)
+        now = time.time()
+        status: dict[str, object] = {
+            "version": VERSION,
+            "timestamp": now,
+            "mode": "active" if self.config.active else "inactive",
+            "strict_candidates": len(scan_result.strict_candidates),
+            "confirmed_candidates": len(eligible),
+            "protected_named_relays": len(scan_result.named_relays),
+            "protected_session_leaders": len(scan_result.session_leaders),
+            "term_sent": term_sent,
+            "kill_sent": kill_sent,
+            "inspection_errors": len(scan_result.inspection_errors),
+            "signal_errors": signal_errors,
+            "next_scan_time": now + self.config.interval_seconds,
+        }
+        atomic_write_json(self.run_dir / "status.json", status)
+        if self.logger is not None:
+            self.logger.info(
+                "cycle mode=%s strict=%d confirmed=%d named_relays=%d session_leaders=%d term_sent=%d kill_sent=%d inspection_errors=%d signal_errors=%d",
+                status["mode"],
+                status["strict_candidates"],
+                status["confirmed_candidates"],
+                status["protected_named_relays"],
+                status["protected_session_leaders"],
+                term_sent,
+                kill_sent,
+                status["inspection_errors"],
+                signal_errors,
+            )
+        return status
+
+    def run(self, max_cycles: int | None = None) -> int:
+        if self.config.active and os.geteuid() != 0:
+            raise WatchdogError("active daemon mode requires root")
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+        lock_file = (self.run_dir / "watchdog.lock").open("a+", encoding="utf-8")
+        try:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            lock_file.close()
+            return 0
+
+        os.umask(0o027)
+        self.logger = configure_logger(self.log_dir, self.config)
+        self._write_process_identity()
+        signal.signal(signal.SIGTERM, self._request_stop)
+        signal.signal(signal.SIGINT, self._request_stop)
+        cycles = 0
+        try:
+            while not self.stop_requested:
+                self.run_cycle()
+                cycles += 1
+                if max_cycles is not None and cycles >= max_cycles:
+                    break
+                self.sleep(self.config.interval_seconds)
+        finally:
+            try:
+                (self.run_dir / "watchdog.pid.json").unlink()
+            except FileNotFoundError:
+                pass
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+            lock_file.close()
+        return 0
+
+
+def scan_payload(scan_result: ScanResult, config: Config) -> dict[str, object]:
+    return {
+        "version": VERSION,
+        "timestamp": scan_result.timestamp,
+        "mode": "scan",
+        "active_configuration": config.active,
+        "strict_count": len(scan_result.strict_candidates),
+        "strict_candidates": [process_summary(process) for process in scan_result.strict_candidates],
+        "protected_named_relay_count": len(scan_result.named_relays),
+        "protected_named_relays": [process_summary(process) for process in scan_result.named_relays],
+        "protected_session_leader_count": len(scan_result.session_leaders),
+        "protected_session_leaders": [process_summary(process) for process in scan_result.session_leaders],
+        "inspection_errors": list(scan_result.inspection_errors),
+    }
+
+
+def print_json(payload: object) -> None:
+    json.dump(payload, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Strict WSL orphan relay watchdog")
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH)
+    parser.add_argument("--proc-root", type=Path, default=Path("/proc"))
+    parser.add_argument("--run-dir", type=Path, default=DEFAULT_RUN_DIR)
+    parser.add_argument("--log-dir", type=Path, default=DEFAULT_LOG_DIR)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("scan", help="inspect live processes without signaling")
+    subparsers.add_parser("status", help="show the most recent daemon status")
+    daemon_parser = subparsers.add_parser("daemon", help="run the singleton monitoring daemon")
+    daemon_parser.add_argument("--max-cycles", type=int, help=argparse.SUPPRESS)
+    run_once_parser = subparsers.add_parser("run-once", help="confirm and clean one bounded batch")
+    run_once_parser.add_argument("--active", action="store_true", help="explicitly permit signaling")
+    subparsers.add_parser("validate-config", help="validate configuration without scanning")
+    return parser
+
+
+def run_once(config: Config, scanner: ProcScanner, active_confirmation: bool) -> int:
+    if not config.active or not active_confirmation:
+        raise WatchdogError("run-once signaling requires ACTIVE=true and --active")
+    if os.geteuid() != 0:
+        raise WatchdogError("active run-once mode requires root")
+    tracker = ObservationTracker()
+    latest_scan: ScanResult | None = None
+    counts: dict[ProcessIdentity, int] = {}
+    for observation_number in range(config.confirmations):
+        latest_scan = scanner.scan(config.min_age_seconds)
+        counts = tracker.update(latest_scan.strict_candidates)
+        if observation_number + 1 < config.confirmations:
+            time.sleep(config.interval_seconds)
+    assert latest_scan is not None
+    eligible = [
+        process
+        for process in latest_scan.strict_candidates
+        if counts.get(process.identity, 0) >= config.confirmations
+    ]
+    decisions = CleanupEngine(scanner, config).clean(eligible)
+    print_json(
+        {
+            "mode": "active-run-once",
+            "strict_candidates": len(latest_scan.strict_candidates),
+            "confirmed_candidates": len(eligible),
+            "term_sent": sum(1 for decision in decisions if decision.term_sent),
+            "kill_sent": sum(1 for decision in decisions if decision.kill_sent),
+            "decisions": [dataclasses.asdict(decision) for decision in decisions],
+        }
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    arguments = parser.parse_args(argv)
+    try:
+        config = Config.load(arguments.config)
+        scanner = ProcScanner(arguments.proc_root)
+        if arguments.command == "validate-config":
+            print_json({"valid": True, "active": config.active, "version": VERSION})
+            return 0
+        if arguments.command == "scan":
+            print_json(scan_payload(scanner.scan(config.min_age_seconds), config))
+            return 0
+        if arguments.command == "status":
+            status_path = arguments.run_dir / "status.json"
+            if not status_path.exists():
+                print_json({"running": False, "status": "unavailable"})
+                return 3
+            status_payload = json.loads(status_path.read_text(encoding="utf-8"))
+            pid_path = arguments.run_dir / "watchdog.pid.json"
+            running = False
+            if pid_path.exists():
+                identity_payload = json.loads(pid_path.read_text(encoding="utf-8"))
+                expected_identity = ProcessIdentity(
+                    pid=int(identity_payload["pid"]),
+                    start_time_ticks=int(identity_payload["start_time_ticks"]),
+                )
+                running = scanner.read_identity(expected_identity.pid) == expected_identity
+                status_payload["watchdog_identity"] = dataclasses.asdict(expected_identity)
+            status_payload["running"] = running
+            print_json(status_payload)
+            return 0 if running else 3
+        if arguments.command == "run-once":
+            return run_once(config, scanner, arguments.active)
+        if arguments.command == "daemon":
+            daemon = WatchdogDaemon(config, scanner, arguments.run_dir, arguments.log_dir)
+            return daemon.run(max_cycles=arguments.max_cycles)
+        parser.error(f"unsupported command: {arguments.command}")
+    except (ConfigError, WatchdogError) as error:
+        print(f"wsl-relay-watchdog: {error}", file=sys.stderr)
+        return 2
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/wsl-relay-watchdog/wsl_relay_watchdog.py
+++ b/scripts/wsl-relay-watchdog/wsl_relay_watchdog.py
@@ -166,9 +166,10 @@ class ProcScanner:
     def _parse_command_line(raw_command_line: bytes) -> tuple[str, ...]:
         if not raw_command_line:
             return ()
+        if not raw_command_line.endswith(b"\0"):
+            raise ValueError("cmdline is missing its procfs delimiter")
         parts = raw_command_line.split(b"\0")
-        if parts and parts[-1] == b"":
-            parts.pop()
+        parts.pop()
         return tuple(part.decode("utf-8", errors="strict") for part in parts)
 
     def _uptime_seconds(self) -> float:
@@ -197,11 +198,14 @@ class ProcScanner:
             )
             if start_time_ticks != identity.start_time_ticks:
                 return None
-            raw_name = (process_dir / "comm").read_text(encoding="utf-8")
-            if not raw_name.endswith("\n"):
+            raw_name = (process_dir / "comm").read_bytes()
+            if not raw_name.endswith(b"\n"):
                 return None
-            name = raw_name[:-1]
-            if "\n" in name or "\r" in name or name != "Relay":
+            raw_name = raw_name[:-1]
+            if b"\n" in raw_name or b"\r" in raw_name:
+                return None
+            name = raw_name.decode("utf-8", errors="strict")
+            if name != "Relay":
                 return None
             command_line = self._parse_command_line((process_dir / "cmdline").read_bytes())
             task_dirs = tuple(
@@ -257,12 +261,13 @@ class ProcScanner:
                 parent_pid, start_time_ticks = self._parse_stat(
                     (process_dir / "stat").read_text(encoding="utf-8")
                 )
-                raw_name = (process_dir / "comm").read_text(encoding="utf-8")
-                if not raw_name.endswith("\n"):
+                raw_name = (process_dir / "comm").read_bytes()
+                if not raw_name.endswith(b"\n"):
                     raise ValueError("comm is missing its procfs delimiter")
-                name = raw_name[:-1]
-                if "\n" in name or "\r" in name:
+                raw_name = raw_name[:-1]
+                if b"\n" in raw_name or b"\r" in raw_name:
                     raise ValueError("comm contains an embedded newline")
+                name = raw_name.decode("utf-8", errors="strict")
                 command_line = None
                 child_count = 0
                 if name == "Relay":

--- a/scripts/wsl-relay-watchdog/wsl_relay_watchdog.py
+++ b/scripts/wsl-relay-watchdog/wsl_relay_watchdog.py
@@ -186,6 +186,55 @@ class ProcScanner:
         except (FileNotFoundError, PermissionError, OSError, UnicodeError, ValueError):
             return None
 
+    def inspect_strict_candidate(
+        self, identity: ProcessIdentity, min_age_seconds: int
+    ) -> ProcessInfo | None:
+        process_dir = self.proc_root / str(identity.pid)
+        try:
+            uptime_seconds = self._uptime_seconds()
+            parent_pid, start_time_ticks = self._parse_stat(
+                (process_dir / "stat").read_text(encoding="utf-8")
+            )
+            if start_time_ticks != identity.start_time_ticks:
+                return None
+            raw_name = (process_dir / "comm").read_text(encoding="utf-8")
+            if not raw_name.endswith("\n"):
+                return None
+            name = raw_name[:-1]
+            if "\n" in name or "\r" in name or name != "Relay":
+                return None
+            command_line = self._parse_command_line((process_dir / "cmdline").read_bytes())
+            task_dirs = tuple(
+                task_dir for task_dir in (process_dir / "task").iterdir() if task_dir.name.isdigit()
+            )
+            if not task_dirs:
+                return None
+            child_pids: set[int] = set()
+            for task_dir in task_dirs:
+                raw_children = (task_dir / "children").read_text(encoding="ascii").strip()
+                if not raw_children:
+                    continue
+                task_child_pids = [int(child_pid) for child_pid in raw_children.split()]
+                if any(child_pid <= 0 for child_pid in task_child_pids):
+                    return None
+                child_pids.update(task_child_pids)
+            age_seconds = uptime_seconds - (start_time_ticks / self.clock_ticks)
+            if age_seconds < min_age_seconds:
+                return None
+            candidate = ProcessInfo(
+                identity=identity,
+                parent_pid=parent_pid,
+                name=name,
+                command_line=command_line,
+                age_seconds=age_seconds,
+                child_count=len(child_pids),
+            )
+            if parent_pid != 1 or command_line != ("/init",) or candidate.child_count != 0:
+                return None
+            return candidate
+        except (FileNotFoundError, PermissionError, OSError, UnicodeError, ValueError):
+            return None
+
     def scan(self, min_age_seconds: int) -> ScanResult:
         timestamp = time.time()
         inspection_errors: list[str] = []
@@ -320,11 +369,7 @@ class CleanupEngine:
         self.sleep = sleep
 
     def _revalidate(self, identity: ProcessIdentity) -> tuple[ProcessInfo | None, tuple[str, ...]]:
-        scan_result = self.scanner.scan(self.config.min_age_seconds)
-        for candidate in scan_result.strict_candidates:
-            if candidate.identity == identity:
-                return candidate, scan_result.inspection_errors
-        return None, scan_result.inspection_errors
+        return self.scanner.inspect_strict_candidate(identity, self.config.min_age_seconds), ()
 
     def clean(self, eligible: Iterable[ProcessInfo]) -> tuple[SignalDecision, ...]:
         ordered = sorted(eligible, key=lambda item: (-item.age_seconds, item.identity.pid))

--- a/scripts/wsl-relay-watchdog/wsl_relay_watchdog.py
+++ b/scripts/wsl-relay-watchdog/wsl_relay_watchdog.py
@@ -716,12 +716,14 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     arguments = parser.parse_args(argv)
     try:
-        config = Config.load(arguments.config)
+        config = None if arguments.command == "status" else Config.load(arguments.config)
         scanner = ProcScanner(arguments.proc_root)
         if arguments.command == "validate-config":
+            assert config is not None
             print_json({"valid": True, "active": config.active, "version": VERSION})
             return 0
         if arguments.command == "scan":
+            assert config is not None
             print_json(scan_payload(scanner.scan(config.min_age_seconds), config))
             return 0
         if arguments.command == "status":
@@ -763,8 +765,10 @@ def main(argv: list[str] | None = None) -> int:
             print_json(status_payload)
             return 0 if running else 3
         if arguments.command == "run-once":
+            assert config is not None
             return run_once(config, scanner, arguments.active)
         if arguments.command == "daemon":
+            assert config is not None
             daemon = WatchdogDaemon(config, scanner, arguments.run_dir, arguments.log_dir)
             return daemon.run(max_cycles=arguments.max_cycles)
         parser.error(f"unsupported command: {arguments.command}")

--- a/scripts/wsl-relay-watchdog/wsl_relay_watchdog.py
+++ b/scripts/wsl-relay-watchdog/wsl_relay_watchdog.py
@@ -208,7 +208,12 @@ class ProcScanner:
                 parent_pid, start_time_ticks = self._parse_stat(
                     (process_dir / "stat").read_text(encoding="utf-8")
                 )
-                name = (process_dir / "comm").read_text(encoding="utf-8").rstrip("\n")
+                raw_name = (process_dir / "comm").read_text(encoding="utf-8")
+                if not raw_name.endswith("\n"):
+                    raise ValueError("comm is missing its procfs delimiter")
+                name = raw_name[:-1]
+                if "\n" in name or "\r" in name:
+                    raise ValueError("comm contains an embedded newline")
                 command_line = None
                 child_count = 0
                 if name == "Relay":


### PR DESCRIPTION
Lane: workbenches-sync
Claim: https://github.com/opensoft/workBenches/issues/23#issuecomment-5593664129

## Summary

- add a fail-closed Linux-side watchdog for strict orphan WSL relay processes
- preserve named relays, SessionLeaders, relays with children on any thread, recent relays, malformed names, and ambiguous identities
- revalidate PID and start-time identity before TERM and before KILL
- refuse occupied unmanaged install paths and modified managed files using recorded SHA-256 digests
- provide reversible installation, bounded logging, dry-run inspection, and documentation

## Validation

- 26 focused unit tests passed
- Python compilation and shell syntax checks passed
- strict OpenSpec validation passed
- live non-mutating qualification with the same 60-second minimum-age policy found zero strict candidates, protected all 25 named relays and 24 SessionLeaders, and found zero scan errors or classification overlap
- git diff --check passed

## Summary by Sourcery

Add a fail-closed WSL relay watchdog that safely detects confirmed orphan relays and provides non-destructive lifecycle management.

New Features:
- Add a fail-closed WSL relay watchdog that identifies and cleans up only confirmed strict orphan relays while preserving named relays, SessionLeaders, child-bearing processes, recent processes, and ambiguous identities.
- Provide dry-run scanning, daemon status reporting, bounded logging, configurable cleanup limits, and reversible installation and rollback without enabling systemd or restarting WSL.

Enhancements:
- Require repeated PID/start-time identity confirmation and full predicate revalidation before TERM and KILL, using pidfds to prevent PID-reuse signaling.
- Make installation non-destructive by preserving unrelated WSL settings, refusing boot-command and managed-path conflicts, and tracking managed-file digests for safe upgrades and removal.

Deployment:
- Register and launch the watchdog through the WSL boot command with root-owned runtime, configuration, state, and log files.

Documentation:
- Document watchdog safety boundaries, installation, activation, status and scan commands, configuration bounds, conflict handling, and rollback procedures.

Tests:
- Add focused synthetic procfs, classification, revalidation, signaling, configuration, daemon, logging, installation, and rollback coverage, along with live non-mutating qualification and syntax checks.