### PR TITLE
Refresh shared AI CLI tooling

### DIFF
--- a/base-image/Dockerfile
+++ b/base-image/Dockerfile
@@ -165,7 +165,7 @@ ENV PATH="/opt/bun/bin:${PATH}"
 
 # Copy and run AI CLI installation script
 COPY install-ai-clis.sh /tmp/
-ARG AI_CLI_REFRESH=2026-07-12
+ARG AI_CLI_REFRESH=2026-09-03
 ARG HERDR_INSTALL_SHA256=""
 RUN echo "AI CLI refresh marker: ${AI_CLI_REFRESH}"
 RUN --mount=type=cache,target=/root/.cache/uv \

--- a/base-image/files/claude-profile
+++ b/base-image/files/claude-profile
@@ -55,7 +55,7 @@ configure_profile_runtime() {
       | .permissions = (.permissions // {})
       | .permissions.defaultMode = "bypassPermissions"
       | .effortLevel = (.effortLevel // "xhigh")
-      | .model = $model
+      | .model = (.model // $model)
       | (if $guard_ok then
             .hooks = (.hooks // {})
             | .hooks.UserPromptSubmit = [{hooks: [{type: "command", command: $guard, timeout: 5}]}]

--- a/base-image/files/claude-profile
+++ b/base-image/files/claude-profile
@@ -45,7 +45,7 @@ configure_profile_runtime() {
   fi
 
   statusline_command='bash "${CLAUDE_CONFIG_DIR}/statusline-command.sh"'
-  default_model='claude-fable-5'
+  default_model='claude-fable-5-1'
   guard_command='bash "${CLAUDE_CONFIG_DIR}/usage-guard.sh"'
   settings_tmp="$(mktemp "$config_dir/.settings.XXXXXX.tmp")"
   if [[ -f "$settings" ]]; then
@@ -183,7 +183,7 @@ export_tmux_identity() {
 # Native Claude records ~/.local/bin/claude as its expected installation path.
 # Bench images install the immutable CLI in /usr/local/bin, so provide a
 # per-user compatibility link to keep Claude's installer health check accurate.
-if [[ "$claude_bin" == "/usr/local/bin/claude" ]]; then
+if [[ ! -e /.dockerenv && "$claude_bin" == "/usr/local/bin/claude" ]]; then
   if mkdir -p "$HOME/.local/bin" 2>/dev/null; then
     if [[ ! -e "$HOME/.local/bin/claude" && ! -L "$HOME/.local/bin/claude" ]]; then
       ln -s /usr/local/bin/claude "$HOME/.local/bin/claude"

--- a/base-image/install-ai-clis.sh
+++ b/base-image/install-ai-clis.sh
@@ -747,7 +747,7 @@ log_info "  - Amp CLI (amp)"
 log_info "  - Aider (aider)"
 log_info "  - OpenHands CLI (openhands)"
 log_info "  - Cursor CLI (cursor-agent)"
-if command -v mcode >/dev/null 2>&1; then
+if command -v mcode >/dev/null 2>&1 || [ -x "$HOME/.minimax-code/bin/mcode" ]; then
     log_info "  - MiniMax Code (mcode)"
 else
     log_info "  - MiniMax Code (mcode) [install skipped or failed]"

--- a/base-image/install-ai-clis.sh
+++ b/base-image/install-ai-clis.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Shared AI CLI Installation Script
-# Version: 2.0.5
+# Version: 2.1.0
 #
 # USER-AGNOSTIC: Runs as root, installs to system-wide paths.
 # All npm globals go to /usr/local (default root prefix).
@@ -18,6 +18,10 @@
 #   - Other AI CLIs (Codex, Gemini, Copilot, etc.)
 #   - Google Antigravity CLI (agy), checksum-gated opt-in
 #   - Claude Code (via native installer, not npm)
+#   - Kimi Code (Moonshot AI, Kimi K3), Qwen Code (Alibaba), Z.AI GLM Coding
+#     Plan helper (chelper), DeepSeek Harness (dsh, developer preview)
+#   - Amp CLI (Sourcegraph), Aider, OpenHands CLI, Cursor CLI (cursor-agent),
+#     MiniMax Code (mcode, via native installer)
 #
 # Note: OpenAgents agent files (openagent.md, opencoder.md) are copied via
 #       Dockerfile, not installed by this script
@@ -42,7 +46,7 @@ INSTALL_ANTIGRAVITY_CLI="${INSTALL_ANTIGRAVITY_CLI:-0}"
 ANTIGRAVITY_INSTALL_URL="${ANTIGRAVITY_INSTALL_URL:-https://antigravity.google/cli/install.sh}"
 ANTIGRAVITY_INSTALL_SHA256="${ANTIGRAVITY_INSTALL_SHA256:-}"
 HERDR_INSTALL_URL="${HERDR_INSTALL_URL:-https://herdr.dev/install.sh}"
-HERDR_INSTALL_SHA256="${HERDR_INSTALL_SHA256:-3db3af8375006e193a393b5e3129feb237f30bc6f053fffbe1dc75da1f3d9ac4}"
+HERDR_INSTALL_SHA256="${HERDR_INSTALL_SHA256:-bf83668c944cff30b3365eee5a4fe15ff61a4b749ab0c73b98e7a203f70893dd}"
 
 log_debug() {
     if [ "$DEBUG" = "1" ]; then
@@ -284,6 +288,98 @@ if run_with_timeout "$COMMAND_TIMEOUT" "Grok native install" bash -o pipefail -c
     fi
 else
     log_error "Grok CLI native installation failed (continuing)"
+fi
+
+# Some newer CLIs ship native postinstall build steps (pty/FFI bindings, spawn
+# helpers). npm blocks arbitrary install scripts by default; explicitly allow
+# only the ones required by the packages installed below.
+NPM_NATIVE_ALLOW_SCRIPTS="@moonshot-ai/kimi-code,node-pty,@qwen-code/audio-capture,@deepseek-ai/dsh-subprocess-local,koffi,@google/genai,protobufjs"
+
+log_info "Installing Moonshot Kimi Code CLI (Kimi K3)..."
+# Kimi Code: Moonshot AI's terminal coding agent (https://github.com/MoonshotAI/kimi-code)
+if ! run_with_timeout "$NPM_INSTALL_TIMEOUT" "Kimi Code npm install" npm install -g --allow-scripts="$NPM_NATIVE_ALLOW_SCRIPTS" @moonshot-ai/kimi-code@latest; then
+    log_error "Kimi Code installation failed (continuing)"
+fi
+
+log_info "Installing Qwen Code CLI..."
+# Qwen Code: Alibaba's terminal coding agent (https://github.com/QwenLM/qwen-code)
+if ! run_with_timeout "$NPM_INSTALL_TIMEOUT" "Qwen Code npm install" npm install -g --allow-scripts="$NPM_NATIVE_ALLOW_SCRIPTS" @qwen-code/qwen-code@latest; then
+    log_error "Qwen Code installation failed (continuing)"
+fi
+
+log_info "Installing Z.AI GLM Coding Plan helper (chelper)..."
+# Coding Tool Helper: Z.AI's official wizard for wiring GLM Coding Plan into
+# Claude Code, OpenCode, Crush, and Factory Droid (not a standalone agent).
+if ! run_with_timeout "$NPM_INSTALL_TIMEOUT" "Z.AI coding-helper npm install" npm install -g @z_ai/coding-helper@latest; then
+    log_error "Z.AI coding-helper installation failed (continuing)"
+fi
+
+log_info "Installing DeepSeek Harness (dsh)..."
+# DeepSeek Harness: DeepSeek AI's open-source, plugin-based agent harness
+# (https://github.com/deepseek-ai/deepseek-harness). Developer preview as of
+# this writing; not added to required_clis below since it may break between
+# releases.
+if ! run_with_timeout "$NPM_INSTALL_TIMEOUT" "DeepSeek Harness npm install" npm install -g --allow-scripts="$NPM_NATIVE_ALLOW_SCRIPTS" @deepseek-ai/dsh@latest; then
+    log_error "DeepSeek Harness installation failed (continuing)"
+fi
+
+log_info "Installing Amp CLI (Sourcegraph)..."
+if ! run_with_timeout "$NPM_INSTALL_TIMEOUT" "Amp CLI npm install" npm install -g @ampcode/cli@latest; then
+    log_error "Amp CLI installation failed (continuing)"
+fi
+
+log_info "Installing Aider..."
+if run_system_uv_tool_install "Aider install" --python python3.12 --with pip aider-chat@latest; then
+    log_info "Aider installed (aider)"
+else
+    log_error "Aider installation failed (continuing)"
+fi
+
+log_info "Installing OpenHands CLI..."
+if run_system_uv_tool_install "OpenHands install" openhands --python 3.12; then
+    log_info "OpenHands CLI installed (openhands)"
+else
+    log_error "OpenHands installation failed (continuing)"
+fi
+
+log_info "Installing Cursor CLI..."
+# Cursor's terminal agent; native installer places the binary under
+# $HOME/.local/bin, exposed as both 'agent' and 'cursor-agent'. Grok's CLI
+# also ships a binary literally named 'agent' (installed above), so only
+# claim the unambiguous 'cursor-agent' name in /usr/local/bin; skip 'agent'
+# here entirely to avoid silently overriding or being shadowed by Grok's.
+if run_with_timeout "$COMMAND_TIMEOUT" "Cursor CLI install" bash -c 'curl -fsSL https://cursor.com/install | bash'; then
+    if [ -f "$HOME/.local/bin/cursor-agent" ] && [ ! -e /usr/local/bin/cursor-agent ]; then
+        cp "$HOME/.local/bin/cursor-agent" /usr/local/bin/cursor-agent
+        chmod +x /usr/local/bin/cursor-agent
+    elif [ -f "$HOME/.local/bin/agent" ] && [ ! -e /usr/local/bin/cursor-agent ]; then
+        cp "$HOME/.local/bin/agent" /usr/local/bin/cursor-agent
+        chmod +x /usr/local/bin/cursor-agent
+    fi
+    if command -v cursor-agent >/dev/null 2>&1; then
+        log_info "Cursor CLI installed to $(command -v cursor-agent)"
+    else
+        log_error "Cursor CLI binary not found on PATH after installation (continuing)"
+    fi
+else
+    log_error "Cursor CLI installation failed (continuing)"
+fi
+
+log_info "Installing MiniMax Code CLI (mcode)..."
+# MiniMax's official terminal coding agent. Its installer targets a per-user
+# shell rc, so copy the resulting binary into /usr/local/bin for every user.
+if run_with_timeout "$COMMAND_TIMEOUT" "MiniMax Code CLI install" bash -c 'curl -fsSL https://filecdn.minimax.chat/public/install.sh | bash'; then
+    if [ -f "$HOME/.minimax-code/bin/mcode" ] && [ ! -e /usr/local/bin/mcode ]; then
+        cp "$HOME/.minimax-code/bin/mcode" /usr/local/bin/mcode
+        chmod +x /usr/local/bin/mcode
+    fi
+    if command -v mcode >/dev/null 2>&1; then
+        log_info "MiniMax Code CLI installed to $(command -v mcode)"
+    else
+        log_error "MiniMax Code CLI binary not found on PATH after installation (continuing)"
+    fi
+else
+    log_error "MiniMax Code CLI installation failed (continuing)"
 fi
 
 install_opencode_release() {
@@ -563,7 +659,10 @@ fi
 # Auth is done on the host (requires browser); tokens mounted into container
 # Install into a shared uv tools directory instead of root's home so bench
 # users can execute the launchers from /usr/local/bin.
-if run_system_uv_tool_install "NotebookLM MCP CLI install" notebooklm-mcp-cli; then
+# notebooklm-py and notebooklm-mcp-cli both publish notebooklm-mcp. Let the
+# dedicated MCP package own that shared launcher while preserving notebooklm
+# from notebooklm-py and adding nlm from notebooklm-mcp-cli.
+if run_system_uv_tool_install "NotebookLM MCP CLI install" notebooklm-mcp-cli --force; then
     log_info "NotebookLM MCP CLI installed (nlm, notebooklm-mcp)"
 else
     log_error "NotebookLM MCP CLI installation failed (continuing)"
@@ -574,7 +673,7 @@ log_info "AI CLI Tools Installation Complete!"
 log_info "=========================================="
 log_info ""
 
-required_clis=(claude codex gemini pi herdr copilot opencode omo letta notebooklm nlm)
+required_clis=(claude codex gemini pi herdr copilot opencode omo letta notebooklm nlm kimi qwen aider openhands amp cursor-agent)
 missing_clis=()
 for cli in "${required_clis[@]}"; do
     if ! command -v "$cli" >/dev/null 2>&1; then
@@ -613,6 +712,23 @@ log_info "  - oh-my-opencode (omo)"
 log_info "  - Letta Code (letta)"
 log_info "  - NotebookLM CLI (notebooklm) [auth via host browser]"
 log_info "  - NotebookLM MCP CLI (nlm) [auth via host browser]"
+log_info "  - Moonshot Kimi Code (kimi)"
+log_info "  - Qwen Code (qwen)"
+log_info "  - Z.AI Coding Plan helper (chelper) [configures other tools, not a standalone agent]"
+if command -v dsh >/dev/null 2>&1; then
+    log_info "  - DeepSeek Harness (dsh) [developer preview]"
+else
+    log_info "  - DeepSeek Harness (dsh) [install skipped or failed, developer preview]"
+fi
+log_info "  - Amp CLI (amp)"
+log_info "  - Aider (aider)"
+log_info "  - OpenHands CLI (openhands)"
+log_info "  - Cursor CLI (cursor-agent)"
+if command -v mcode >/dev/null 2>&1; then
+    log_info "  - MiniMax Code (mcode)"
+else
+    log_info "  - MiniMax Code (mcode) [install skipped or failed]"
+fi
 log_info ""
 log_info "Agent files (openagent.md, opencoder.md) provided via Dockerfile COPY"
 log_info ""

--- a/base-image/install-ai-clis.sh
+++ b/base-image/install-ai-clis.sh
@@ -38,6 +38,7 @@ set -e
 DEBUG="${DEBUG:-1}"
 COMMAND_TIMEOUT="${COMMAND_TIMEOUT:-300}"  # 5 minutes per general command
 NPM_INSTALL_TIMEOUT="${NPM_INSTALL_TIMEOUT:-600}"  # 10 minutes for npm package installs
+NPM_VERSION="${NPM_VERSION:-12.0.2}"
 GIT_CLONE_TIMEOUT="${GIT_CLONE_TIMEOUT:-900}"  # 15 minutes for slow GitHub clones
 RELEASE_DOWNLOAD_TIMEOUT="${RELEASE_DOWNLOAD_TIMEOUT:-3600}"  # 60 minutes for slow GitHub release assets
 BUN_OPERATIONS_TIMEOUT="${BUN_OPERATIONS_TIMEOUT:-900}"  # 15 minutes for bun ops
@@ -83,6 +84,20 @@ run_with_timeout() {
         fi
         return $exit_code
     fi
+}
+
+ensure_selective_npm_scripts() {
+    local current_version
+
+    current_version="$(npm --version)"
+    if [ "$current_version" != "$NPM_VERSION" ]; then
+        log_info "Installing npm ${NPM_VERSION} for selective lifecycle-script controls..."
+        run_with_timeout "$NPM_INSTALL_TIMEOUT" "npm ${NPM_VERSION} install" \
+            npm install -g "npm@${NPM_VERSION}" || return 1
+        hash -r
+    fi
+
+    npm install --help | grep -Fq -- '--allow-scripts'
 }
 
 ensure_system_uv_tool_paths() {
@@ -185,7 +200,7 @@ log_info "Installing Claude Code CLI (native installer)..."
 # which places a launcher in ~/.local/bin/. Since we run as root, we need to
 # find the binary and copy it to /usr/local/bin ourselves.
 # Claude installer needs more time for download, use 5 minutes
-run_with_timeout "300" "Claude Code native install" bash -c 'curl -fsSL https://claude.ai/install.sh | bash' || true
+run_with_timeout "300" "Claude Code native install" bash -o pipefail -c 'curl -fsSL https://claude.ai/install.sh | bash' || true
 
 # Find the claude binary wherever the installer put it and copy to /usr/local/bin
 CLAUDE_BIN=""
@@ -294,6 +309,10 @@ fi
 # helpers). npm blocks arbitrary install scripts by default; explicitly allow
 # only the ones required by the packages installed below.
 NPM_NATIVE_ALLOW_SCRIPTS="@moonshot-ai/kimi-code,node-pty,@qwen-code/audio-capture,@deepseek-ai/dsh-subprocess-local,koffi,@google/genai,protobufjs"
+if ! ensure_selective_npm_scripts; then
+    log_error "npm ${NPM_VERSION} selective lifecycle-script controls are unavailable"
+    exit 1
+fi
 
 log_info "Installing Moonshot Kimi Code CLI (Kimi K3)..."
 # Kimi Code: Moonshot AI's terminal coding agent (https://github.com/MoonshotAI/kimi-code)
@@ -348,7 +367,7 @@ log_info "Installing Cursor CLI..."
 # also ships a binary literally named 'agent' (installed above), so only
 # claim the unambiguous 'cursor-agent' name in /usr/local/bin; skip 'agent'
 # here entirely to avoid silently overriding or being shadowed by Grok's.
-if run_with_timeout "$COMMAND_TIMEOUT" "Cursor CLI install" bash -c 'curl -fsSL https://cursor.com/install | bash'; then
+if run_with_timeout "$COMMAND_TIMEOUT" "Cursor CLI install" bash -o pipefail -c 'curl -fsSL https://cursor.com/install | bash'; then
     if [ -f "$HOME/.local/bin/cursor-agent" ] && [ ! -e /usr/local/bin/cursor-agent ]; then
         cp "$HOME/.local/bin/cursor-agent" /usr/local/bin/cursor-agent
         chmod +x /usr/local/bin/cursor-agent
@@ -368,7 +387,7 @@ fi
 log_info "Installing MiniMax Code CLI (mcode)..."
 # MiniMax's official terminal coding agent. Its installer targets a per-user
 # shell rc, so copy the resulting binary into /usr/local/bin for every user.
-if run_with_timeout "$COMMAND_TIMEOUT" "MiniMax Code CLI install" bash -c 'curl -fsSL https://filecdn.minimax.chat/public/install.sh | bash'; then
+if run_with_timeout "$COMMAND_TIMEOUT" "MiniMax Code CLI install" bash -o pipefail -c 'curl -fsSL https://filecdn.minimax.chat/public/install.sh | bash'; then
     if [ -f "$HOME/.minimax-code/bin/mcode" ] && [ ! -e /usr/local/bin/mcode ]; then
         cp "$HOME/.minimax-code/bin/mcode" /usr/local/bin/mcode
         chmod +x /usr/local/bin/mcode

--- a/base-image/install-ai-clis.sh
+++ b/base-image/install-ai-clis.sh
@@ -733,7 +733,11 @@ log_info "  - NotebookLM CLI (notebooklm) [auth via host browser]"
 log_info "  - NotebookLM MCP CLI (nlm) [auth via host browser]"
 log_info "  - Moonshot Kimi Code (kimi)"
 log_info "  - Qwen Code (qwen)"
-log_info "  - Z.AI Coding Plan helper (chelper) [configures other tools, not a standalone agent]"
+if command -v chelper >/dev/null 2>&1; then
+    log_info "  - Z.AI Coding Plan helper (chelper) [configures other tools, not a standalone agent]"
+else
+    log_info "  - Z.AI Coding Plan helper (chelper) [install skipped or failed]"
+fi
 if command -v dsh >/dev/null 2>&1; then
     log_info "  - DeepSeek Harness (dsh) [developer preview]"
 else

--- a/devBenches/base-image/install-ai-clis.sh
+++ b/devBenches/base-image/install-ai-clis.sh
@@ -541,7 +541,11 @@ log_info "  - oh-my-opencode (omo)"
 log_info "  - Letta Code (letta)"
 log_info "  - Moonshot Kimi Code (kimi)"
 log_info "  - Qwen Code (qwen)"
-log_info "  - Z.AI Coding Plan helper (chelper)"
+if command -v chelper >/dev/null 2>&1; then
+    log_info "  - Z.AI Coding Plan helper (chelper)"
+else
+    log_info "  - Z.AI Coding Plan helper (chelper) [install skipped or failed]"
+fi
 if command -v dsh >/dev/null 2>&1; then
     log_info "  - DeepSeek Harness (dsh) [developer preview]"
 else

--- a/devBenches/base-image/install-ai-clis.sh
+++ b/devBenches/base-image/install-ai-clis.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Shared AI CLI Installation Script
-# Version: 1.3.2
+# Version: 1.4.0
 #
 # This script installs all AI CLI tools for devcontainers.
 # Source this from Dockerfiles to maintain a single source of truth.
@@ -12,6 +12,9 @@
 #   - Auth plugins (opencode-gemini-auth, opencode-openai-codex-auth)
 #   - Other AI CLIs (Codex, Gemini, Copilot, etc.)
 #   - Claude Code (via native installer, not npm)
+#   - Kimi Code (Moonshot AI, Kimi K3), Qwen Code (Alibaba), Z.AI GLM Coding
+#     Plan helper (chelper), DeepSeek Harness (dsh, developer preview), and
+#     MiniMax Code (mcode, via native installer)
 #
 # Note: OpenAgents agent files (openagent.md, opencoder.md) are copied via
 #       Dockerfile, not installed by this script
@@ -446,12 +449,52 @@ if ! run_with_timeout "$NPM_INSTALL_TIMEOUT" "Letta Code npm install" npm instal
     log_error "Letta Code installation failed (continuing)"
 fi
 
+# Some newer CLIs ship native postinstall build steps (pty/FFI bindings, spawn
+# helpers). npm blocks arbitrary install scripts by default; explicitly allow
+# only the ones required by the packages installed below.
+NPM_NATIVE_ALLOW_SCRIPTS="@moonshot-ai/kimi-code,node-pty,@qwen-code/audio-capture,@deepseek-ai/dsh-subprocess-local,koffi,@google/genai,protobufjs"
+
+log_info "Installing Moonshot Kimi Code CLI (Kimi K3)..."
+# Kimi Code: Moonshot AI's terminal coding agent (https://github.com/MoonshotAI/kimi-code)
+if ! run_with_timeout "$NPM_INSTALL_TIMEOUT" "Kimi Code npm install" npm install -g --allow-scripts="$NPM_NATIVE_ALLOW_SCRIPTS" @moonshot-ai/kimi-code@latest; then
+    log_error "Kimi Code installation failed (continuing)"
+fi
+
+log_info "Installing Qwen Code CLI..."
+# Qwen Code: Alibaba's terminal coding agent (https://github.com/QwenLM/qwen-code)
+if ! run_with_timeout "$NPM_INSTALL_TIMEOUT" "Qwen Code npm install" npm install -g --allow-scripts="$NPM_NATIVE_ALLOW_SCRIPTS" @qwen-code/qwen-code@latest; then
+    log_error "Qwen Code installation failed (continuing)"
+fi
+
+log_info "Installing Z.AI GLM Coding Plan helper (chelper)..."
+# Coding Tool Helper: Z.AI's official wizard for wiring GLM Coding Plan into
+# Claude Code, OpenCode, Crush, and Factory Droid (not a standalone agent).
+if ! run_with_timeout "$NPM_INSTALL_TIMEOUT" "Z.AI coding-helper npm install" npm install -g @z_ai/coding-helper@latest; then
+    log_error "Z.AI coding-helper installation failed (continuing)"
+fi
+
+log_info "Installing DeepSeek Harness (dsh)..."
+# DeepSeek Harness: DeepSeek AI's open-source, plugin-based agent harness
+# (https://github.com/deepseek-ai/deepseek-harness). Developer preview as of
+# this writing; not added to required_clis below since it may break between
+# releases.
+if ! run_with_timeout "$NPM_INSTALL_TIMEOUT" "DeepSeek Harness npm install" npm install -g --allow-scripts="$NPM_NATIVE_ALLOW_SCRIPTS" @deepseek-ai/dsh@latest; then
+    log_error "DeepSeek Harness installation failed (continuing)"
+fi
+
+log_info "Installing MiniMax Code CLI (mcode)..."
+# MiniMax Code: MiniMax's official terminal coding agent, installed via its
+# native installer (not npm-global); adds itself to PATH via shell rc.
+if ! run_with_timeout "$COMMAND_TIMEOUT" "MiniMax Code CLI install" bash -c 'curl -fsSL https://filecdn.minimax.chat/public/install.sh | bash'; then
+    log_error "MiniMax Code CLI installation failed (continuing)"
+fi
+
 log_info "=========================================="
 log_info "AI CLI Tools Installation Complete!"
 log_info "=========================================="
 log_info ""
 
-required_clis=(claude codex gemini copilot opencode omo letta)
+required_clis=(claude codex gemini copilot opencode omo letta kimi qwen)
 missing_clis=()
 for cli in "${required_clis[@]}"; do
     if ! command -v "$cli" >/dev/null 2>&1; then
@@ -477,6 +520,11 @@ log_info "  - GitHub Copilot (copilot)"
 log_info "  - OpenCode (opencode)"
 log_info "  - oh-my-opencode (omo)"
 log_info "  - Letta Code (letta)"
+log_info "  - Moonshot Kimi Code (kimi)"
+log_info "  - Qwen Code (qwen)"
+log_info "  - Z.AI Coding Plan helper (chelper)"
+log_info "  - DeepSeek Harness (dsh)"
+log_info "  - MiniMax Code (mcode)"
 log_info ""
 log_info "Agent files (openagent.md, opencoder.md) provided via Dockerfile COPY"
 log_info ""

--- a/devBenches/base-image/install-ai-clis.sh
+++ b/devBenches/base-image/install-ai-clis.sh
@@ -551,7 +551,7 @@ if command -v dsh >/dev/null 2>&1; then
 else
     log_info "  - DeepSeek Harness (dsh) [install skipped or failed, developer preview]"
 fi
-if command -v mcode >/dev/null 2>&1; then
+if command -v mcode >/dev/null 2>&1 || [ -x "$HOME/.minimax-code/bin/mcode" ]; then
     log_info "  - MiniMax Code (mcode)"
 else
     log_info "  - MiniMax Code (mcode) [install skipped or failed]"

--- a/devBenches/base-image/install-ai-clis.sh
+++ b/devBenches/base-image/install-ai-clis.sh
@@ -31,6 +31,7 @@ set -e
 DEBUG="${DEBUG:-1}"
 COMMAND_TIMEOUT="${COMMAND_TIMEOUT:-300}"  # 5 minutes per general command
 NPM_INSTALL_TIMEOUT="${NPM_INSTALL_TIMEOUT:-600}"  # 10 minutes for npm package installs
+NPM_VERSION="${NPM_VERSION:-12.0.2}"
 GIT_CLONE_TIMEOUT="${GIT_CLONE_TIMEOUT:-900}"  # 15 minutes for slow GitHub clones
 RELEASE_DOWNLOAD_TIMEOUT="${RELEASE_DOWNLOAD_TIMEOUT:-3600}"  # 60 minutes for slow GitHub release assets
 BUN_OPERATIONS_TIMEOUT="${BUN_OPERATIONS_TIMEOUT:-900}"  # 15 minutes for bun ops
@@ -70,6 +71,20 @@ run_with_timeout() {
         fi
         return $exit_code
     fi
+}
+
+ensure_selective_npm_scripts() {
+    local current_version
+
+    current_version="$(npm --version)"
+    if [ "$current_version" != "$NPM_VERSION" ]; then
+        log_info "Installing npm ${NPM_VERSION} for selective lifecycle-script controls..."
+        run_with_timeout "$NPM_INSTALL_TIMEOUT" "npm ${NPM_VERSION} install" \
+            npm install -g "npm@${NPM_VERSION}" || return 1
+        hash -r
+    fi
+
+    npm install --help | grep -Fq -- '--allow-scripts'
 }
 
 check_system_resources() {
@@ -142,7 +157,7 @@ export PATH="$HOME/.npm-global/bin:$PATH"
 # BUN RUNTIME (for OpenCode plugins)
 # ========================================
 log_info "Installing Bun runtime..."
-if run_with_timeout "$COMMAND_TIMEOUT" "Bun runtime download and install" bash -c 'curl -fsSL https://bun.sh/install | bash'; then
+if run_with_timeout "$COMMAND_TIMEOUT" "Bun runtime download and install" bash -o pipefail -c 'curl -fsSL https://bun.sh/install | bash'; then
     log_debug "Bun installation completed"
 else
     log_error "Failed to download or install Bun. Continuing without Bun support."
@@ -167,7 +182,7 @@ fi
 log_info "Installing Claude Code CLI (native installer)..."
 # Native installer is now the recommended method (npm is deprecated)
 # Installs to ~/.local/bin/claude, auto-updates in background, no Node.js dependency
-if ! run_with_timeout "$COMMAND_TIMEOUT" "Claude Code native install" bash -c 'curl -fsSL https://claude.ai/install.sh | bash'; then
+if ! run_with_timeout "$COMMAND_TIMEOUT" "Claude Code native install" bash -o pipefail -c 'curl -fsSL https://claude.ai/install.sh | bash'; then
     log_error "Claude Code native installation failed (continuing)"
 fi
 
@@ -453,6 +468,10 @@ fi
 # helpers). npm blocks arbitrary install scripts by default; explicitly allow
 # only the ones required by the packages installed below.
 NPM_NATIVE_ALLOW_SCRIPTS="@moonshot-ai/kimi-code,node-pty,@qwen-code/audio-capture,@deepseek-ai/dsh-subprocess-local,koffi,@google/genai,protobufjs"
+if ! ensure_selective_npm_scripts; then
+    log_error "npm ${NPM_VERSION} selective lifecycle-script controls are unavailable"
+    exit 1
+fi
 
 log_info "Installing Moonshot Kimi Code CLI (Kimi K3)..."
 # Kimi Code: Moonshot AI's terminal coding agent (https://github.com/MoonshotAI/kimi-code)
@@ -485,7 +504,7 @@ fi
 log_info "Installing MiniMax Code CLI (mcode)..."
 # MiniMax Code: MiniMax's official terminal coding agent, installed via its
 # native installer (not npm-global); adds itself to PATH via shell rc.
-if ! run_with_timeout "$COMMAND_TIMEOUT" "MiniMax Code CLI install" bash -c 'curl -fsSL https://filecdn.minimax.chat/public/install.sh | bash'; then
+if ! run_with_timeout "$COMMAND_TIMEOUT" "MiniMax Code CLI install" bash -o pipefail -c 'curl -fsSL https://filecdn.minimax.chat/public/install.sh | bash'; then
     log_error "MiniMax Code CLI installation failed (continuing)"
 fi
 
@@ -523,8 +542,16 @@ log_info "  - Letta Code (letta)"
 log_info "  - Moonshot Kimi Code (kimi)"
 log_info "  - Qwen Code (qwen)"
 log_info "  - Z.AI Coding Plan helper (chelper)"
-log_info "  - DeepSeek Harness (dsh)"
-log_info "  - MiniMax Code (mcode)"
+if command -v dsh >/dev/null 2>&1; then
+    log_info "  - DeepSeek Harness (dsh) [developer preview]"
+else
+    log_info "  - DeepSeek Harness (dsh) [install skipped or failed, developer preview]"
+fi
+if command -v mcode >/dev/null 2>&1; then
+    log_info "  - MiniMax Code (mcode)"
+else
+    log_info "  - MiniMax Code (mcode) [install skipped or failed]"
+fi
 log_info ""
 log_info "Agent files (openagent.md, opencoder.md) provided via Dockerfile COPY"
 log_info ""

--- a/devBenches/scripts/ai-cli-adapter.sh
+++ b/devBenches/scripts/ai-cli-adapter.sh
@@ -233,7 +233,12 @@ get_all_cli_status() {
                 cli_status_map["minimax"]=$(check_generic_cli_status "minimax-code" "mcode")
                 ;;
             deepseek)
-                cli_status_map["deepseek"]=$(check_generic_cli_status "dsh" "dsh")
+                cli_status_map["deepseek"]=$(
+                    check_generic_cli_status \
+                        "dsh" \
+                        "dsh" \
+                        "${DSH_HOME:-$HOME/.dsh}"
+                )
                 ;;
             *)
                 continue
@@ -282,7 +287,12 @@ get_authenticated_cli() {
                 cli_status=$(check_generic_cli_status "minimax-code" "mcode")
                 ;;
             deepseek)
-                cli_status=$(check_generic_cli_status "dsh" "dsh")
+                cli_status=$(
+                    check_generic_cli_status \
+                        "dsh" \
+                        "dsh" \
+                        "${DSH_HOME:-$HOME/.dsh}"
+                )
                 ;;
             *)
                 continue
@@ -362,7 +372,12 @@ get_unauthenticated_clis() {
                 cli_status=$(check_generic_cli_status "minimax-code" "mcode")
                 ;;
             deepseek)
-                cli_status=$(check_generic_cli_status "dsh" "dsh")
+                cli_status=$(
+                    check_generic_cli_status \
+                        "dsh" \
+                        "dsh" \
+                        "${DSH_HOME:-$HOME/.dsh}"
+                )
                 ;;
             *)
                 continue
@@ -382,6 +397,43 @@ get_unauthenticated_clis() {
     return 1
 }
 
+# Get installed-but-unauthenticated providers supported by the unified call
+# interface. Inventory-only providers remain visible in status output but must
+# not trigger a login prompt that cannot route a request afterward.
+get_unauthenticated_routing_clis() {
+    local -a unauthenticated=()
+    local provider
+    local cli_status
+
+    for provider in "${ROUTING_PROVIDER_PRIORITY[@]}"; do
+        case "$provider" in
+            codex)
+                cli_status=$(check_codex_status)
+                ;;
+            claude)
+                cli_status=$(check_claude_status)
+                ;;
+            gemini)
+                cli_status=$(check_gemini_status)
+                ;;
+            *)
+                continue
+                ;;
+        esac
+
+        if [ "$cli_status" = "$CLI_INSTALLED_NOT_AUTH" ]; then
+            unauthenticated+=("$provider")
+        fi
+    done
+
+    if [ ${#unauthenticated[@]} -gt 0 ]; then
+        printf '%s\n' "${unauthenticated[@]}"
+        return 0
+    fi
+
+    return 1
+}
+
 # ============================================================================
 # User Interaction
 # ============================================================================
@@ -389,7 +441,7 @@ get_unauthenticated_clis() {
 # Prompt user to authenticate CLI tools
 prompt_cli_authentication() {
     local -a unauthenticated
-    mapfile -t unauthenticated < <(get_unauthenticated_clis)
+    mapfile -t unauthenticated < <(get_unauthenticated_routing_clis)
     
     if [ ${#unauthenticated[@]} -eq 0 ]; then
         return 1
@@ -513,7 +565,7 @@ select_ai_provider() {
     fi
     
     # Second: Check if CLIs are installed but not authenticated
-    if get_unauthenticated_clis >/dev/null 2>&1; then
+    if get_unauthenticated_routing_clis >/dev/null 2>&1; then
         # Prompt user to authenticate
         local authenticated
         if authenticated=$(prompt_cli_authentication); then

--- a/devBenches/scripts/ai-cli-adapter.sh
+++ b/devBenches/scripts/ai-cli-adapter.sh
@@ -169,7 +169,7 @@ check_copilot_status() {
     return 1
 }
 
-# Generic check for other providers (meta, kimi2, deepseek)
+# Generic check for providers whose config directory is created only after login.
 check_generic_cli_status() {
     local provider="$1"
     local cli_cmd="$2"
@@ -188,6 +188,216 @@ check_generic_cli_status() {
         return 0
     fi
     
+    echo "$CLI_INSTALLED_NOT_AUTH"
+    return 1
+}
+
+dotenv_has_nonempty_value() {
+    local env_file="$1"
+    local key="$2"
+
+    [ -s "$env_file" ] || return 1
+    [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || return 1
+    grep -Eq \
+        "^[[:space:]]*(export[[:space:]]+)?${key}[[:space:]]*=[[:space:]]*(\"[^\"]+\"|'[^']+'|[^#[:space:]][^#]*)[[:space:]]*(#.*)?$" \
+        "$env_file"
+}
+
+find_qwen_env_file() {
+    local search_dir="$PWD"
+    local parent_dir
+
+    while :; do
+        if [ -f "$search_dir/.qwen/.env" ]; then
+            printf '%s\n' "$search_dir/.qwen/.env"
+            return 0
+        fi
+        if [ -f "$search_dir/.env" ]; then
+            printf '%s\n' "$search_dir/.env"
+            return 0
+        fi
+
+        [ "$search_dir" = "/" ] && break
+        parent_dir=$(dirname -- "$search_dir")
+        [ "$parent_dir" = "$search_dir" ] && break
+        search_dir="$parent_dir"
+    done
+
+    if [ -f "$HOME/.qwen/.env" ]; then
+        printf '%s\n' "$HOME/.qwen/.env"
+        return 0
+    fi
+    if [ -f "$HOME/.env" ]; then
+        printf '%s\n' "$HOME/.env"
+        return 0
+    fi
+
+    return 1
+}
+
+# Qwen creates ~/.qwen before /auth completes. Treat it as authenticated only
+# when the selected provider has an actual credential source, or when a legacy
+# OAuth cache still contains a token.
+check_qwen_status() {
+    if ! command -v qwen >/dev/null 2>&1; then
+        echo "$CLI_NOT_INSTALLED"
+        return 1
+    fi
+
+    local qwen_home="$HOME/.qwen"
+    local settings_file="$qwen_home/settings.json"
+    local oauth_file="$qwen_home/oauth_creds.json"
+    local selected_type=""
+    local env_key=""
+    local qwen_env_file=""
+
+    if [ -s "$oauth_file" ] \
+        && grep -Eq '"(access_token|accessToken|refresh_token|refreshToken)"[[:space:]]*:[[:space:]]*"[^"[:space:]]+"' "$oauth_file"; then
+        echo "$CLI_AUTHENTICATED"
+        return 0
+    fi
+
+    if [ -s "$settings_file" ] && command -v jq >/dev/null 2>&1; then
+        selected_type=$(jq -r '.security.auth.selectedType? // empty' "$settings_file" 2>/dev/null || true)
+    fi
+    qwen_env_file=$(find_qwen_env_file 2>/dev/null || true)
+
+    # OPENAI_API_KEY selects Qwen's OpenAI-compatible auth when no persisted
+    # auth type overrides it. Provider-specific keys require settings below.
+    if [ -z "$selected_type" ]; then
+        if [ -n "${OPENAI_API_KEY:-}" ] \
+            || { [ -n "$qwen_env_file" ] \
+                && dotenv_has_nonempty_value "$qwen_env_file" "OPENAI_API_KEY"; }; then
+            echo "$CLI_AUTHENTICATED"
+            return 0
+        fi
+        echo "$CLI_INSTALLED_NOT_AUTH"
+        return 1
+    fi
+
+    if jq -e '.security.auth.apiKey? | strings | length > 0' \
+        "$settings_file" >/dev/null 2>&1; then
+        echo "$CLI_AUTHENTICATED"
+        return 0
+    fi
+
+    case "$selected_type" in
+        openai)
+            env_key="OPENAI_API_KEY"
+            ;;
+        anthropic)
+            env_key="ANTHROPIC_API_KEY"
+            ;;
+        gemini)
+            env_key="GEMINI_API_KEY"
+            ;;
+        vertex-ai)
+            if [ -n "${GOOGLE_API_KEY:-}" ] \
+                || { [ -n "${GOOGLE_CLOUD_PROJECT:-}" ] \
+                    && { { [ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ] \
+                            && [ -s "$GOOGLE_APPLICATION_CREDENTIALS" ]; } \
+                        || [ -s "$HOME/.config/gcloud/application_default_credentials.json" ]; }; }; then
+                echo "$CLI_AUTHENTICATED"
+                return 0
+            fi
+            ;;
+    esac
+
+    if [ -n "$env_key" ]; then
+        if [ -n "${!env_key:-}" ] \
+            || { [ -n "$qwen_env_file" ] \
+                && dotenv_has_nonempty_value "$qwen_env_file" "$env_key"; } \
+            || jq -e --arg key "$env_key" '.env[$key]? | strings | length > 0' \
+                "$settings_file" >/dev/null 2>&1; then
+            echo "$CLI_AUTHENTICATED"
+            return 0
+        fi
+    fi
+
+    while IFS= read -r env_key; do
+        [[ "$env_key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+        if [ -n "${!env_key:-}" ] \
+            || { [ -n "$qwen_env_file" ] \
+                && dotenv_has_nonempty_value "$qwen_env_file" "$env_key"; } \
+            || jq -e --arg key "$env_key" '.env[$key]? | strings | length > 0' \
+                "$settings_file" >/dev/null 2>&1; then
+            echo "$CLI_AUTHENTICATED"
+            return 0
+        fi
+    done < <(
+        jq -r --arg type "$selected_type" \
+            '.modelProviders[$type] // [] | .. | objects | .envKey? // empty' \
+            "$settings_file" 2>/dev/null
+    )
+
+    echo "$CLI_INSTALLED_NOT_AUTH"
+    return 1
+}
+
+# Kimi creates KIMI_CODE_HOME and a default config before /login. A usable
+# profile has either a non-empty provider key or a persisted OAuth token under
+# the credential directory managed by the login flow.
+check_kimi_status() {
+    if ! command -v kimi >/dev/null 2>&1; then
+        echo "$CLI_NOT_INSTALLED"
+        return 1
+    fi
+
+    local kimi_home="${KIMI_CODE_HOME:-$HOME/.kimi-code}"
+    local config_file="$kimi_home/config.toml"
+    local credential_file
+    if [ -s "$config_file" ]; then
+        if awk '
+            /^[[:space:]]*\[/ {
+                in_provider = ($0 ~ /^[[:space:]]*\[providers\./)
+            }
+            in_provider && /^[[:space:]]*(api_key|[A-Za-z_][A-Za-z0-9_]*API_KEY)[[:space:]]*=/ {
+                value = $0
+                sub(/^[^=]*=[[:space:]]*/, "", value)
+                if (value ~ /^"[^"[:space:]][^"]*"/) {
+                    found = 1
+                }
+            }
+            END { exit(found ? 0 : 1) }
+        ' "$config_file"; then
+            echo "$CLI_AUTHENTICATED"
+            return 0
+        fi
+    fi
+
+    if [ -d "$kimi_home/credentials" ]; then
+        while IFS= read -r -d '' credential_file; do
+            if [ -s "$credential_file" ] \
+                && grep -Eq '"(access_token|accessToken|refresh_token|refreshToken)"[[:space:]]*:[[:space:]]*"[^"[:space:]]+"' "$credential_file"; then
+                echo "$CLI_AUTHENTICATED"
+                return 0
+            fi
+        done < <(find "$kimi_home/credentials" -maxdepth 1 -type f -name '*.json' -print0 2>/dev/null)
+    fi
+
+    echo "$CLI_INSTALLED_NOT_AUTH"
+    return 1
+}
+
+# DeepSeek Harness resolves its default key from the launch environment, its
+# managed credentials file, the invoking project's .env, then DSH_HOME/.env.
+check_deepseek_status() {
+    if ! command -v dsh >/dev/null 2>&1; then
+        echo "$CLI_NOT_INSTALLED"
+        return 1
+    fi
+
+    local dsh_home="${DSH_HOME:-$HOME/.dsh}"
+    local credentials_file="$dsh_home/.credentials.yaml"
+    if [ -n "${DEEPSEEK_API_KEY:-}" ] \
+        || { [ -s "$credentials_file" ] \
+            && grep -Eq '^[[:space:]]*DEEPSEEK_API_KEY:[[:space:]]*("[^"]+"|'\''[^'\'']+'\''|[^#[:space:]][^#]*)' "$credentials_file"; } \
+        || dotenv_has_nonempty_value "$PWD/.env" "DEEPSEEK_API_KEY" \
+        || dotenv_has_nonempty_value "$dsh_home/.env" "DEEPSEEK_API_KEY"; then
+        echo "$CLI_AUTHENTICATED"
+        return 0
+    fi
+
     echo "$CLI_INSTALLED_NOT_AUTH"
     return 1
 }
@@ -236,30 +446,19 @@ get_all_cli_status() {
                 cli_status_map["copilot"]=$(check_copilot_status)
                 ;;
             qwen)
-                cli_status_map["qwen"]=$(check_generic_cli_status "qwen" "qwen")
+                cli_status_map["qwen"]=$(check_qwen_status)
                 ;;
             meta)
                 cli_status_map["meta"]=$(check_generic_cli_status "meta" "llama")
                 ;;
             kimi2)
-                # Kimi Code CLI (Moonshot AI) stores state under ~/.kimi-code
-                cli_status_map["kimi2"]=$(
-                    check_generic_cli_status \
-                        "kimi-code" \
-                        "kimi" \
-                        "${KIMI_CODE_HOME:-$HOME/.kimi-code}"
-                )
+                cli_status_map["kimi2"]=$(check_kimi_status)
                 ;;
             minimax)
                 cli_status_map["minimax"]=$(check_minimax_status)
                 ;;
             deepseek)
-                cli_status_map["deepseek"]=$(
-                    check_generic_cli_status \
-                        "dsh" \
-                        "dsh" \
-                        "${DSH_HOME:-$HOME/.dsh}"
-                )
+                cli_status_map["deepseek"]=$(check_deepseek_status)
                 ;;
             *)
                 continue
@@ -291,29 +490,19 @@ get_authenticated_cli() {
                 cli_status=$(check_copilot_status)
                 ;;
             qwen)
-                cli_status=$(check_generic_cli_status "qwen" "qwen")
+                cli_status=$(check_qwen_status)
                 ;;
             meta)
                 cli_status=$(check_generic_cli_status "meta" "llama")
                 ;;
             kimi2)
-                cli_status=$(
-                    check_generic_cli_status \
-                        "kimi-code" \
-                        "kimi" \
-                        "${KIMI_CODE_HOME:-$HOME/.kimi-code}"
-                )
+                cli_status=$(check_kimi_status)
                 ;;
             minimax)
                 cli_status=$(check_minimax_status)
                 ;;
             deepseek)
-                cli_status=$(
-                    check_generic_cli_status \
-                        "dsh" \
-                        "dsh" \
-                        "${DSH_HOME:-$HOME/.dsh}"
-                )
+                cli_status=$(check_deepseek_status)
                 ;;
             *)
                 continue
@@ -376,29 +565,19 @@ get_unauthenticated_clis() {
                 cli_status=$(check_copilot_status)
                 ;;
             qwen)
-                cli_status=$(check_generic_cli_status "qwen" "qwen")
+                cli_status=$(check_qwen_status)
                 ;;
             meta)
                 cli_status=$(check_generic_cli_status "meta" "llama")
                 ;;
             kimi2)
-                cli_status=$(
-                    check_generic_cli_status \
-                        "kimi-code" \
-                        "kimi" \
-                        "${KIMI_CODE_HOME:-$HOME/.kimi-code}"
-                )
+                cli_status=$(check_kimi_status)
                 ;;
             minimax)
                 cli_status=$(check_minimax_status)
                 ;;
             deepseek)
-                cli_status=$(
-                    check_generic_cli_status \
-                        "dsh" \
-                        "dsh" \
-                        "${DSH_HOME:-$HOME/.dsh}"
-                )
+                cli_status=$(check_deepseek_status)
                 ;;
             *)
                 continue

--- a/devBenches/scripts/ai-cli-adapter.sh
+++ b/devBenches/scripts/ai-cli-adapter.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # AI CLI Adapter - Provider detection and unified interface
 # Version: 1.0.0
-# Supports: Codex, Claude Code, Gemini CLI with subscription auth
+# Supports non-interactive calls through Codex, Claude Code, and Gemini CLI.
 # Shared across all bench types (frappe, flutter, dotnet)
 
 # Prevent double-sourcing
@@ -21,7 +21,7 @@ if [ -f "$PRIORITY_CONFIG" ]; then
     mapfile -t PROVIDER_PRIORITY < "$PRIORITY_CONFIG"
 else
     # Default provider priority order
-    PROVIDER_PRIORITY=("codex" "claude" "gemini" "copilot" "qwen" "meta" "kimi2" "minimax" "deepseek")
+    PROVIDER_PRIORITY=("codex" "claude" "gemini")
 fi
 
 filter_supported_providers() {
@@ -30,7 +30,7 @@ filter_supported_providers() {
 
     for provider in "${PROVIDER_PRIORITY[@]}"; do
         case "$provider" in
-            codex|claude|gemini|copilot|qwen|meta|kimi2|minimax|deepseek)
+            codex|claude|gemini)
                 filtered+=("$provider")
                 ;;
         esac
@@ -39,7 +39,7 @@ filter_supported_providers() {
     if [ ${#filtered[@]} -gt 0 ]; then
         PROVIDER_PRIORITY=("${filtered[@]}")
     else
-        PROVIDER_PRIORITY=("codex" "claude" "gemini" "copilot" "qwen" "meta" "kimi2" "minimax" "deepseek")
+        PROVIDER_PRIORITY=("codex" "claude" "gemini")
     fi
 }
 

--- a/devBenches/scripts/ai-cli-adapter.sh
+++ b/devBenches/scripts/ai-cli-adapter.sh
@@ -21,7 +21,7 @@ if [ -f "$PRIORITY_CONFIG" ]; then
     mapfile -t PROVIDER_PRIORITY < "$PRIORITY_CONFIG"
 else
     # Default provider priority order
-    PROVIDER_PRIORITY=("codex" "claude" "gemini" "copilot" "meta" "kimi2" "deepseek")
+    PROVIDER_PRIORITY=("codex" "claude" "gemini" "copilot" "qwen" "meta" "kimi2" "minimax" "deepseek")
 fi
 
 filter_supported_providers() {
@@ -30,7 +30,7 @@ filter_supported_providers() {
 
     for provider in "${PROVIDER_PRIORITY[@]}"; do
         case "$provider" in
-            codex|claude|gemini|copilot|meta|kimi2|deepseek)
+            codex|claude|gemini|copilot|qwen|meta|kimi2|minimax|deepseek)
                 filtered+=("$provider")
                 ;;
         esac
@@ -39,7 +39,7 @@ filter_supported_providers() {
     if [ ${#filtered[@]} -gt 0 ]; then
         PROVIDER_PRIORITY=("${filtered[@]}")
     else
-        PROVIDER_PRIORITY=("codex" "claude" "gemini" "copilot" "meta" "kimi2" "deepseek")
+        PROVIDER_PRIORITY=("codex" "claude" "gemini" "copilot" "qwen" "meta" "kimi2" "minimax" "deepseek")
     fi
 }
 
@@ -215,11 +215,18 @@ get_all_cli_status() {
             copilot)
                 cli_status_map["copilot"]=$(check_copilot_status)
                 ;;
+            qwen)
+                cli_status_map["qwen"]=$(check_generic_cli_status "qwen" "qwen")
+                ;;
             meta)
                 cli_status_map["meta"]=$(check_generic_cli_status "meta" "llama")
                 ;;
             kimi2)
-                cli_status_map["kimi2"]=$(check_generic_cli_status "kimi" "kimi")
+                # Kimi Code CLI (Moonshot AI) stores state under ~/.kimi-code
+                cli_status_map["kimi2"]=$(check_generic_cli_status "kimi-code" "kimi")
+                ;;
+            minimax)
+                cli_status_map["minimax"]=$(check_generic_cli_status "minimax-code" "mcode")
                 ;;
             deepseek)
                 cli_status_map["deepseek"]=$(check_generic_cli_status "deepseek" "deepseek")
