### PR TITLE
Enable user-owned Codex updates in Layer 3

### DIFF
--- a/devcontainer.test/test-ensure-layer3-freshness.sh
+++ b/devcontainer.test/test-ensure-layer3-freshness.sh
@@ -73,12 +73,26 @@ export PATH="$TEST_DIR/bin:$PATH"
 export TEST_SOCKET_GID="$(stat -c '%g' /var/run/docker.sock 2>/dev/null || true)"
 
 recipe_sha256() {
+    local hash_tool
+    if command -v sha256sum >/dev/null 2>&1; then
+        hash_tool=sha256sum
+    else
+        hash_tool=shasum
+    fi
+
     (
         cd "$ROOT_DIR/user-layer"
-        find . -type f -print0 \
-            | LC_ALL=C sort -z \
-            | xargs -0 sha256sum \
-            | sha256sum \
+        find . -type f -print \
+            | LC_ALL=C sort \
+            | while IFS= read -r recipe_file; do
+                if [[ "$hash_tool" == sha256sum ]]; then
+                    file_sha="$(sha256sum "$recipe_file" | awk '{print $1}')"
+                else
+                    file_sha="$(shasum -a 256 "$recipe_file" | awk '{print $1}')"
+                fi
+                printf '%s  %s\n' "$file_sha" "$recipe_file"
+            done \
+            | if [[ "$hash_tool" == sha256sum ]]; then sha256sum; else shasum -a 256; fi \
             | awk '{print $1}'
     )
 }

--- a/devcontainer.test/test-ensure-layer3-freshness.sh
+++ b/devcontainer.test/test-ensure-layer3-freshness.sh
@@ -31,6 +31,9 @@ case "$1 $2" in
         fi
         ;;
     "container inspect")
+        if [[ -f "${TEST_REMOVED_MARKER:-/nonexistent}" ]]; then
+            exit 1
+        fi
         case "$4" in
             *Config.Image*) printf '%s\n' dotnet-bench:brett ;;
             *State.Running*) printf '%s\n' false ;;
@@ -58,6 +61,10 @@ case "$1 $2" in
     "rm -f")
         ;;
     "rm stale-container")
+        if [[ "${TEST_RM_ALREADY_ABSENT:-false}" == true ]]; then
+            : > "$TEST_REMOVED_MARKER"
+            exit 1
+        fi
         ;;
     "build --build-arg")
         ;;
@@ -114,5 +121,11 @@ if grep -q '^build ' "$DOCKER_LOG"; then
     exit 1
 fi
 grep -q '^rm stale-container$' "$DOCKER_LOG"
+
+export TEST_RM_ALREADY_ABSENT=true
+export TEST_REMOVED_MARKER="$TEST_DIR/removed"
+run_check
+grep -q '^rm stale-container$' "$DOCKER_LOG"
+grep -q '^container inspect stale-container$' "$DOCKER_LOG"
 
 echo "ensure-layer3 recipe freshness tests passed"

--- a/devcontainer.test/test-ensure-layer3-freshness.sh
+++ b/devcontainer.test/test-ensure-layer3-freshness.sh
@@ -18,15 +18,28 @@ printf '%s\n' "$*" >> "$DOCKER_LOG"
 case "$1 $2" in
     "image inspect")
         if [[ "$3" == "--format" ]]; then
-            printf '%s\n' "${TEST_IMAGE_RECIPE_SHA256:-}"
+            if [[ "$4" == *recipe-sha256* ]]; then
+                printf '%s\n' "${TEST_IMAGE_RECIPE_SHA256:-}"
+            else
+                printf '%s\n' 'sha256:new-user-image'
+            fi
         fi
         ;;
     "container ls")
+        if [[ " $* " == *" --all "* && "${TEST_STALE_CONTAINER:-false}" == true ]]; then
+            printf '%s\n' stale-container
+        fi
         ;;
     "container inspect")
+        case "$4" in
+            *Config.Image*) printf '%s\n' dotnet-bench:brett ;;
+            *State.Running*) printf '%s\n' false ;;
+        esac
         ;;
     "inspect --format")
-        if [[ "$4" == *:latest ]]; then
+        if [[ "$3" == *Image* && "$4" == stale-container ]]; then
+            printf '%s\n' 'sha256:old-user-image'
+        elif [[ "$4" == *:latest ]]; then
             printf '%s\n' '2026-09-08T12:00:00Z'
         else
             printf '%s\n' '2026-09-08T12:01:00Z'
@@ -43,6 +56,8 @@ case "$1 $2" in
         fi
         ;;
     "rm -f")
+        ;;
+    "rm stale-container")
         ;;
     "build --build-arg")
         ;;
@@ -78,10 +93,12 @@ run_check
 grep -q '^build ' "$DOCKER_LOG"
 
 export TEST_IMAGE_RECIPE_SHA256="$(recipe_sha256)"
+export TEST_STALE_CONTAINER=true
 run_check
 if grep -q '^build ' "$DOCKER_LOG"; then
     echo "matching recipe fingerprint unexpectedly rebuilt Layer 3" >&2
     exit 1
 fi
+grep -q '^rm stale-container$' "$DOCKER_LOG"
 
 echo "ensure-layer3 recipe freshness tests passed"

--- a/devcontainer.test/test-ensure-layer3-freshness.sh
+++ b/devcontainer.test/test-ensure-layer3-freshness.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+mkdir -p "$TEST_DIR/bin"
+DOCKER_LOG="$TEST_DIR/docker.log"
+export DOCKER_LOG
+
+cat > "$TEST_DIR/bin/docker" <<'EOF'
+#!/bin/bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "$DOCKER_LOG"
+
+case "$1 $2" in
+    "image inspect")
+        if [[ "$3" == "--format" ]]; then
+            printf '%s\n' "${TEST_IMAGE_RECIPE_SHA256:-}"
+        fi
+        ;;
+    "container ls")
+        ;;
+    "container inspect")
+        ;;
+    "inspect --format")
+        if [[ "$4" == *:latest ]]; then
+            printf '%s\n' '2026-09-08T12:00:00Z'
+        else
+            printf '%s\n' '2026-09-08T12:01:00Z'
+        fi
+        ;;
+    "create --name")
+        printf '%s\n' test-container
+        ;;
+    "cp ensure-layer3-check"*)
+        if [[ "$2" == *:/etc/passwd ]]; then
+            printf 'brett:x:1000:%s::/home/brett:/bin/zsh\n' "${TEST_SOCKET_GID:-1000}" > "$3"
+        else
+            printf 'docker-host:x:%s:brett\n' "${TEST_SOCKET_GID:-1000}" > "$3"
+        fi
+        ;;
+    "rm -f")
+        ;;
+    "build --build-arg")
+        ;;
+    *)
+        echo "unexpected docker invocation: $*" >&2
+        exit 1
+        ;;
+esac
+EOF
+chmod +x "$TEST_DIR/bin/docker"
+
+export PATH="$TEST_DIR/bin:$PATH"
+export TEST_SOCKET_GID="$(stat -c '%g' /var/run/docker.sock 2>/dev/null || true)"
+
+recipe_sha256() {
+    (
+        cd "$ROOT_DIR/user-layer"
+        find . -type f -print0 \
+            | LC_ALL=C sort -z \
+            | xargs -0 sha256sum \
+            | sha256sum \
+            | awk '{print $1}'
+    )
+}
+
+run_check() {
+    : > "$DOCKER_LOG"
+    "$ROOT_DIR/scripts/ensure-layer3.sh" --base dotnet-bench:latest --user brett
+}
+
+export TEST_IMAGE_RECIPE_SHA256=stale
+run_check
+grep -q '^build ' "$DOCKER_LOG"
+
+export TEST_IMAGE_RECIPE_SHA256="$(recipe_sha256)"
+run_check
+if grep -q '^build ' "$DOCKER_LOG"; then
+    echo "matching recipe fingerprint unexpectedly rebuilt Layer 3" >&2
+    exit 1
+fi
+
+echo "ensure-layer3 recipe freshness tests passed"

--- a/openspec/changes/enable-user-codex-updates/.openspec.yaml
+++ b/openspec/changes/enable-user-codex-updates/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-08