@@ -250,11 +257,17 @@ get_authenticated_cli() {
             copilot)
                 cli_status=$(check_copilot_status)
                 ;;
+            qwen)
+                cli_status=$(check_generic_cli_status "qwen" "qwen")
+                ;;
             meta)
                 cli_status=$(check_generic_cli_status "meta" "llama")
                 ;;
             kimi2)
-                cli_status=$(check_generic_cli_status "kimi" "kimi")
+                cli_status=$(check_generic_cli_status "kimi-code" "kimi")
+                ;;
+            minimax)
+                cli_status=$(check_generic_cli_status "minimax-code" "mcode")
                 ;;
             deepseek)
                 cli_status=$(check_generic_cli_status "deepseek" "deepseek")
@@ -289,11 +302,17 @@ get_unauthenticated_clis() {
             copilot)
                 cli_status=$(check_copilot_status)
                 ;;
+            qwen)
+                cli_status=$(check_generic_cli_status "qwen" "qwen")
+                ;;
             meta)
                 cli_status=$(check_generic_cli_status "meta" "llama")
                 ;;
             kimi2)
-                cli_status=$(check_generic_cli_status "kimi" "kimi")
+                cli_status=$(check_generic_cli_status "kimi-code" "kimi")
+                ;;
+            minimax)
+                cli_status=$(check_generic_cli_status "minimax-code" "mcode")
                 ;;
             deepseek)
                 cli_status=$(check_generic_cli_status "deepseek" "deepseek")

--- a/devBenches/scripts/ai-cli-adapter.sh
+++ b/devBenches/scripts/ai-cli-adapter.sh
@@ -173,6 +173,7 @@ check_copilot_status() {
 check_generic_cli_status() {
     local provider="$1"
     local cli_cmd="$2"
+    local config_dir="${3:-$HOME/.${provider}}"
     
     # Check if CLI is installed
     if ! command -v "$cli_cmd" >/dev/null 2>&1; then
@@ -181,7 +182,7 @@ check_generic_cli_status() {
     fi
     
     # Check if config directory exists
-    if [ -d "$HOME/.${provider}" ]; then
+    if [ -d "$config_dir" ]; then
         # Assume authenticated if config dir exists
         echo "$CLI_AUTHENTICATED"
         return 0
@@ -197,7 +198,7 @@ check_generic_cli_status() {
 
 # Get status of all CLI providers
 get_all_cli_status() {
-    local -A cli_status_map
+    local -A cli_status_map=()
     
     for provider in "${PROVIDER_PRIORITY[@]}"; do
         case "$provider" in
@@ -221,13 +222,21 @@ get_all_cli_status() {
                 ;;
             kimi2)
                 # Kimi Code CLI (Moonshot AI) stores state under ~/.kimi-code
-                cli_status_map["kimi2"]=$(check_generic_cli_status "kimi-code" "kimi")
+                cli_status_map["kimi2"]=$(
+                    check_generic_cli_status \
+                        "kimi-code" \
+                        "kimi" \
+                        "${KIMI_CODE_HOME:-$HOME/.kimi-code}"
+                )
                 ;;
             minimax)
                 cli_status_map["minimax"]=$(check_generic_cli_status "minimax-code" "mcode")
                 ;;
             deepseek)
                 cli_status_map["deepseek"]=$(check_generic_cli_status "dsh" "dsh")
+                ;;
+            *)
+                continue
                 ;;
         esac
     done
@@ -262,13 +271,21 @@ get_authenticated_cli() {
                 cli_status=$(check_generic_cli_status "meta" "llama")
                 ;;
             kimi2)
-                cli_status=$(check_generic_cli_status "kimi-code" "kimi")
+                cli_status=$(
+                    check_generic_cli_status \
+                        "kimi-code" \
+                        "kimi" \
+                        "${KIMI_CODE_HOME:-$HOME/.kimi-code}"
+                )
                 ;;
             minimax)
                 cli_status=$(check_generic_cli_status "minimax-code" "mcode")
                 ;;
             deepseek)
                 cli_status=$(check_generic_cli_status "dsh" "dsh")