--- a/openspec/changes/enable-user-codex-updates/design.md
+++ b/openspec/changes/enable-user-codex-updates/design.md
@@ -23,6 +23,8 @@ system-wide Codex binary without a writable npm prefix.
 - Install a second Codex copy into the runtime user's `$HOME/.npm-global` after Layer 3
   switches to the runtime user. This isolates user updates from the shared
   root-owned package.
+- Bake a reviewed, pinned Codex version into Layer 3. Runtime users can advance
+  their writable copy later with the normal Codex update workflow.
 - Set the npm global prefix and prepend its bin directory through Layer 3
   environment configuration. The resolved `codex` and the updater therefore
   use the same writable location.

--- a/openspec/changes/enable-user-codex-updates/design.md
+++ b/openspec/changes/enable-user-codex-updates/design.md
@@ -1,0 +1,48 @@
+## Context
+
+See proposal.md for motivation. Layer 0 deliberately installs shared npm
+packages as root. Layer 3 creates the runtime user but currently inherits the
+system-wide Codex binary without a writable npm prefix.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the Layer 3 `codex` executable and its npm package writable by the
+  runtime user.
+- Preserve the shared Layer 0 Codex package and its ownership.
+
+**Non-Goals:**
+
+- Do not change Layer 0 or Layer 2 images.
+- Do not replace or restart a running bench.
+- Do not make arbitrary system npm packages user-writable.
+
+## Decisions
+
+- Install a second Codex copy into the runtime user's `$HOME/.npm-global` after Layer 3
+  switches to the runtime user. This isolates user updates from the shared
+  root-owned package.
+- Set the npm global prefix and prepend its bin directory through Layer 3
+  environment configuration. The resolved `codex` and the updater therefore
+  use the same writable location.
+- Retain the Layer 0 copy as a base-image fallback. Chowning the shared npm
+  directory was rejected because it would weaken the user-agnostic ownership
+  boundary; requiring `sudo` was rejected because it leaves untracked
+  container drift.
+
+## Risks / Trade-offs
+
+- [User-updated Codex can differ from the baked baseline] → The image build
+  supplies an initial known package and version checks will report the resolved
+  user copy.
+- [Two Codex installations increase image size] → The additional package is
+  small relative to the bench image and preserves the shared baseline.
+
+## Migration Plan
+
+1. Build the target Layer 3 image from its existing Layer 2 base.
+2. Verify the resolved Codex path, ownership, writable npm prefix, and version
+   in a disposable container.
+3. Keep the running bench unchanged until an explicit managed close/reopen is
+   authorized.

--- a/openspec/changes/enable-user-codex-updates/design.md
+++ b/openspec/changes/enable-user-codex-updates/design.md
@@ -32,6 +32,9 @@ system-wide Codex binary without a writable npm prefix.
   directory was rejected because it would weaken the user-agnostic ownership
   boundary; requiring `sudo` was rejected because it leaves untracked
   container drift.
+- Reconcile stopped containers configured for the user-image tag whenever the
+  tag points at a newer image ID. Removal is non-forced and a container that
+  starts during the check is preserved.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/enable-user-codex-updates/proposal.md
+++ b/openspec/changes/enable-user-codex-updates/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Codex is installed in the shared Layer 0 image as root, so its built-in npm
+updater fails for the non-root user in a running bench. Users need a writable
+Codex installation without weakening ownership of the shared baseline.
+
+## What Changes
+
+- Add a user-owned Codex npm installation to Layer 3 after the runtime user is
+  created.
+- Prepend that user-owned npm bin directory to the Layer 3 `PATH`.
+- Keep the existing root-owned Layer 0 Codex installation unchanged as the
+  shared baseline.
+
+## Capabilities
+
+### New Capabilities
+
+- `user-managed-codex-updates`: Layer 3 user images provide a writable Codex
+  installation that supports the Codex npm update workflow.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- [user-layer/Dockerfile](../../../user-layer/Dockerfile): installs and
+  prioritizes the user-owned Codex overlay.
+- Layer 3 images must be rebuilt to include the behavior; no live container is
+  replaced by this change.

--- a/openspec/changes/enable-user-codex-updates/specs/user-managed-codex-updates/spec.md
+++ b/openspec/changes/enable-user-codex-updates/specs/user-managed-codex-updates/spec.md
@@ -1,0 +1,22 @@
+## Purpose
+
+Provide each personalized bench image with a Codex installation that its
+runtime user can update without modifying the shared image baseline.
+
+## ADDED Requirements
+
+### Requirement: Layer 3 provides a user-owned Codex installation
+The Layer 3 image SHALL install Codex into an npm prefix owned by its runtime
+user and SHALL resolve `codex` from that prefix before any system-wide copy.
+
+#### Scenario: Runtime user resolves the writable Codex copy
+- **WHEN** a user starts a shell in a Layer 3 bench image
+- **THEN** `command -v codex` resolves under that user's npm global prefix
+
+### Requirement: The shared Codex baseline remains root-owned
+The Layer 3 image SHALL NOT change ownership or permissions of the Codex
+installation inherited from the shared base image.
+
+#### Scenario: Updating Codex does not require writes to the shared prefix
+- **WHEN** the runtime user updates the resolved Codex installation
+- **THEN** npm writes only within the user's global npm prefix

--- a/openspec/changes/enable-user-codex-updates/tasks.md
+++ b/openspec/changes/enable-user-codex-updates/tasks.md
@@ -1,0 +1,9 @@
+## 1. Layer 3 Codex Overlay
+
+- [x] 1.1 Configure a user-owned npm prefix and PATH precedence in `user-layer/Dockerfile`, then verify the inherited system prefix is not modified.
+- [x] 1.2 Install Codex into the Layer 3 user prefix as the runtime user, then verify the installed package is user-owned.
+
+## 2. Image Validation
+
+- [x] 2.1 Build a disposable `dotnet-bench:brett` Layer 3 image and verify `codex` resolves from `$HOME/.npm-global/bin`.
+- [x] 2.2 Verify the resolved Codex package is writable by `brett`, the shared `/usr/lib/node_modules/@openai/codex` remains root-owned, and OpenSpec validation passes.

--- a/openspec/changes/enable-user-codex-updates/tasks.md
+++ b/openspec/changes/enable-user-codex-updates/tasks.md
@@ -3,9 +3,10 @@
 - [x] 1.1 Configure a user-owned npm prefix and PATH precedence in `user-layer/Dockerfile`, then verify the inherited system prefix is not modified.
 - [x] 1.2 Install a pinned Codex version into the Layer 3 user prefix as the runtime user, then verify the installed package is user-owned.
 - [x] 1.3 Fingerprint the Layer 3 build recipe and rebuild an existing user image whenever its recorded recipe fingerprint differs.
+- [x] 1.4 Remove only stopped containers configured for the user-image tag when their immutable image ID is stale, preserving running or racing containers.
 
 ## 2. Image Validation
 
 - [x] 2.1 Build a disposable `dotnet-bench:brett` Layer 3 image and verify `codex` resolves from `$HOME/.npm-global/bin`.
 - [x] 2.2 Verify the resolved Codex package is writable by `brett`, the base image's shared Codex package (located with its root npm global prefix) remains root-owned, and OpenSpec validation passes.
-- [x] 2.3 Verify the Layer 3 freshness check rebuilds a stale recipe fingerprint and preserves the fast path for an exact fingerprint match.
+- [x] 2.3 Verify the Layer 3 freshness check rebuilds a stale recipe fingerprint, preserves the fast path for an exact fingerprint match, and reconciles a stopped stale container.

--- a/openspec/changes/enable-user-codex-updates/tasks.md
+++ b/openspec/changes/enable-user-codex-updates/tasks.md
@@ -1,9 +1,11 @@
 ## 1. Layer 3 Codex Overlay
 
 - [x] 1.1 Configure a user-owned npm prefix and PATH precedence in `user-layer/Dockerfile`, then verify the inherited system prefix is not modified.
-- [x] 1.2 Install Codex into the Layer 3 user prefix as the runtime user, then verify the installed package is user-owned.
+- [x] 1.2 Install a pinned Codex version into the Layer 3 user prefix as the runtime user, then verify the installed package is user-owned.
+- [x] 1.3 Fingerprint the Layer 3 build recipe and rebuild an existing user image whenever its recorded recipe fingerprint differs.
 
 ## 2. Image Validation
 
 - [x] 2.1 Build a disposable `dotnet-bench:brett` Layer 3 image and verify `codex` resolves from `$HOME/.npm-global/bin`.