+                ;;
+            *)
+                continue
                 ;;
         esac
         
@@ -310,7 +327,7 @@ get_authenticated_routing_cli() {
 
 # Get list of installed but not authenticated CLIs
 get_unauthenticated_clis() {
-    local -a unauthenticated
+    local -a unauthenticated=()
     
     for provider in "${PROVIDER_PRIORITY[@]}"; do
         local cli_status
@@ -334,13 +351,21 @@ get_unauthenticated_clis() {
                 cli_status=$(check_generic_cli_status "meta" "llama")
                 ;;
             kimi2)
-                cli_status=$(check_generic_cli_status "kimi-code" "kimi")
+                cli_status=$(
+                    check_generic_cli_status \
+                        "kimi-code" \
+                        "kimi" \
+                        "${KIMI_CODE_HOME:-$HOME/.kimi-code}"
+                )
                 ;;
             minimax)
                 cli_status=$(check_generic_cli_status "minimax-code" "mcode")
                 ;;
             deepseek)
                 cli_status=$(check_generic_cli_status "dsh" "dsh")
+                ;;
+            *)
+                continue
                 ;;
         esac
         

--- a/devBenches/scripts/ai-cli-adapter.sh
+++ b/devBenches/scripts/ai-cli-adapter.sh
@@ -5,7 +5,7 @@
 # Shared across all bench types (frappe, flutter, dotnet)
 
 # Prevent double-sourcing
-if [ -n "$_AI_CLI_ADAPTER_SOURCED" ]; then
+if [ -n "${_AI_CLI_ADAPTER_SOURCED:-}" ]; then
     return 0
 fi
 _AI_CLI_ADAPTER_SOURCED=1
@@ -24,26 +24,24 @@ else
     PROVIDER_PRIORITY=("codex" "claude" "gemini")
 fi
 