-- [x] 2.2 Verify the resolved Codex package is writable by `brett`, the shared `/usr/lib/node_modules/@openai/codex` remains root-owned, and OpenSpec validation passes.
+- [x] 2.2 Verify the resolved Codex package is writable by `brett`, the base image's shared Codex package (located with its root npm global prefix) remains root-owned, and OpenSpec validation passes.
+- [x] 2.3 Verify the Layer 3 freshness check rebuilds a stale recipe fingerprint and preserves the fast path for an exact fingerprint match.

--- a/scripts/ensure-layer3.sh
+++ b/scripts/ensure-layer3.sh
@@ -73,17 +73,29 @@ USER_IMAGE="${BASE_NAME}:${USERNAME}"
 echo -e "${CYAN}ensure-layer3: Checking ${USER_IMAGE}...${NC}"
 
 layer3_recipe_sha256() {
-    if ! command -v sha256sum >/dev/null 2>&1; then
-        echo "sha256sum is required to fingerprint the Layer 3 recipe" >&2
+    local hash_tool
+    if command -v sha256sum >/dev/null 2>&1; then
+        hash_tool=sha256sum
+    elif command -v shasum >/dev/null 2>&1; then
+        hash_tool=shasum
+    else
+        echo "sha256sum or shasum is required to fingerprint the Layer 3 recipe" >&2
         return 1
     fi
 
     (
         cd "$LAYER3_RECIPE_DIR"
-        find . -type f -print0 \
-            | LC_ALL=C sort -z \
-            | xargs -0 sha256sum \
-            | sha256sum \
+        find . -type f -print \
+            | LC_ALL=C sort \
+            | while IFS= read -r recipe_file; do
+                if [[ "$hash_tool" == sha256sum ]]; then
+                    file_sha="$(sha256sum "$recipe_file" | awk '{print $1}')"
+                else
+                    file_sha="$(shasum -a 256 "$recipe_file" | awk '{print $1}')"
+                fi
+                printf '%s  %s\n' "$file_sha" "$recipe_file"
+            done \
+            | if [[ "$hash_tool" == sha256sum ]]; then sha256sum; else shasum -a 256; fi \
             | awk '{print $1}'
     )
 }

--- a/scripts/ensure-layer3.sh
+++ b/scripts/ensure-layer3.sh
@@ -22,6 +22,7 @@ USER_UID=$(id -u)
 USER_GID=$(id -g)
 DOCKER_SOCKET_GID=""
 FORCE=false
+LAYER3_RECIPE_DIR="$REPO_DIR/user-layer"
 
 # Colors
 RED='\033[0;31m'
@@ -70,6 +71,24 @@ BASE_NAME="${BASE_IMAGE%%:*}"
 USER_IMAGE="${BASE_NAME}:${USERNAME}"
 
 echo -e "${CYAN}ensure-layer3: Checking ${USER_IMAGE}...${NC}"
+
+layer3_recipe_sha256() {
+    if ! command -v sha256sum >/dev/null 2>&1; then
+        echo "sha256sum is required to fingerprint the Layer 3 recipe" >&2
+        return 1
+    fi
+
+    (
+        cd "$LAYER3_RECIPE_DIR"
+        find . -type f -print0 \
+            | LC_ALL=C sort -z \
+            | xargs -0 sha256sum \
+            | sha256sum \
+            | awk '{print $1}'
+    )
+}
+
+LAYER3_RECIPE_SHA256="$(layer3_recipe_sha256)"
 
 running_container_for_image() {
     local container_id
@@ -200,8 +219,11 @@ image_group_gid_has_member() {
 if [ "$FORCE" = false ] && docker image inspect "$USER_IMAGE" >/dev/null 2>&1; then
     BASE_CREATED=$(docker inspect --format '{{.Created}}' "$BASE_IMAGE" 2>/dev/null)
     USER_CREATED=$(docker inspect --format '{{.Created}}' "$USER_IMAGE" 2>/dev/null)
+    IMAGE_RECIPE_SHA256=$(docker image inspect --format '{{ index .Config.Labels "io.opensoft.workbenches.layer3.recipe-sha256" }}' "$USER_IMAGE" 2>/dev/null || true)
 
-    if [[ -n "$BASE_CREATED" && -n "$USER_CREATED" ]]; then
+    if [[ "$IMAGE_RECIPE_SHA256" != "$LAYER3_RECIPE_SHA256" ]]; then
+        echo -e "${YELLOW}⟳ ${USER_IMAGE} was built from a different Layer 3 recipe, rebuilding...${NC}"
+    elif [[ -n "$BASE_CREATED" && -n "$USER_CREATED" ]]; then
         # Compare timestamps (ISO 8601 strings sort lexicographically)
         if [[ "$USER_CREATED" > "$BASE_CREATED" ]]; then
             # Verify the user actually exists inside the image
@@ -238,6 +260,7 @@ if [ ! -x "$BUILD_SCRIPT" ]; then
 fi
 
 BUILD_ARGS=(--base "$BASE_IMAGE" --user "$USERNAME" --uid "$USER_UID" --gid "$USER_GID")
+BUILD_ARGS+=(--recipe-sha256 "$LAYER3_RECIPE_SHA256")
 if [ -n "$DOCKER_SOCKET_GID" ]; then
     BUILD_ARGS+=(--docker-gid "$DOCKER_SOCKET_GID")
 fi

--- a/scripts/ensure-layer3.sh
+++ b/scripts/ensure-layer3.sh
@@ -106,6 +106,36 @@ running_container_for_image() {
     return 1
 }
 
+reconcile_stopped_containers_for_image() {
+    local expected_image_id
+    local container_id
+    local configured_image
+    local running
+    local current_image_id
+
+    expected_image_id="$(docker image inspect --format '{{.Id}}' "$USER_IMAGE")"
+    while IFS= read -r container_id; do
+        [[ -n "$container_id" ]] || continue
+        configured_image="$(docker container inspect --format '{{.Config.Image}}' "$container_id" 2>/dev/null || true)"
+        [[ "$configured_image" == "$USER_IMAGE" ]] || continue
+        running="$(docker container inspect --format '{{.State.Running}}' "$container_id" 2>/dev/null || true)"
+        [[ "$running" == "false" ]] || continue
+        current_image_id="$(docker inspect --format '{{.Image}}' "$container_id" 2>/dev/null || true)"
+        [[ -n "$current_image_id" && "$current_image_id" != "$expected_image_id" ]] || continue
+
+        echo -e "${YELLOW}⟳ Removing stopped container '${container_id}' because it uses the previous ${USER_IMAGE} image ID${NC}"
+        if ! docker rm "$container_id" >/dev/null; then
+            running="$(docker container inspect --format '{{.State.Running}}' "$container_id" 2>/dev/null || true)"
+            if [[ "$running" == "true" ]]; then
+                echo -e "${YELLOW}↷ Container '${container_id}' started during reconciliation; preserving it${NC}"
+            else
+                echo -e "${RED}✗ Unable to remove stale stopped container '${container_id}'${NC}" >&2
+                return 1
+            fi
+        fi
+    done < <(docker container ls --all --quiet)
+}
+
 # Check if base image exists
 if ! docker image inspect "$BASE_IMAGE" >/dev/null 2>&1; then
     echo -e "${RED}✗ Base image '$BASE_IMAGE' not found!${NC}"
@@ -233,6 +263,7 @@ if [ "$FORCE" = false ] && docker image inspect "$USER_IMAGE" >/dev/null 2>&1; t
                     ! image_group_gid_has_member "$USER_IMAGE" "$DOCKER_SOCKET_GID" "$USERNAME"; then
                     echo -e "${YELLOW}⟳ Docker socket group '$DOCKER_SOCKET_GID' missing from ${USER_IMAGE}, rebuilding...${NC}"
                 else
+                    reconcile_stopped_containers_for_image
                     echo -e "${GREEN}✓ ${USER_IMAGE} is up-to-date (newer than ${BASE_IMAGE})${NC}"
                     exit 0
                 fi
@@ -269,5 +300,6 @@ if [ -n "$EXTRA_CHOWN" ]; then
 fi
 
 "$BUILD_SCRIPT" "${BUILD_ARGS[@]}"
+reconcile_stopped_containers_for_image
 
 echo -e "${GREEN}✓ ${USER_IMAGE} ready${NC}"

--- a/scripts/ensure-layer3.sh
+++ b/scripts/ensure-layer3.sh
@@ -137,6 +137,10 @@ reconcile_stopped_containers_for_image() {
 
         echo -e "${YELLOW}⟳ Removing stopped container '${container_id}' because it uses the previous ${USER_IMAGE} image ID${NC}"
         if ! docker rm "$container_id" >/dev/null; then
+            if ! docker container inspect "$container_id" >/dev/null 2>&1; then
+                echo -e "${GREEN}✓ Stale container '${container_id}' was already removed by another startup${NC}"
+                continue
+            fi
             running="$(docker container inspect --format '{{.State.Running}}' "$container_id" 2>/dev/null || true)"
             if [[ "$running" == "true" ]]; then
                 echo -e "${YELLOW}↷ Container '${container_id}' started during reconciliation; preserving it${NC}"

--- a/user-layer/Dockerfile
+++ b/user-layer/Dockerfile
@@ -27,6 +27,10 @@ ARG USER_UID=1000
 ARG USER_GID=1000
 ARG DOCKER_SOCKET_GID=""
 ARG EXTRA_CHOWN_DIRS=""
+ARG LAYER3_RECIPE_SHA256="unknown"
+ARG CODEX_VERSION="0.153.4"
+
+LABEL io.opensoft.workbenches.layer3.recipe-sha256="${LAYER3_RECIPE_SHA256}"
 
 USER root
 
@@ -131,7 +135,7 @@ USER $USERNAME
 ENV NPM_CONFIG_PREFIX=/home/${USERNAME}/.npm-global
 ENV PATH=/home/${USERNAME}/.npm-global/bin:${PATH}
 RUN mkdir -p "$NPM_CONFIG_PREFIX" \
-    && npm install -g @openai/codex@latest
+    && npm install -g "@openai/codex@${CODEX_VERSION}"
 
 # Pre-create user-owned cache roots so first-use named volumes inherit the
 # runtime user's ownership instead of becoming root-only.

--- a/user-layer/Dockerfile
+++ b/user-layer/Dockerfile
@@ -126,6 +126,13 @@ RUN if [ -n "$EXTRA_CHOWN_DIRS" ]; then \
 
 USER $USERNAME
 
+# User-owned Codex overlay. Keep the shared Layer 0 package root-owned while
+# allowing the runtime user to run `codex update` against this writable prefix.
+ENV NPM_CONFIG_PREFIX=/home/${USERNAME}/.npm-global
+ENV PATH=/home/${USERNAME}/.npm-global/bin:${PATH}
+RUN mkdir -p "$NPM_CONFIG_PREFIX" \
+    && npm install -g @openai/codex@latest
+
 # Pre-create user-owned cache roots so first-use named volumes inherit the
 # runtime user's ownership instead of becoming root-only.
 RUN mkdir -p \

--- a/user-layer/build.sh
+++ b/user-layer/build.sh
@@ -25,6 +25,8 @@ DOCKER_SOCKET_GID=""
 BASE_IMAGE=""
 EXTRA_CHOWN_DIRS=""
 NO_CACHE="${NO_CACHE:-false}"
+LAYER3_RECIPE_SHA256=""
+CODEX_VERSION="0.153.4"
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -35,6 +37,8 @@ while [[ $# -gt 0 ]]; do
         --gid) USER_GID="$2"; shift 2 ;;
         --docker-gid) DOCKER_SOCKET_GID="$2"; shift 2 ;;
         --chown) EXTRA_CHOWN_DIRS="$2"; shift 2 ;;
+        --recipe-sha256) LAYER3_RECIPE_SHA256="$2"; shift 2 ;;
+        --codex-version) CODEX_VERSION="$2"; shift 2 ;;
         --no-cache) NO_CACHE=true; shift ;;
         -h|--help)
             echo "Usage: $0 --base <image:latest> [--user USERNAME] [--chown \"dir1 dir2\"] [--no-cache]"