-filter_supported_providers() {
-    local -a filtered=()
+build_routing_provider_priority() {
+    ROUTING_PROVIDER_PRIORITY=()
     local provider
 
     for provider in "${PROVIDER_PRIORITY[@]}"; do
         case "$provider" in
             codex|claude|gemini)
-                filtered+=("$provider")
+                ROUTING_PROVIDER_PRIORITY+=("$provider")
                 ;;
         esac
     done
 
-    if [ ${#filtered[@]} -gt 0 ]; then
-        PROVIDER_PRIORITY=("${filtered[@]}")
-    else
-        PROVIDER_PRIORITY=("codex" "claude" "gemini")
+    if [ ${#ROUTING_PROVIDER_PRIORITY[@]} -eq 0 ]; then
+        ROUTING_PROVIDER_PRIORITY=("codex" "claude" "gemini")
     fi
 }
 
-filter_supported_providers
+build_routing_provider_priority
 
 # Timeout for CLI probes (seconds)
 readonly PROBE_TIMEOUT=10
@@ -283,6 +281,33 @@ get_authenticated_cli() {
     return 1
 }
 
+# Get the first authenticated provider supported by the unified call interface.
+get_authenticated_routing_cli() {
+    local provider
+    local cli_status
+
+    for provider in "${ROUTING_PROVIDER_PRIORITY[@]}"; do
+        case "$provider" in
+            codex)
+                cli_status=$(check_codex_status)
+                ;;
+            claude)
+                cli_status=$(check_claude_status)
+                ;;
+            gemini)
+                cli_status=$(check_gemini_status)
+                ;;
+        esac
+
+        if [ "$cli_status" = "$CLI_AUTHENTICATED" ]; then
+            echo "$provider"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
 # Get list of installed but not authenticated CLIs
 get_unauthenticated_clis() {
     local -a unauthenticated
@@ -406,7 +431,7 @@ call_ai_cli() {
     
     # Get authenticated provider
     local provider
-    provider=$(get_authenticated_cli)
+    provider=$(get_authenticated_routing_cli)
     
     if [ -z "$provider" ]; then
         echo "Error: No authenticated CLI provider available" >&2
@@ -455,7 +480,7 @@ call_ai_cli() {
 select_ai_provider() {
     # First: Try to get authenticated CLI
     local cli_provider
-    cli_provider=$(get_authenticated_cli)
+    cli_provider=$(get_authenticated_routing_cli)
     
     if [ -n "$cli_provider" ]; then
         echo "${cli_provider}|cli"

--- a/devBenches/scripts/ai-cli-adapter.sh
+++ b/devBenches/scripts/ai-cli-adapter.sh
@@ -192,6 +192,27 @@ check_generic_cli_status() {
     return 1
 }
 
+# MiniMax Code's installer creates ~/.minimax-code before authentication. Its
+# login credential is stored separately under MINIMAX_DATA_DIR (or ~/.minimax),
+# so installation state must not be mistaken for an authenticated profile.
+check_minimax_status() {
+    if ! command -v mcode >/dev/null 2>&1; then
+        echo "$CLI_NOT_INSTALLED"
+        return 1
+    fi
+
+    local data_dir="${MINIMAX_DATA_DIR:-${MAVIS_DATA_DIR:-$HOME/.minimax}}"
+    local auth_file="$data_dir/local-runtime.auth.json"
+    if [ -s "$auth_file" ] \
+        && grep -Eq '"accessToken"[[:space:]]*:[[:space:]]*"[^"[:space:]]+"' "$auth_file"; then
+        echo "$CLI_AUTHENTICATED"
+        return 0
+    fi
+
+    echo "$CLI_INSTALLED_NOT_AUTH"
+    return 1
+}
+
 # ============================================================================
 # Provider Selection Logic
 # ============================================================================
@@ -230,7 +251,7 @@ get_all_cli_status() {
                 )
                 ;;
             minimax)
-                cli_status_map["minimax"]=$(check_generic_cli_status "minimax-code" "mcode")
+                cli_status_map["minimax"]=$(check_minimax_status)
                 ;;
             deepseek)
                 cli_status_map["deepseek"]=$(
@@ -284,7 +305,7 @@ get_authenticated_cli() {
                 )
                 ;;
             minimax)
-                cli_status=$(check_generic_cli_status "minimax-code" "mcode")
+                cli_status=$(check_minimax_status)
                 ;;
             deepseek)
                 cli_status=$(
@@ -369,7 +390,7 @@ get_unauthenticated_clis() {
                 )
                 ;;
             minimax)
-                cli_status=$(check_generic_cli_status "minimax-code" "mcode")
+                cli_status=$(check_minimax_status)
                 ;;
             deepseek)
                 cli_status=$(

--- a/devBenches/scripts/ai-cli-adapter.sh
+++ b/devBenches/scripts/ai-cli-adapter.sh
@@ -227,7 +227,7 @@ get_all_cli_status() {
                 cli_status_map["minimax"]=$(check_generic_cli_status "minimax-code" "mcode")
                 ;;
             deepseek)
-                cli_status_map["deepseek"]=$(check_generic_cli_status "deepseek" "deepseek")
+                cli_status_map["deepseek"]=$(check_generic_cli_status "dsh" "dsh")
                 ;;
         esac
     done
@@ -268,7 +268,7 @@ get_authenticated_cli() {
                 cli_status=$(check_generic_cli_status "minimax-code" "mcode")
                 ;;
             deepseek)
-                cli_status=$(check_generic_cli_status "deepseek" "deepseek")
+                cli_status=$(check_generic_cli_status "dsh" "dsh")
                 ;;
         esac
         
@@ -340,7 +340,7 @@ get_unauthenticated_clis() {
                 cli_status=$(check_generic_cli_status "minimax-code" "mcode")
                 ;;
             deepseek)
-                cli_status=$(check_generic_cli_status "deepseek" "deepseek")
+                cli_status=$(check_generic_cli_status "dsh" "dsh")
                 ;;
         esac
         
@@ -404,7 +404,7 @@ prompt_cli_authentication() {
         
         # Re-check authentication
         local authenticated
-        authenticated=$(get_authenticated_cli)
+        authenticated=$(get_authenticated_routing_cli)
         if [ -n "$authenticated" ]; then
             echo -e "\033[0;32m✓ Successfully authenticated with $authenticated\033[0m"
             echo "$authenticated"

--- a/devcontainer.test/test-ai-cli-adapter-routing.sh
+++ b/devcontainer.test/test-ai-cli-adapter-routing.sh
@@ -15,15 +15,22 @@ source "$ADAPTER"
 [[ "${PROVIDER_PRIORITY[*]}" == "qwen codex kimi2 minimax deepseek" ]]
 [[ "${ROUTING_PROVIDER_PRIORITY[*]}" == "codex" ]]
 
-mkdir -p "$temporary_home/bin" "$temporary_home/kimi-profile"
+mkdir -p "$temporary_home/bin" "$temporary_home/kimi-profile" "$temporary_home/minimax-data"
 printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"$temporary_home/bin/kimi"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"$temporary_home/bin/mcode"
 chmod +x "$temporary_home/bin/kimi"
+chmod +x "$temporary_home/bin/mcode"
 PATH="$temporary_home/bin:$PATH"
 KIMI_CODE_HOME="$temporary_home/kimi-profile"
 DSH_HOME="$temporary_home/dsh-profile"
+MINIMAX_DATA_DIR="$temporary_home/minimax-data"
 mkdir -p "$DSH_HOME"
-export PATH KIMI_CODE_HOME DSH_HOME
+export PATH KIMI_CODE_HOME DSH_HOME MINIMAX_DATA_DIR
 [[ "$(check_generic_cli_status "kimi-code" "kimi" "$KIMI_CODE_HOME")" == "$CLI_AUTHENTICATED" ]]
+[[ "$(check_minimax_status)" == "$CLI_INSTALLED_NOT_AUTH" ]]
+printf '%s\n' '{"version":1,"auth":{"accessToken":"fixture-token"}}' \
+    >"$MINIMAX_DATA_DIR/local-runtime.auth.json"
+[[ "$(check_minimax_status)" == "$CLI_AUTHENTICATED" ]]
 
 generic_calls="$temporary_home/generic-calls"
 check_generic_cli_status() {

--- a/devcontainer.test/test-ai-cli-adapter-routing.sh
+++ b/devcontainer.test/test-ai-cli-adapter-routing.sh
@@ -15,9 +15,17 @@ source "$ADAPTER"
 [[ "${PROVIDER_PRIORITY[*]}" == "qwen codex kimi2 minimax deepseek" ]]
 [[ "${ROUTING_PROVIDER_PRIORITY[*]}" == "codex" ]]
 
+mkdir -p "$temporary_home/bin" "$temporary_home/kimi-profile"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"$temporary_home/bin/kimi"
+chmod +x "$temporary_home/bin/kimi"
+PATH="$temporary_home/bin:$PATH"
+KIMI_CODE_HOME="$temporary_home/kimi-profile"
+export PATH KIMI_CODE_HOME
+[[ "$(check_generic_cli_status "kimi-code" "kimi" "$KIMI_CODE_HOME")" == "$CLI_AUTHENTICATED" ]]
+
 generic_calls="$temporary_home/generic-calls"
 check_generic_cli_status() {
-    printf '%s|%s\n' "$1" "$2" >>"$generic_calls"
+    printf '%s|%s|%s\n' "$1" "$2" "${3-}" >>"$generic_calls"
     printf '%s\n' "$CLI_AUTHENTICATED"
 }
 check_codex_status() {
@@ -32,7 +40,17 @@ grep -qx 'qwen=authenticated' <<<"$inventory"
 grep -qx 'kimi2=authenticated' <<<"$inventory"
 grep -qx 'minimax=authenticated' <<<"$inventory"
 grep -qx 'deepseek=authenticated' <<<"$inventory"
-grep -qx 'dsh|dsh' "$generic_calls"
+grep -qx 'dsh|dsh|' "$generic_calls"
+grep -qx "kimi-code|kimi|$KIMI_CODE_HOME" "$generic_calls"
+
+saved_priority=("${PROVIDER_PRIORITY[@]}")
+PROVIDER_PRIORITY=("" antigravity qwen)
+[[ "$(get_authenticated_cli)" == qwen ]]
+if get_unauthenticated_clis >/dev/null 2>&1; then
+    echo "unexpected unauthenticated provider from unknown-entry fixture" >&2
+    exit 1
+fi
+PROVIDER_PRIORITY=("${saved_priority[@]}")
 
 get_unauthenticated_clis() {
     printf '%s\n' codex

--- a/devcontainer.test/test-ai-cli-adapter-routing.sh
+++ b/devcontainer.test/test-ai-cli-adapter-routing.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ADAPTER=${1:-"$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)/devBenches/scripts/ai-cli-adapter.sh"}
+temporary_home=$(mktemp -d)
+trap 'rm -rf -- "$temporary_home"' EXIT
+
+mkdir -p "$temporary_home/.config/workbenches"
+printf '%s\n' qwen codex kimi2 minimax >"$temporary_home/.config/workbenches/ai-provider-priority.conf"
+
+HOME=$temporary_home
+unset _AI_CLI_ADAPTER_SOURCED
+source "$ADAPTER"
+
+[[ "${PROVIDER_PRIORITY[*]}" == "qwen codex kimi2 minimax" ]]
+[[ "${ROUTING_PROVIDER_PRIORITY[*]}" == "codex" ]]
+
+check_generic_cli_status() {
+    printf '%s\n' "$CLI_AUTHENTICATED"
+}
+check_codex_status() {
+    printf '%s\n' "$CLI_AUTHENTICATED"
+}
+
+[[ "$(get_authenticated_cli)" == "qwen" ]]
+[[ "$(get_authenticated_routing_cli)" == "codex" ]]
+
+inventory=$(get_all_cli_status)
+grep -qx 'qwen=authenticated' <<<"$inventory"
+grep -qx 'kimi2=authenticated' <<<"$inventory"
+grep -qx 'minimax=authenticated' <<<"$inventory"
+
+printf 'ai-cli adapter inventory and routing checks passed\n'

--- a/devcontainer.test/test-ai-cli-adapter-routing.sh
+++ b/devcontainer.test/test-ai-cli-adapter-routing.sh
@@ -15,28 +15,67 @@ source "$ADAPTER"
 [[ "${PROVIDER_PRIORITY[*]}" == "qwen codex kimi2 minimax deepseek" ]]
 [[ "${ROUTING_PROVIDER_PRIORITY[*]}" == "codex" ]]
 
-mkdir -p "$temporary_home/bin" "$temporary_home/kimi-profile" "$temporary_home/minimax-data"
+mkdir -p \
+    "$temporary_home/bin" \
+    "$temporary_home/.qwen" \
+    "$temporary_home/kimi-profile" \
+    "$temporary_home/minimax-data" \
+    "$temporary_home/dsh-profile"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"$temporary_home/bin/qwen"
 printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"$temporary_home/bin/kimi"
 printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"$temporary_home/bin/mcode"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"$temporary_home/bin/dsh"
+chmod +x "$temporary_home/bin/qwen"
 chmod +x "$temporary_home/bin/kimi"
 chmod +x "$temporary_home/bin/mcode"
+chmod +x "$temporary_home/bin/dsh"
 PATH="$temporary_home/bin:$PATH"
 KIMI_CODE_HOME="$temporary_home/kimi-profile"
 DSH_HOME="$temporary_home/dsh-profile"
 MINIMAX_DATA_DIR="$temporary_home/minimax-data"
-mkdir -p "$DSH_HOME"
 export PATH KIMI_CODE_HOME DSH_HOME MINIMAX_DATA_DIR
-[[ "$(check_generic_cli_status "kimi-code" "kimi" "$KIMI_CODE_HOME")" == "$CLI_AUTHENTICATED" ]]
+
+# Installation creates these profile roots before credentials exist.
+printf '%s\n' '{"security":{"auth":{"selectedType":"openai"}}}' \
+    >"$temporary_home/.qwen/settings.json"
+printf '%s\n' '[providers."managed:kimi-code"]' 'api_key = ""' \
+    >"$KIMI_CODE_HOME/config.toml"
+printf '%s\n' 'version: 1' 'refs: {}' >"$DSH_HOME/.credentials.yaml"
+[[ "$(check_qwen_status)" == "$CLI_INSTALLED_NOT_AUTH" ]]
+[[ "$(check_kimi_status)" == "$CLI_INSTALLED_NOT_AUTH" ]]
+[[ "$(check_deepseek_status)" == "$CLI_INSTALLED_NOT_AUTH" ]]
 [[ "$(check_minimax_status)" == "$CLI_INSTALLED_NOT_AUTH" ]]
+
+mkdir -p "$KIMI_CODE_HOME/credentials"
+printf '%s\n' '{"accessToken":"fixture-token"}' \
+    >"$KIMI_CODE_HOME/credentials/managed:kimi-code.json"
+[[ "$(check_kimi_status)" == "$CLI_AUTHENTICATED" ]]
+: >"$KIMI_CODE_HOME/credentials/managed:kimi-code.json"
+
+printf '%s\n' \
+    '{"modelProviders":{"anthropic":[{"envKey":"OTHER_PROVIDER_KEY"}]},"env":{"OTHER_PROVIDER_KEY":"fixture-key"},"security":{"auth":{"selectedType":"openai"}}}' \
+    >"$temporary_home/.qwen/settings.json"
+[[ "$(check_qwen_status)" == "$CLI_INSTALLED_NOT_AUTH" ]]
+
+printf '%s\n' \
+    '{"modelProviders":{"vertex-ai":[{"id":"fixture-model"}]},"security":{"auth":{"selectedType":"vertex-ai"}}}' \
+    >"$temporary_home/.qwen/settings.json"
+[[ "$(GOOGLE_CLOUD_PROJECT=fixture-project check_qwen_status)" == "$CLI_INSTALLED_NOT_AUTH" ]]
+
+printf '%s\n' \
+    '{"modelProviders":{"openai":[{"envKey":"QWEN_TEST_API_KEY"}]},"env":{"QWEN_TEST_API_KEY":"fixture-key"},"security":{"auth":{"selectedType":"openai"}}}' \
+    >"$temporary_home/.qwen/settings.json"
+printf '%s\n' '[providers."managed:kimi-code"]' 'api_key = "fixture-key"' \
+    >"$KIMI_CODE_HOME/config.toml"
+printf '%s\n' 'version: 1' 'refs:' '  DEEPSEEK_API_KEY: fixture-key' \
+    >"$DSH_HOME/.credentials.yaml"
 printf '%s\n' '{"version":1,"auth":{"accessToken":"fixture-token"}}' \
     >"$MINIMAX_DATA_DIR/local-runtime.auth.json"
+[[ "$(check_qwen_status)" == "$CLI_AUTHENTICATED" ]]
+[[ "$(check_kimi_status)" == "$CLI_AUTHENTICATED" ]]
+[[ "$(check_deepseek_status)" == "$CLI_AUTHENTICATED" ]]
 [[ "$(check_minimax_status)" == "$CLI_AUTHENTICATED" ]]
 
-generic_calls="$temporary_home/generic-calls"
-check_generic_cli_status() {
-    printf '%s|%s|%s\n' "$1" "$2" "${3-}" >>"$generic_calls"
-    printf '%s\n' "$CLI_AUTHENTICATED"
-}
 check_codex_status() {
     printf '%s\n' "$CLI_AUTHENTICATED"
 }
@@ -49,8 +88,6 @@ grep -qx 'qwen=authenticated' <<<"$inventory"
 grep -qx 'kimi2=authenticated' <<<"$inventory"
 grep -qx 'minimax=authenticated' <<<"$inventory"
 grep -qx 'deepseek=authenticated' <<<"$inventory"
-grep -qx "dsh|dsh|$DSH_HOME" "$generic_calls"
-grep -qx "kimi-code|kimi|$KIMI_CODE_HOME" "$generic_calls"
 
 saved_priority=("${PROVIDER_PRIORITY[@]}")
 PROVIDER_PRIORITY=("" antigravity qwen)
@@ -63,7 +100,7 @@ PROVIDER_PRIORITY=("${saved_priority[@]}")
 
 PROVIDER_PRIORITY=(qwen)
 ROUTING_PROVIDER_PRIORITY=(codex)
-check_generic_cli_status() {
+check_qwen_status() {
     printf '%s\n' "$CLI_INSTALLED_NOT_AUTH"
 }
 check_codex_status() {

--- a/devcontainer.test/test-ai-cli-adapter-routing.sh
+++ b/devcontainer.test/test-ai-cli-adapter-routing.sh
@@ -6,16 +6,18 @@ temporary_home=$(mktemp -d)
 trap 'rm -rf -- "$temporary_home"' EXIT
 
 mkdir -p "$temporary_home/.config/workbenches"
-printf '%s\n' qwen codex kimi2 minimax >"$temporary_home/.config/workbenches/ai-provider-priority.conf"
+printf '%s\n' qwen codex kimi2 minimax deepseek >"$temporary_home/.config/workbenches/ai-provider-priority.conf"
 
 HOME=$temporary_home
 unset _AI_CLI_ADAPTER_SOURCED
 source "$ADAPTER"
 
-[[ "${PROVIDER_PRIORITY[*]}" == "qwen codex kimi2 minimax" ]]
+[[ "${PROVIDER_PRIORITY[*]}" == "qwen codex kimi2 minimax deepseek" ]]
 [[ "${ROUTING_PROVIDER_PRIORITY[*]}" == "codex" ]]
 
+generic_calls="$temporary_home/generic-calls"
 check_generic_cli_status() {
+    printf '%s|%s\n' "$1" "$2" >>"$generic_calls"
     printf '%s\n' "$CLI_AUTHENTICATED"
 }
 check_codex_status() {
@@ -29,5 +31,20 @@ inventory=$(get_all_cli_status)
 grep -qx 'qwen=authenticated' <<<"$inventory"
 grep -qx 'kimi2=authenticated' <<<"$inventory"
 grep -qx 'minimax=authenticated' <<<"$inventory"
+grep -qx 'deepseek=authenticated' <<<"$inventory"
+grep -qx 'dsh|dsh' "$generic_calls"
+
+get_unauthenticated_clis() {
+    printf '%s\n' codex
+}
+get_authenticated_cli() {
+    printf '%s\n' qwen
+}
+get_authenticated_routing_cli() {
+    printf '%s\n' codex
+}
+
+authentication_output="$(prompt_cli_authentication <<< $'\n')"
+[[ "$(tail -n 1 <<<"$authentication_output")" == codex ]]
 
 printf 'ai-cli adapter inventory and routing checks passed\n'

--- a/devcontainer.test/test-ai-cli-adapter-routing.sh
+++ b/devcontainer.test/test-ai-cli-adapter-routing.sh
@@ -20,7 +20,9 @@ printf '%s\n' '#!/usr/bin/env bash' 'exit 0' >"$temporary_home/bin/kimi"
 chmod +x "$temporary_home/bin/kimi"
 PATH="$temporary_home/bin:$PATH"
 KIMI_CODE_HOME="$temporary_home/kimi-profile"
-export PATH KIMI_CODE_HOME
+DSH_HOME="$temporary_home/dsh-profile"
+mkdir -p "$DSH_HOME"
+export PATH KIMI_CODE_HOME DSH_HOME
 [[ "$(check_generic_cli_status "kimi-code" "kimi" "$KIMI_CODE_HOME")" == "$CLI_AUTHENTICATED" ]]
 
 generic_calls="$temporary_home/generic-calls"
@@ -40,7 +42,7 @@ grep -qx 'qwen=authenticated' <<<"$inventory"
 grep -qx 'kimi2=authenticated' <<<"$inventory"
 grep -qx 'minimax=authenticated' <<<"$inventory"
 grep -qx 'deepseek=authenticated' <<<"$inventory"
-grep -qx 'dsh|dsh|' "$generic_calls"
+grep -qx "dsh|dsh|$DSH_HOME" "$generic_calls"
 grep -qx "kimi-code|kimi|$KIMI_CODE_HOME" "$generic_calls"
 
 saved_priority=("${PROVIDER_PRIORITY[@]}")
@@ -52,7 +54,24 @@ if get_unauthenticated_clis >/dev/null 2>&1; then
 fi
 PROVIDER_PRIORITY=("${saved_priority[@]}")
 
+PROVIDER_PRIORITY=(qwen)
+ROUTING_PROVIDER_PRIORITY=(codex)
+check_generic_cli_status() {
+    printf '%s\n' "$CLI_INSTALLED_NOT_AUTH"
+}
+check_codex_status() {
+    printf '%s\n' "$CLI_NOT_INSTALLED"
+}
+[[ "$(get_unauthenticated_clis)" == qwen ]]
+if get_unauthenticated_routing_clis >/dev/null 2>&1; then
+    echo "direct-only provider unexpectedly entered the routing login prompt" >&2
+    exit 1
+fi
+
 get_unauthenticated_clis() {
+    printf '%s\n' codex
+}
+get_unauthenticated_routing_clis() {
     printf '%s\n' codex
 }
 get_authenticated_cli() {

--- a/devcontainer.test/test-ai-cli-install-summary.sh
+++ b/devcontainer.test/test-ai-cli-install-summary.sh
@@ -11,6 +11,12 @@ for installer in \
     grep -Fq 'command -v chelper' <<<"$summary_block"
     grep -Fq 'Z.AI Coding Plan helper (chelper)' <<<"$summary_block"
     grep -Fq '[install skipped or failed]' <<<"$summary_block"
+
+    minimax_summary_block="$(sed -n '/^if command -v mcode /,/^fi$/p' "$installer")"
+    grep -Fq 'command -v mcode' <<<"$minimax_summary_block"
+    grep -Fq "\$HOME/.minimax-code/bin/mcode" <<<"$minimax_summary_block"
+    grep -Fq 'MiniMax Code (mcode)' <<<"$minimax_summary_block"
+    grep -Fq '[install skipped or failed]' <<<"$minimax_summary_block"
 done
 
 printf 'ai-cli optional install summaries are status-aware\n'

--- a/devcontainer.test/test-ai-cli-install-summary.sh
+++ b/devcontainer.test/test-ai-cli-install-summary.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+
+for installer in \
+    "$repo_root/base-image/install-ai-clis.sh" \
+    "$repo_root/devBenches/base-image/install-ai-clis.sh"; do
+    bash -n "$installer"
+    summary_block="$(sed -n '/^if command -v chelper /,/^fi$/p' "$installer")"
+    grep -Fq 'command -v chelper' <<<"$summary_block"
+    grep -Fq 'Z.AI Coding Plan helper (chelper)' <<<"$summary_block"
+    grep -Fq '[install skipped or failed]' <<<"$summary_block"
+done
+
+printf 'ai-cli optional install summaries are status-aware\n'

--- a/devcontainer.test/test-claude-profile-preserves-model.sh
+++ b/devcontainer.test/test-claude-profile-preserves-model.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+launcher="$repo_root/base-image/files/claude-profile"
+test_root="$(mktemp -d)"
+trap 'rm -rf "$test_root"' EXIT
+
+profiles_home="$test_root/profiles-home"
+profile_dir="$profiles_home/profiles/team"
+manifest="$test_root/claude-profiles.json"
+fake_claude="$test_root/claude"
+mkdir -p "$profile_dir"
+
+printf '%s\n' \
+  '{"profiles":[{"name":"team","email":"team@example.invalid","family":"test","profilePath":"team"}]}' \
+  > "$manifest"
+printf '%s\n' '{"model":"custom-model","effortLevel":"high"}' > "$profile_dir/settings.json"
+printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "$fake_claude"
+chmod +x "$fake_claude"
+
+run_status() {
+  HOME="$test_root/home" \
+  CLAUDE_PROFILES_HOME="$profiles_home" \
+  CLAUDE_PROFILES_MANIFEST="$manifest" \
+  CLAUDE_BIN="$fake_claude" \
+  WORKBENCHES_SHARED_MCP_FAMILIES=none \
+    "$launcher" status team >/dev/null
+}
+
+run_status
+jq -e '.model == "custom-model" and .effortLevel == "high"' "$profile_dir/settings.json" >/dev/null
+
+printf '%s\n' '{"effortLevel":"high"}' > "$profile_dir/settings.json"
+run_status
+jq -e '.model == "claude-fable-5-1" and .effortLevel == "high"' "$profile_dir/settings.json" >/dev/null
+
+echo "PASS: Claude profile model preservation"

--- a/devcontainer.test/test-claude-profile-preserves-model.sh
+++ b/devcontainer.test/test-claude-profile-preserves-model.sh
@@ -36,4 +36,35 @@ printf '%s\n' '{"effortLevel":"high"}' > "$profile_dir/settings.json"
 run_status
 jq -e '.model == "claude-fable-5-1" and .effortLevel == "high"' "$profile_dir/settings.json" >/dev/null
 
+setup_home="$test_root/setup-home"
+setup_config="$test_root/setup-config"
+setup_profiles="$test_root/setup-profiles"
+setup_manifest="$test_root/setup-claude-profiles.json"
+preserved_profile="$setup_profiles/profiles/test/preserved"
+fresh_profile="$setup_profiles/profiles/test/fresh"
+retained_profile="$setup_profiles/profiles/legacy/retained"
+mkdir -p "$setup_home" "$preserved_profile" "$retained_profile"
+printf '%s\n' '{"model":"custom-model","effortLevel":"high"}' > "$preserved_profile/settings.json"
+printf '%s\n' '{"model":"retained-model"}' > "$retained_profile/settings.json"
+printf '%s\n' \
+  '{"version":1,"profiles":[{"name":"preserved","email":"preserved@example.invalid","family":"test","profilePath":"test/preserved"},{"name":"fresh","email":"fresh@example.invalid","family":"test","profilePath":"test/fresh"}]}' \
+  > "$setup_manifest"
+
+run_setup() {
+  HOME="$setup_home" \
+  XDG_CONFIG_HOME="$setup_config" \
+  CLAUDE_PROFILES_HOME="$setup_profiles" \
+  CLAUDE_PROFILES_MANIFEST="$setup_manifest" \
+    "$repo_root/scripts/setup-claude-profiles.sh" --manifest "$setup_manifest" >/dev/null
+}
+
+run_setup
+jq -e '.model == "custom-model" and .effortLevel == "high"' "$preserved_profile/settings.json" >/dev/null
+jq -e '.model == "claude-fable-5-1"' "$fresh_profile/settings.json" >/dev/null
+jq -e '.model == "retained-model"' "$retained_profile/settings.json" >/dev/null
+
+printf '%s\n' '{"effortLevel":"high"}' > "$preserved_profile/settings.json"
+run_setup
+jq -e '.model == "claude-fable-5-1" and .effortLevel == "high"' "$preserved_profile/settings.json" >/dev/null
+
 echo "PASS: Claude profile model preservation"

--- a/docs/ai-harness-account-management.md
+++ b/docs/ai-harness-account-management.md
@@ -20,9 +20,9 @@ The supported harness families are:
 | `gemini` | Google Gemini CLI | `gemini` | One `GEMINI_CLI_HOME` per account | Login and local credential presence |
 | `grok` | Grok Build | `grok` | One `GROK_HOME` per account | Login and verification |
 | `glm` | Z.AI GLM Coding Plan through OpenCode | `opencode` | Profile-specific XDG directories | Login and verification |
-| `kimi-code` | Kimi Code CLI (Moonshot AI, Kimi K3) | `kimi` | One `KIMI_CODE_HOME` per account | Login and verification |
-| `qwen` | Qwen Code CLI (Alibaba) | `qwen` | Profile-specific `~/.qwen` config | Login and verification |
-| `minimax` | MiniMax Code CLI | `mcode` | Region-aware login (`global`/`cn`) | Login and verification |
+| `kimi-code` | Kimi Code CLI (Moonshot AI, Kimi K3) | `kimi` | One `KIMI_CODE_HOME` per account | Inventory and manual verification |
+| `qwen` | Qwen Code CLI (Alibaba) | `qwen` | Profile-specific `~/.qwen` config | Inventory and manual verification |
+| `minimax` | MiniMax Code CLI | `mcode` | Region-aware login (`global`/`cn`) | Inventory and manual verification |
 | `deepseek-harness` | DeepSeek Harness (developer preview) | `dsh` | One `DSH_HOME` per account | Inventory and manual verification |
 | `antigravity` | Google Antigravity, the Gemini CLI migration target | `agy` | Operating-system secure keyring | Inventory and manual verification |
 | `abacus` | Abacus AI CLI | `abacusai` | Provider login or per-process API key | Inventory and manual verification |
@@ -72,6 +72,11 @@ Open `http://127.0.0.1:8765`. The server binds only to loopback. It displays
 the source repository URL, verifies supported local profiles, and can start
 vendor login flows. It does not read, return, copy, or commit credential
 contents.
+
+Kimi, Qwen, and MiniMax are recognized in the shared CLI inventory and shell
+adapter, but the dashboard does not yet implement their profile-home or
+authentication adapters. Use the vendor commands in their workflows below for
+login and verification.
 
 ## Provider workflows
 

--- a/docs/ai-harness-account-management.md
+++ b/docs/ai-harness-account-management.md
@@ -20,6 +20,10 @@ The supported harness families are:
 | `gemini` | Google Gemini CLI | `gemini` | One `GEMINI_CLI_HOME` per account | Login and local credential presence |
 | `grok` | Grok Build | `grok` | One `GROK_HOME` per account | Login and verification |
 | `glm` | Z.AI GLM Coding Plan through OpenCode | `opencode` | Profile-specific XDG directories | Login and verification |
+| `kimi-code` | Kimi Code CLI (Moonshot AI, Kimi K3) | `kimi` | One `KIMI_CODE_HOME` per account | Login and verification |
+| `qwen` | Qwen Code CLI (Alibaba) | `qwen` | Profile-specific `~/.qwen` config | Login and verification |
+| `minimax` | MiniMax Code CLI | `mcode` | Region-aware login (`global`/`cn`) | Login and verification |
+| `deepseek-harness` | DeepSeek Harness (developer preview) | `dsh` | One `DSH_HOME` per account | Inventory and manual verification |
 | `antigravity` | Google Antigravity, the Gemini CLI migration target | `agy` | Operating-system secure keyring | Inventory and manual verification |
 | `abacus` | Abacus AI CLI | `abacusai` | Provider login or per-process API key | Inventory and manual verification |
 
@@ -181,6 +185,89 @@ pglm team001
 
 `pzai` is an alias for `pglm`. The profile manifest records the expected email
 but never contains the API key.
+
+### Kimi Code CLI
+
+Kimi Code CLI is Moonshot AI's terminal coding agent (Kimi K3 and later). It
+reads local data from `~/.kimi-code/` by default, and honors a `KIMI_CODE_HOME`
+override for a per-account root:
+
+```bash
+KIMI_CODE_HOME="$HOME/.kimi-code-profiles/personal" kimi
+```
+
+Inside the CLI, `/login` opens a chooser for Kimi Code OAuth (device-code flow)
+or a Moonshot AI Open Platform API key; `/logout` clears the active profile's
+credentials. Do not confuse this current TypeScript CLI with the legacy Python
+`kimi-cli` package (distributed on PyPI as `kimi-cli`); check `kimi --version`
+and expect a `0.x` release for the current tool.
+
+### Qwen Code CLI
+
+Qwen Code CLI is Alibaba's terminal coding agent. Configuration lives in
+`~/.qwen/settings.json`, which can declare multiple named model providers
+(Alibaba Cloud Model Studio, DeepSeek, MiniMax, Z.AI, Kimi, OpenRouter, or any
+OpenAI/Anthropic/Gemini-compatible endpoint) side by side:
+
+```bash
+qwen
+# inside the CLI
+/auth
+```
+
+Since Qwen Code's `settings.json` can hold several third-party provider keys at
+once, a single Qwen Code account/profile can double as the practical way to
+use DeepSeek's or MiniMax's models without a dedicated CLI for those vendors.
+
+### MiniMax Code CLI
+
+MiniMax Code CLI (`mcode`) is MiniMax's terminal coding agent, distinct from
+MiniMax's multimodal `mmx-cli` (`mmx`, for text/image/video/speech/music
+generation). Sign-in is region-aware:
+
+```bash
+mcode login --region global   # overseas MiniMax account
+mcode login --region cn       # mainland China MiniMax account
+mcode /status                 # inside the TUI: verify account, model, region
+```
+
+### DeepSeek Harness
+
+DeepSeek Harness (`dsh`, package `@deepseek-ai/dsh`) is DeepSeek AI's official,
+plugin-based agent harness, released as an MIT-licensed developer preview. It
+is genuinely different from the Claude Code/Codex/Kimi/Qwen model: nearly
+everything (models, tools, sessions, sandboxes, the agent loop, and the UI) is
+a swappable Cordis plugin rather than a fixed CLI surface.
+
+```bash
+npx @deepseek-ai/dsh web              # local Web UI at http://127.0.0.1:3080
+dsh --profile headless "do the task"  # one-shot headless run for scripts/CI
+```
+
+Credentials resolve from the inherited environment, `$DSH_HOME/.credentials.yaml`,
+the invoking directory's `.env`, then `$DSH_HOME/.env`; a DeepSeek API key
+added under Settings → Models (or the credential provider) takes effect
+immediately. Treat it as evaluation/development infrastructure, not a stable
+daily driver: the upstream README warns in capitals that breaking changes are
+expected between developer-preview releases, and installing a third-party
+plugin runs that plugin's code unsandboxed.
+
+### GLM/Z.AI Coding Tool Helper
+
+Z.AI does not ship a standalone GLM coding agent. Its official `chelper`
+(`@z_ai/coding-helper`) is a setup wizard that wires the GLM Coding Plan into
+an existing tool (Claude Code, OpenCode, Crush, or Factory Droid) rather than
+acting as an agent itself:
+
+```bash
+coding-helper init                       # interactive wizard
+chelper auth glm_coding_plan_global <token>
+chelper auth reload claude                # push the plan into Claude Code
+chelper doctor                            # health check
+```
+
+This complements, rather than replaces, the existing OpenCode-based `glm`
+profile workflow described above.
 
 ### Google Antigravity
 

--- a/openspec/changes/refresh-shared-ai-cli-tooling/.openspec.yaml
+++ b/openspec/changes/refresh-shared-ai-cli-tooling/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-09

--- a/openspec/changes/refresh-shared-ai-cli-tooling/design.md
+++ b/openspec/changes/refresh-shared-ai-cli-tooling/design.md
@@ -1,0 +1,74 @@
+## Context
+
+The canonical Layer 0 image installs AI tools system-wide as root so every
+Layer 2 and Layer 3 bench inherits the same reproducible baseline. The legacy
+devBench installer and account adapter mirror part of that surface. New tools
+have different distribution mechanisms, native post-install requirements, and
+occasionally conflicting command names, so the refresh must keep installation
+ownership and command resolution explicit.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Install and verify the expanded CLI set during image construction.
+- Keep system-wide packages root-owned and leave user credentials outside image
+  layers.
+- Expose unambiguous command names and profile-family mappings.
+- Preserve existing tools while correcting the Herdr checksum, NotebookLM MCP
+  launcher ownership, and Claude profile defaults.
+
+**Non-Goals:**
+
+- Do not authenticate any provider during an image build.
+- Do not recreate or restart running bench containers.
+- Do not make preview or best-effort installers mandatory when their upstream
+  distribution is not stable enough for a hard build gate.
+- Do not let Cursor's generic `agent` command replace another installed tool.
+
+## Decisions
+
+- Keep the canonical tools in the shared Layer 0 image. Installing them in each
+  bench would multiply drift and build time.
+- Use npm's explicit `allow-scripts` list only for packages whose published
+  installation requires native post-install work. This retains npm's default
+  script blocking for unrelated dependencies.
+- Treat the command-presence list as the hard image contract. Preview tools
+  such as DeepSeek Harness and native tools whose installer can be unavailable
+  remain best effort and are reported distinctly at build completion.
+- Install Cursor only as `cursor-agent`; never claim the ambiguous `agent`
+  binary because Grok already uses that name.
+- Let the dedicated NotebookLM MCP package own its shared launcher while
+  retaining the NotebookLM and `nlm` entry points from their respective
+  packages.
+- Initialize new Claude profiles with the Fable 5.1 model identifier, while
+  retaining any model already present in an existing profile settings file.
+- Skip creation of the native Claude compatibility link when the launcher is
+  running inside a container. Host installation health remains a host concern.
+
+## Risks / Trade-offs
+
+- [Floating upstream packages can change between builds] -> A no-cache image
+  build and command smoke test gate each merge; checksum-gated installers stay
+  pinned where the project already has that contract.
+- [Native installers can change behavior] -> Copy only the expected binary to
+  the system path, verify it explicitly, and keep non-critical native tools
+  best effort.
+- [More CLIs increase image size and build duration] -> Centralize them in the
+  shared base so the cost is paid once per image family refresh.
+- [Provider command names or profile folders can drift] -> Keep mappings in the
+  adapter and document the exact launcher/profile-family contract.
+
+## Migration Plan
+
+1. Run syntax and focused launcher/profile tests.
+2. Build the shared image without cache and verify every required command.
+3. Merge the source change without touching running containers.
+4. Activate rebuilt images only through the separately authorized managed
+   workBench recreation workflow.
+5. Roll back by rebuilding from the prior merge commit; existing credentials
+   remain external to the image and require no migration.
+
+## Open Questions
+
+None.

--- a/openspec/changes/refresh-shared-ai-cli-tooling/design.md
+++ b/openspec/changes/refresh-shared-ai-cli-tooling/design.md
@@ -31,8 +31,13 @@ ownership and command resolution explicit.
 - Keep the canonical tools in the shared Layer 0 image. Installing them in each
   bench would multiply drift and build time.
 - Use npm's explicit `allow-scripts` list only for packages whose published
-  installation requires native post-install work. This retains npm's default
-  script blocking for unrelated dependencies.
+  installation requires native post-install work. Pin npm to a release that
+  implements that option and fail the image build if the option is unavailable.
+  This retains npm's default script blocking for unrelated dependencies.
+- Keep account/profile-family recognition separate from the unified prompt
+  adapter. The adapter selects only providers with a tested non-interactive
+  invocation contract; newly recognized profile families remain directly
+  launchable until their prompt/output flags are qualified.
 - Treat the command-presence list as the hard image contract. Preview tools
   such as DeepSeek Harness and native tools whose installer can be unavailable
   remain best effort and are reported distinctly at build completion.

--- a/openspec/changes/refresh-shared-ai-cli-tooling/proposal.md
+++ b/openspec/changes/refresh-shared-ai-cli-tooling/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+The shared bench images and account adapter do not yet expose several supported
+AI coding tools, and a few existing installer/profile integrations have drifted
+from their current upstream behavior. Refreshing the image-managed baseline
+keeps every bench consistent while retaining explicit ownership and command-name
+boundaries.
+
+## What Changes
+
+- Add image-managed installers and command verification for Kimi Code, Qwen
+  Code, the Z.AI configuration helper, DeepSeek Harness, Amp, Aider, OpenHands,
+  Cursor CLI, and MiniMax Code.
+- Extend the account adapter and operator documentation for Qwen, Kimi Code,
+  and MiniMax profiles.
+- Refresh the Herdr installer checksum and the NotebookLM MCP launcher
+  reconciliation.
+- Use the current Claude Fable 5.1 profile default and prevent a containerized
+  profile launcher from rewriting the host's native Claude compatibility link.
+
+## Capabilities
+
+### New Capabilities
+
+- `shared-ai-cli-tooling`: Defines how supported AI CLIs are installed,
+  verified, named, and exposed through shared workBench images and profile
+  selection.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affects the shared Layer 0 and legacy devBench AI CLI installation scripts,
+  profile launchers, adapter routing, operator documentation, and image refresh
+  marker.
+- Adds upstream package and native-installer dependencies to image builds.
+- Does not mutate running benches; rebuilt images require a separate managed
+  container recreation before they become live.

--- a/openspec/changes/refresh-shared-ai-cli-tooling/specs/shared-ai-cli-tooling/spec.md
+++ b/openspec/changes/refresh-shared-ai-cli-tooling/specs/shared-ai-cli-tooling/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: Shared image owns the CLI baseline
+The Layer 0 image build SHALL install supported shared AI CLIs into system-owned
+locations without embedding provider credentials.
+
+#### Scenario: Bench inherits the baseline
+- **WHEN** a Layer 2 or Layer 3 bench is built from the refreshed shared image
+- **THEN** every required CLI command resolves from the inherited image-managed installation
+
+#### Scenario: Build has no provider credentials
+- **WHEN** the shared image is inspected after construction
+- **THEN** no provider login bundle or user profile is present in an image layer
+
+### Requirement: Native installation scripts are explicitly bounded
+The installer SHALL allow package installation scripts only for the enumerated
+packages that require them and SHALL avoid overwriting an existing ambiguous
+command name.
+
+#### Scenario: Required native package installs
+- **WHEN** npm installs a CLI whose published package requires a post-install script
+- **THEN** the package is included in the explicit allow list and its expected command is verified
+
+#### Scenario: Cursor command does not collide
+- **WHEN** Cursor CLI and another tool both publish a generic `agent` command
+- **THEN** the shared image exposes Cursor as `cursor-agent` without replacing the existing `agent`
+
+### Requirement: Required and best-effort tools are distinguished
+The image build SHALL fail when a required CLI command is absent and SHALL
+report a non-critical preview or best-effort tool as skipped or failed without
+misrepresenting it as installed.
+
+#### Scenario: Required command is missing
+- **WHEN** installation completes without one of the required CLI commands
+- **THEN** the image build exits unsuccessfully and identifies the missing command
+
+#### Scenario: Preview tool is unavailable
+- **WHEN** a preview or best-effort upstream installer fails
+- **THEN** the build reports that status and continues only if the tool is outside the required command contract
+
+### Requirement: Profile routing names the correct tool family
+The account adapter SHALL recognize the documented Qwen, Kimi Code, and MiniMax
+families and SHALL inspect the matching command and profile directory for each.
+
+#### Scenario: Kimi profile is inspected
+- **WHEN** the adapter evaluates a Kimi Code account
+- **THEN** it checks the `kimi` command and the Kimi Code profile directory
+
+#### Scenario: Qwen and MiniMax profiles are inspected
+- **WHEN** the adapter evaluates Qwen or MiniMax accounts
+- **THEN** it checks the documented command and profile directory for the selected family
+
+### Requirement: Claude profile initialization preserves host boundaries
+The Claude profile launcher SHALL initialize new profiles with the configured
+Fable 5.1 default and SHALL NOT create the host native-install compatibility
+link while running inside a container.
+
+#### Scenario: New Claude profile is created
+- **WHEN** a profile has no existing model selection
+- **THEN** the launcher writes the Fable 5.1 model identifier as its default
+
+#### Scenario: Launcher runs in a bench container
+- **WHEN** the launcher detects the container filesystem marker
+- **THEN** it leaves the host native Claude compatibility link unchanged
+
+### Requirement: Source and live activation remain separate
+Merging or rebuilding the shared image SHALL NOT be represented as updating an
+already-running bench container.
+
+#### Scenario: Refreshed image is built
+- **WHEN** the no-cache shared image build succeeds
+- **THEN** existing running benches remain untouched until a separately authorized managed recreation

--- a/openspec/changes/refresh-shared-ai-cli-tooling/tasks.md
+++ b/openspec/changes/refresh-shared-ai-cli-tooling/tasks.md
@@ -1,0 +1,18 @@
+## 1. Shared Installer Contract
+
+- [x] 1.1 Add the expanded CLI installers with bounded native-script permissions and explicit required-command verification.
+- [x] 1.2 Preserve unambiguous command ownership for Cursor, Grok, and the NotebookLM launchers.
+- [x] 1.3 Refresh the Herdr checksum and shared image rebuild marker.
+
+## 2. Profiles, Routing, and Documentation
+
+- [x] 2.1 Add Qwen, Kimi Code, and MiniMax profile-family mappings to the account adapter.
+- [x] 2.2 Update the operator documentation for the expanded harness set and authentication boundaries.
+- [x] 2.3 Update Claude profile initialization and prevent container launches from modifying the host compatibility link.
+
+## 3. Validation
+
+- [x] 3.1 Run shell syntax checks, focused shared-profile tests, and diff hygiene checks.
+- [x] 3.2 Verify npm native-script allow-list behavior and an Aider installation in disposable containers.
+- [ ] 3.3 Complete a no-cache shared image build and verify every required command in a disposable container.
+- [ ] 3.4 Record that running bench containers were not recreated during source and image validation.

--- a/openspec/changes/refresh-shared-ai-cli-tooling/tasks.md
+++ b/openspec/changes/refresh-shared-ai-cli-tooling/tasks.md
@@ -3,16 +3,18 @@
 - [x] 1.1 Add the expanded CLI installers with bounded native-script permissions and explicit required-command verification.
 - [x] 1.2 Preserve unambiguous command ownership for Cursor, Grok, and the NotebookLM launchers.
 - [x] 1.3 Refresh the Herdr checksum and shared image rebuild marker.
+- [x] 1.4 Pin npm 12.0.2 before selective native-script installs and fail closed when `--allow-scripts` is unavailable.
 
 ## 2. Profiles, Routing, and Documentation
 
 - [x] 2.1 Add Qwen, Kimi Code, and MiniMax profile-family mappings to the account adapter.
 - [x] 2.2 Update the operator documentation for the expanded harness set and authentication boundaries.
 - [x] 2.3 Update Claude profile initialization and prevent container launches from modifying the host compatibility link.
+- [x] 2.4 Limit unified non-interactive routing to providers with implemented prompt and output contracts.
 
 ## 3. Validation
 
 - [x] 3.1 Run shell syntax checks, focused shared-profile tests, and diff hygiene checks.
 - [x] 3.2 Verify npm native-script allow-list behavior and an Aider installation in disposable containers.
-- [ ] 3.3 Complete a no-cache shared image build and verify every required command in a disposable container.
-- [ ] 3.4 Record that running bench containers were not recreated during source and image validation.
+- [x] 3.3 Complete a no-cache shared image build and verify every required command in a disposable container.
+- [x] 3.4 Record that running bench containers were not recreated during source and image validation.

--- a/scripts/AI-PROVIDER-SETUP.md
+++ b/scripts/AI-PROVIDER-SETUP.md
@@ -69,8 +69,10 @@ claude
 codex
 gemini
 copilot
+qwen
 meta
 kimi2
+minimax
 deepseek
 ```
 
@@ -82,9 +84,16 @@ deepseek
 | claude | Claude (Anthropic) | `claude` | CLI OAuth + API key |
 | gemini | Legacy Gemini CLI ID; migrate to Antigravity | `gemini` | CLI OAuth |
 | copilot | GitHub Copilot | `copilot` | CLI OAuth |
+| qwen | Qwen Code (Alibaba) | `qwen` | CLI login / API key |
 | meta | Meta Llama | `llama` | CLI OAuth |
-| kimi2 | Moonshot Kimi 2 | `kimi` | CLI OAuth |
-| deepseek | DeepSeek | `deepseek` | CLI OAuth |
+| kimi2 | Kimi Code (Moonshot AI, Kimi K3) | `kimi` | CLI OAuth / API key |
+| minimax | MiniMax Code | `mcode` | CLI login (region-aware) |
+| deepseek | DeepSeek Harness (`dsh`) or DeepSeek as a provider inside Qwen Code/OpenCode | `dsh` | API key |
+
+GLM/Z.AI has no standalone agent CLI; it is used by pointing Claude Code,
+OpenCode, Crush, or Factory Droid at the GLM Coding Plan endpoint, optionally
+via the official `chelper` (`@z_ai/coding-helper`) setup wizard. It is
+therefore not a selectable entry in this priority list.
 
 ## Default Priority Order
 
@@ -92,9 +101,11 @@ deepseek
 2. **claude** (Claude - Anthropic)
 3. **gemini** (legacy ID; Google Antigravity is the migration target)
 4. **copilot** (GitHub Copilot)
-5. **meta** (Meta Llama)
-6. **kimi2** (Moonshot Kimi 2)
-7. **deepseek** (DeepSeek)
+5. **qwen** (Qwen Code)
+6. **meta** (Meta Llama)
+7. **kimi2** (Kimi Code / Kimi K3)
+8. **minimax** (MiniMax Code)
+9. **deepseek** (DeepSeek Harness / DeepSeek as a provider)
 
 ## How It Works
 

--- a/scripts/AI-PROVIDER-SETUP.md
+++ b/scripts/AI-PROVIDER-SETUP.md
@@ -95,17 +95,16 @@ OpenCode, Crush, or Factory Droid at the GLM Coding Plan endpoint, optionally
 via the official `chelper` (`@z_ai/coding-helper`) setup wizard. It is
 therefore not a selectable entry in this priority list.
 
-## Default Priority Order
+## Unified Non-Interactive Priority Order
 
 1. **codex** (ChatGPT account / Codex CLI)
 2. **claude** (Claude - Anthropic)
-3. **gemini** (legacy ID; Google Antigravity is the migration target)
-4. **copilot** (GitHub Copilot)
-5. **qwen** (Qwen Code)
-6. **meta** (Meta Llama)
-7. **kimi2** (Kimi Code / Kimi K3)
-8. **minimax** (MiniMax Code)
-9. **deepseek** (DeepSeek Harness / DeepSeek as a provider)
+3. **gemini** (Google Gemini CLI)
+
+The shared image also installs Copilot, Qwen, Kimi, MiniMax, and other direct
+CLIs listed above. Launch those commands directly. They are not selectable in
+the unified priority router until they have a qualified, non-interactive call
+contract in `ai-cli-adapter.sh`.
 
 ## How It Works
 

--- a/scripts/configure-ai-priority.sh
+++ b/scripts/configure-ai-priority.sh
@@ -22,33 +22,21 @@ PRIORITY_CONFIG="${CONFIG_DIR}/ai-provider-priority.conf"
 DEFAULT_PROVIDERS=(
     "codex"
     "claude"
-    "antigravity"
-    "copilot"
-    "meta"
-    "kimi2"
-    "deepseek"
+    "gemini"
 )
 
 # Provider display names
 declare -A PROVIDER_NAMES=(
     ["codex"]="GitHub Codex"
     ["claude"]="Claude (Anthropic)"
-    ["antigravity"]="Google Antigravity"
-    ["copilot"]="GitHub Copilot"
-    ["meta"]="Meta Llama"
-    ["kimi2"]="Moonshot Kimi 2"
-    ["deepseek"]="DeepSeek"
+    ["gemini"]="Google Gemini"
 )
 
 # Provider CLI commands to check
 declare -A PROVIDER_CLI=(
     ["codex"]="codex"
     ["claude"]="claude"
-    ["antigravity"]="agy"
-    ["copilot"]="copilot"
-    ["meta"]="llama"
-    ["kimi2"]="kimi"
-    ["deepseek"]="deepseek"
+    ["gemini"]="gemini"
 )
 
 # Log functions

--- a/scripts/setup-claude-profiles.sh
+++ b/scripts/setup-claude-profiles.sh
@@ -6,6 +6,7 @@ config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/workbenches"
 default_manifest="$config_dir/claude-profiles.json"
 manifest="${CLAUDE_PROFILES_MANIFEST:-$default_manifest}"
 base="${CLAUDE_PROFILES_HOME:-$HOME/.claude-profiles}"
+default_model='claude-fable-5-1'
 interactive=false
 
 usage() {
@@ -227,7 +228,6 @@ while IFS=$'\t' read -r name family profile_path; do
   settings="$profile_dir/settings.json"
   settings_tmp="$(mktemp "$profile_dir/.settings.XXXXXX.tmp")"
   statusline_command='bash "${CLAUDE_CONFIG_DIR}/statusline-command.sh"'
-  default_model='claude-fable-5'
   if [[ -e "$settings" ]] && ! jq -e 'type == "object"' "$settings" >/dev/null 2>&1; then
     echo "Claude profile settings are not valid JSON: $settings" >&2
     rm -f "$settings_tmp"
@@ -239,7 +239,7 @@ while IFS=$'\t' read -r name family profile_path; do
       | .permissions = (.permissions // {})
       | .permissions.defaultMode = "bypassPermissions"
       | .effortLevel = (.effortLevel // "xhigh")
-      | .model = $model
+      | .model = (.model // $model)
     ' "$settings" > "$settings_tmp"
   else
     jq -n --arg command "$statusline_command" --arg model "$default_model" '{
@@ -254,14 +254,15 @@ while IFS=$'\t' read -r name family profile_path; do
 done < <(jq -r '.profiles[] | [.name, .family, (.profilePath // .name)] | @tsv' "$manifest")
 
 # Profiles retained from older manifests remain launchable through their local
-# metadata. Keep their startup model aligned with the active manifest profiles.
+# metadata. Preserve explicit selections and seed the current default only when
+# a retained profile has no model configured.
 while IFS= read -r -d '' settings; do
   if ! jq -e 'type == "object"' "$settings" >/dev/null 2>&1; then
     echo "Claude profile settings are not valid JSON: $settings" >&2
     exit 1
   fi
   settings_tmp="$(mktemp "$(dirname "$settings")/.settings.XXXXXX.tmp")"
-  jq --arg model 'claude-fable-5' '.model = $model' "$settings" > "$settings_tmp"
+  jq --arg model "$default_model" '.model = (.model // $model)' "$settings" > "$settings_tmp"
   chmod 600 "$settings_tmp"
   mv -f "$settings_tmp" "$settings"
 done < <(find "$base/profiles" -mindepth 2 -type f -name settings.json -print0)

--- a/sysBenches/base-image/install-admin-tools.sh
+++ b/sysBenches/base-image/install-admin-tools.sh
@@ -91,7 +91,7 @@ az version
 echo "Installing Google Cloud SDK..."
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 curl "${CURL_RETRY[@]}" https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
-apt-get update && apt-get install -y google-cloud-sdk
+apt-get update && apt-get install -y google-cloud-cli
 gcloud version
 
 # ========================================


### PR DESCRIPTION
Lane: workbenches-sync
Claim: https://github.com/opensoft/workBenches/issues/23#issuecomment-5593664129

## Summary
- refresh the shared AI CLI inventory and compatibility adapters
- pin npm 12.0.2 and fail closed unless selective lifecycle-script support is available
- make download pipelines propagate upstream failures and qualify only supported noninteractive call providers

## Validation
- no-cache shared base-image build
- disposable runtime probe for every required AI CLI and npm 12.0.2
- shell syntax, adapter profile, shared MCP, Claude tmux, and Codex profile tests
- strict OpenSpec validation
- no running bench container recreation

## Summary by Sourcery

Refresh the shared AI CLI baseline, profile integrations, and noninteractive routing while enforcing safer installation and authentication boundaries.

New Features:
- Expand shared images with additional AI coding CLIs and provider-specific profile recognition.

Bug Fixes:
- Propagate failures from piped native installer downloads and refresh the Herdr installer checksum.
- Preserve existing Claude profile model selections while using the updated default for new profiles.
- Prevent ambiguous Cursor command ownership and reconcile the shared NotebookLM MCP launcher.

Enhancements:
- Pin npm 12.0.2 and fail closed when selective lifecycle-script controls are unavailable.
- Restrict unified noninteractive provider routing to qualified Codex, Claude, and Gemini integrations while retaining broader inventory detection.
- Improve authentication detection for Qwen, Kimi Code, DeepSeek Harness, and MiniMax profiles.
- Document the expanded CLI inventory, authentication workflows, and routing boundaries.

Build:
- Refresh the shared image marker and update the system Google Cloud package to google-cloud-cli.

Documentation:
- Add operator guidance for Kimi Code, Qwen Code, MiniMax Code, DeepSeek Harness, and the Z.AI coding helper.

Tests:
- Add adapter routing, optional-install summary, and Claude profile preservation tests.

Chores:
- Add OpenSpec change documentation covering the refreshed shared AI CLI baseline and activation boundaries.