@@ -45,6 +49,8 @@ while [[ $# -gt 0 ]]; do
             echo "  --uid UID       User UID (default: \$(id -u))"
             echo "  --gid GID       User GID (default: \$(id -g))"
             echo "  --chown DIRS    Space-separated dirs to chown to user (e.g. \"/opt/vcpkg /go\")"
+            echo "  --recipe-sha256 SHA256  Layer 3 recipe fingerprint (computed automatically by default)"
+            echo "  --codex-version VERSION  Pinned Codex version baked into Layer 3 (default: $CODEX_VERSION)"
             echo "  --no-cache      Force Docker to rebuild without cached layers"
             exit 0
             ;;
@@ -58,6 +64,17 @@ if [ -z "$BASE_IMAGE" ]; then
     exit 1
 fi
 
+if [ -z "$LAYER3_RECIPE_SHA256" ]; then
+    LAYER3_RECIPE_SHA256="$(
+        cd "$SCRIPT_DIR"
+        find . -type f -print0 \
+            | LC_ALL=C sort -z \
+            | xargs -0 sha256sum \
+            | sha256sum \
+            | awk '{print $1}'
+    )"
+fi
+
 # Derive output tag: replace :latest with :$USERNAME
 OUTPUT_IMAGE="${BASE_IMAGE%%:*}:${USERNAME}"
 
@@ -69,6 +86,8 @@ echo "  UID/GID:     $USER_UID/$USER_GID"
 echo "  Docker GID:  ${DOCKER_SOCKET_GID:-none}"
 echo "  Extra chown: ${EXTRA_CHOWN_DIRS:-none}"
 echo "  No cache:    $NO_CACHE"
+echo "  Recipe SHA:  $LAYER3_RECIPE_SHA256"
+echo "  Codex:       $CODEX_VERSION"
 echo ""
 
 # Check if base image exists
@@ -89,6 +108,8 @@ docker build \
     --build-arg USER_GID="$USER_GID" \
     --build-arg DOCKER_SOCKET_GID="$DOCKER_SOCKET_GID" \
     --build-arg EXTRA_CHOWN_DIRS="$EXTRA_CHOWN_DIRS" \
+    --build-arg LAYER3_RECIPE_SHA256="$LAYER3_RECIPE_SHA256" \
+    --build-arg CODEX_VERSION="$CODEX_VERSION" \
     -t "$OUTPUT_IMAGE" \
     -f "$SCRIPT_DIR/Dockerfile" \
     "$SCRIPT_DIR"


### PR DESCRIPTION
Lane: workbenches-sync
Claim: https://github.com/opensoft/workBenches/issues/23#issuecomment-5593664129

## Summary

- keep the Layer 0 Codex installation root-owned as the shared image baseline
- install pinned Codex 0.153.4 into a writable Layer 3 npm prefix owned by the runtime user
- fingerprint the full Layer 3 recipe and rebuild user images whenever that recipe changes
- remove only stopped containers configured for the user-image tag when their immutable image ID is stale
- preserve running containers and containers that start during reconciliation

## Validation

- no-cache dotnet-bench:brett Layer 3 build passed
- Codex resolves to /home/brett/.npm-global/bin/codex and reports codex-cli 0.153.4
- user overlay is brett-owned and writable; shared package discovered via the base image npm root remains root-owned
- stale-fingerprint rebuild, exact-fingerprint fast path, and stale stopped-container reconciliation regression tests passed
- live check preserved the running dotnet-bench container and deferred refresh
- strict OpenSpec validation, shell syntax, and git diff checks passed

## Summary by Sourcery

Enable user-managed Codex updates in Layer 3 while preserving the shared baseline and safely refreshing stale user images.

New Features:
- Provide Layer 3 images with a writable, runtime-user-owned Codex installation pinned to version 0.153.4 while retaining the shared root-owned baseline.

Bug Fixes:
- Ensure user images are rebuilt when their Layer 3 recipe changes and remove only stopped containers tied to stale image IDs without disrupting running containers.

Enhancements:
- Add Layer 3 recipe fingerprinting and safe stale-container reconciliation to the image freshness workflow.

Tests:
- Add regression coverage for stale recipe rebuilds, exact-fingerprint reuse, and stopped-container reconciliation.