### PR TITLE
Add a bounded WSL transport watchdog

### DIFF
--- a/docs/wsl-transport-watchdog.md
+++ b/docs/wsl-transport-watchdog.md
@@ -1,0 +1,66 @@
+# WSL transport watchdog
+
+The WSL transport watchdog checks the Windows-to-Linux process creation path independently of the Linux relay watchdog.
+
+## Failure boundary
+
+The probe runs:
+
+```powershell
+wsl.exe --distribution Ubuntu-24.04 --exec /bin/true
+```
+
+Each probe has an eight-second deadline. Two consecutive failures classify the channel as `stuck`. The watchdog terminates only the `wsl.exe` process that it created for the timed-out probe.
+
+It never:
+
+- restarts `WSLService`;
+- runs `wsl --terminate`;
+- runs `wsl --shutdown`;
+- signals existing `wsl.exe` or `wslhost.exe` processes;
+- signals Linux named relays or `SessionLeader` processes.
+
+The separate Linux relay watchdog remains responsible only for repeatedly confirmed strict orphan relays.
+
+## Install and operate
+
+Run from Windows PowerShell:
+
+```powershell
+& .\scripts\install-wsl-transport-watchdog.ps1 -Action Install
+& .\scripts\install-wsl-transport-watchdog.ps1 -Action Status
+& .\scripts\install-wsl-transport-watchdog.ps1 -Action Stop
+& .\scripts\install-wsl-transport-watchdog.ps1 -Action Start
+```
+
+The per-user scheduled task starts at logon and is named `workBenches WSL Transport Watchdog`.
+
+Runtime files are stored under:
+
+```text
+%LOCALAPPDATA%\workBenches\wsl-transport-watchdog\
+```
+
+- `status.json` contains current health and the last probe.
+- `events.jsonl` contains transitions and ten-minute heartbeats.
+- `evidence\wsl-transport-*.json` contains bounded Windows and Linux snapshots captured when health changes to `stuck`.
+
+## Diagnosis and recovery
+
+The evidence distinguishes these cases:
+
+1. **Strict orphan relays present**: the Linux relay watchdog confirms and removes only strict orphan `/init` relays.
+2. **Guest filesystem alive but process creation stuck**: the WSL session hvsocket or `WslCorePort` is wedged. The Windows watchdog records host process counts, WSL service identity, memory, Linux pressure, relay-watchdog status, and recent HNS/Hyper-V events.
+3. **Guest filesystem and process creation both unavailable**: the failure is broader than the session channel and requires controlled maintenance.
+
+There is no supported non-disruptive command that reconstructs a dead WSL VM/session hvsocket on WSL 2.6.1. Restarting `WSLService`, terminating the distribution, or shutting down WSL can interrupt all active workloads and is intentionally outside the watchdog's authority.
+
+Microsoft's WSL releases include a later fix for a broken `WslCorePort` channel after a receive timeout. Upgrade WSL during a controlled maintenance window, then let this watchdog verify that subsequent timeouts recover without accumulating probes.
+
+For root-cause ETW evidence, run Microsoft's official WSL log collector from an elevated PowerShell before reproducing the issue:
+
+```powershell
+.\collect-wsl-logs.ps1 -LogProfile hvsocket
+```
+
+The watchdog evidence timestamp identifies the exact interval to inspect in the resulting ETL trace.

--- a/docs/wsl-transport-watchdog.md
+++ b/docs/wsl-transport-watchdog.md
@@ -31,6 +31,7 @@ Run from Windows PowerShell:
 & .\scripts\install-wsl-transport-watchdog.ps1 -Action Status
 & .\scripts\install-wsl-transport-watchdog.ps1 -Action Stop
 & .\scripts\install-wsl-transport-watchdog.ps1 -Action Start
+& .\scripts\install-wsl-transport-watchdog.ps1 -Action Uninstall
 ```
 
 The per-user scheduled task starts at logon and is named `workBenches WSL Transport Watchdog`.

--- a/openspec/changes/add-wsl-transport-watchdog/.openspec.yaml
+++ b/openspec/changes/add-wsl-transport-watchdog/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-09

--- a/openspec/changes/add-wsl-transport-watchdog/design.md
+++ b/openspec/changes/add-wsl-transport-watchdog/design.md
@@ -35,7 +35,8 @@ without gaining authority over WSL services or existing workloads.
 - Write current state atomically, rotate the append-only event log at a bounded
   size, and retain at most 20 failure snapshots. Evidence is captured only on
   transition to `stuck`; diagnostic query failures are recorded without
-  terminating the daemon.
+  terminating the daemon, and host plus Windows-event collection runs in an
+  owned child process with a ten-second deadline.
 - Gather guest filesystem evidence through the distribution's UNC filesystem
   in a separately bounded PowerShell child. This can still work when guest
   process creation is unavailable and can itself time out safely.

--- a/openspec/changes/add-wsl-transport-watchdog/design.md
+++ b/openspec/changes/add-wsl-transport-watchdog/design.md
@@ -32,8 +32,10 @@ without gaining authority over WSL services or existing workloads.
   process-name cleanup is explicitly rejected.
 - Require consecutive failures before entering the `stuck` state so a single
   slow launch does not create a false incident.
-- Write current state atomically and rotate the append-only event log at a
-  bounded size. Evidence is captured only on transition to `stuck`.
+- Write current state atomically, rotate the append-only event log at a bounded
+  size, and retain at most 20 failure snapshots. Evidence is captured only on
+  transition to `stuck`; diagnostic query failures are recorded without
+  terminating the daemon.
 - Gather guest filesystem evidence through the distribution's UNC filesystem
   in a separately bounded PowerShell child. This can still work when guest
   process creation is unavailable and can itself time out safely.

--- a/openspec/changes/add-wsl-transport-watchdog/design.md
+++ b/openspec/changes/add-wsl-transport-watchdog/design.md
@@ -1,0 +1,69 @@
+## Context
+
+The Linux relay watchdog can identify strict orphan `/init` relay processes,
+but it cannot prove that Windows can still create a new process inside the WSL
+distribution. The complementary transport watchdog therefore runs in the
+Windows user session, owns each probe process it starts, and records evidence
+without gaining authority over WSL services or existing workloads.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Detect repeated Windows-to-WSL process-creation failures with bounded probes.
+- Kill only a timed-out probe owned by the watchdog.
+- Record compact health state, transition events, and diagnostic evidence.
+- Provide reversible, limited-user scheduled-task installation.
+
+**Non-Goals:**
+
+- Do not restart `WSLService`, terminate a distribution, or shut down WSL.
+- Do not signal existing Windows WSL processes or Linux relay processes.
+- Do not automatically repair a broken transport channel.
+- Do not expose process environments, credentials, or unrestricted command
+  lines in diagnostic output.
+
+## Decisions
+
+- Probe with `wsl.exe --distribution <name> --exec /bin/true`. This tests the
+  exact process-creation path while keeping guest-side work minimal.
+- Create the probe through `System.Diagnostics.Process`, retain its object and
+  PID, and terminate only that object after the configured deadline. Broad
+  process-name cleanup is explicitly rejected.
+- Require consecutive failures before entering the `stuck` state so a single
+  slow launch does not create a false incident.
+- Write current state atomically and rotate the append-only event log at a
+  bounded size. Evidence is captured only on transition to `stuck`.
+- Gather guest filesystem evidence through the distribution's UNC filesystem
+  in a separately bounded PowerShell child. This can still work when guest
+  process creation is unavailable and can itself time out safely.
+- Register a per-user, limited-privilege scheduled task at logon. The installer
+  copies the script to a user-owned local application-data directory and
+  exposes explicit lifecycle actions.
+- Treat Windows event-log access as best effort. Missing providers or access
+  errors are recorded as evidence fields rather than escalating privileges.
+
+## Risks / Trade-offs
+
+- [A slow but healthy WSL launch can time out] -> Require multiple consecutive
+  failures and make timeout, interval, and threshold bounded parameters.
+- [Guest filesystem inspection can block] -> Run it in a separate child with a
+  five-second deadline and terminate only that owned child.
+- [A stale status file can resemble a live daemon] -> Record and verify both
+  the daemon PID and process start time.
+- [Diagnostic logs can grow or include sensitive data] -> Rotate at a fixed
+  size and collect only bounded process identity, memory, service, pressure,
+  and event summaries.
+
+## Migration Plan
+
+1. Parse the scripts and run one probe against a temporary state directory.
+2. Merge the source without installing or starting a scheduled task.
+3. When explicitly requested, run the installer as the target Windows user and
+   verify task state plus daemon PID/start-time identity.
+4. Roll back with the uninstall action, which removes only the scheduled task
+   and installed script while preserving diagnostic state for audit.
+
+## Open Questions
+
+None.

--- a/openspec/changes/add-wsl-transport-watchdog/proposal.md
+++ b/openspec/changes/add-wsl-transport-watchdog/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+Wave terminals can fail even when the WSL guest filesystem remains reachable,
+because the Windows-to-Linux process-creation channel can become stuck. A
+bounded Windows-side probe is needed to detect and capture that failure without
+restarting WSL or disturbing unrelated sessions and containers.
+
+## What Changes
+
+- Add a per-user Windows watchdog that probes WSL process creation with a fixed
+  deadline and classifies consecutive failures.
+- Terminate only the watchdog-owned probe process when that deadline expires.
+- Capture bounded, secret-free Windows and guest evidence on health
+  transitions.
+- Add a reversible scheduled-task installer with install, uninstall, start,
+  stop, and status actions.
+- Document the boundary between Windows transport diagnosis and the separate
+  Linux strict-orphan relay watchdog.
+
+## Capabilities
+
+### New Capabilities
+
+- `wsl-transport-watchdog`: Detects and records WSL process-creation transport
+  failures from Windows without broad service, distribution, or workload
+  lifecycle actions.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds Windows PowerShell scripts and operator documentation.
+- Optional installation creates one limited, per-user scheduled task and local
+  state beneath the user's local application-data directory.
+- Does not install automatically, change WSL configuration, terminate a
+  distribution, restart WSL services, or recreate bench containers.

--- a/openspec/changes/add-wsl-transport-watchdog/specs/wsl-transport-watchdog/spec.md
+++ b/openspec/changes/add-wsl-transport-watchdog/specs/wsl-transport-watchdog/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Probe WSL process creation with a deadline
+The watchdog SHALL test process creation in the configured WSL distribution by
+running a minimal guest command with a bounded timeout.
+
+#### Scenario: Probe succeeds
+- **WHEN** WSL starts the guest command and it exits successfully before the deadline
+- **THEN** the watchdog records a healthy result and its measured latency
+
+#### Scenario: Probe times out
+- **WHEN** the watchdog-owned probe remains active past the deadline
+- **THEN** the watchdog terminates only that probe and records the timeout outcome
+
+### Requirement: Classify health from consecutive observations
+The watchdog SHALL require the configured number of consecutive failed probes
+before it reports the transport as stuck.
+
+#### Scenario: One transient failure occurs
+- **WHEN** a failed probe is followed by a successful probe before the threshold
+- **THEN** the consecutive-failure count resets and health remains or returns healthy
+
+#### Scenario: Failure threshold is reached
+- **WHEN** consecutive failed probes reach the configured threshold
+- **THEN** health transitions to stuck and one bounded evidence snapshot is created
+
+### Requirement: Preserve unrelated WSL workloads
+The watchdog MUST NOT restart WSL services, terminate or shut down a
+distribution, or signal processes it did not create for its own bounded probe
+and evidence operations.
+
+#### Scenario: Transport is stuck
+- **WHEN** the watchdog classifies the configured distribution as stuck
+- **THEN** existing WSL sessions, containers, relays, and host processes remain untouched
+
+### Requirement: Bound and sanitize diagnostic state
+The watchdog SHALL atomically write current state, rotate its event log at a
+fixed limit, and restrict evidence to bounded operational metadata.
+
+#### Scenario: Event log reaches its limit
+- **WHEN** the event log exceeds the configured maximum size
+- **THEN** the watchdog rotates only its own bounded log files before appending new events
+
+#### Scenario: Failure evidence is captured
+- **WHEN** health changes to stuck
+- **THEN** the evidence omits process environments and unrestricted command lines while recording diagnostic success or error fields
+
+### Requirement: Installation is explicit and reversible
+The installer SHALL create a limited per-user scheduled task only when invoked
+with the install action and SHALL support status, start, stop, and uninstall
+without requiring WSL lifecycle changes.
+
+#### Scenario: Source is merely merged
+- **WHEN** the repository change lands without an install action
+- **THEN** no scheduled task or background watchdog is created
+
+#### Scenario: User uninstalls the watchdog
+- **WHEN** the uninstall action is invoked
+- **THEN** only the named scheduled task and installed script are removed while diagnostic state is preserved

--- a/openspec/changes/add-wsl-transport-watchdog/tasks.md
+++ b/openspec/changes/add-wsl-transport-watchdog/tasks.md
@@ -15,3 +15,4 @@
 - [x] 3.1 Parse both PowerShell scripts without syntax errors and run static analysis when available.
 - [x] 3.2 Run a one-shot probe against a temporary state directory and verify its JSON contract.
 - [x] 3.3 Verify strict OpenSpec validation, diff hygiene, and absence of host-specific committed paths.
+- [x] 3.4 Verify bounded child-process termination, status output/exit-code separation, encoded child arguments, and installed-script removal on uninstall.

--- a/openspec/changes/add-wsl-transport-watchdog/tasks.md
+++ b/openspec/changes/add-wsl-transport-watchdog/tasks.md
@@ -17,3 +17,4 @@
 - [x] 3.3 Verify strict OpenSpec validation, diff hygiene, and absence of host-specific committed paths.
 - [x] 3.4 Verify bounded child-process termination, status output/exit-code separation, encoded child arguments, and installed-script removal on uninstall.
 - [x] 3.5 Verify host diagnostic failures remain non-fatal and failure evidence retention is bounded.
+- [x] 3.6 Verify host and Windows-event diagnostics run behind an owned-process deadline.

--- a/openspec/changes/add-wsl-transport-watchdog/tasks.md
+++ b/openspec/changes/add-wsl-transport-watchdog/tasks.md
@@ -16,3 +16,4 @@
 - [x] 3.2 Run a one-shot probe against a temporary state directory and verify its JSON contract.
 - [x] 3.3 Verify strict OpenSpec validation, diff hygiene, and absence of host-specific committed paths.
 - [x] 3.4 Verify bounded child-process termination, status output/exit-code separation, encoded child arguments, and installed-script removal on uninstall.
+- [x] 3.5 Verify host diagnostic failures remain non-fatal and failure evidence retention is bounded.

--- a/openspec/changes/add-wsl-transport-watchdog/tasks.md
+++ b/openspec/changes/add-wsl-transport-watchdog/tasks.md
@@ -1,0 +1,17 @@
+## 1. Bounded Transport Probe
+
+- [x] 1.1 Implement a deadline-bound WSL process-creation probe that owns and can terminate only its own child process.
+- [x] 1.2 Implement consecutive-failure health classification and transition-based evidence capture.
+- [x] 1.3 Add atomic status writes, bounded event-log rotation, and sanitized host/guest evidence collection.
+
+## 2. Explicit Lifecycle and Documentation
+
+- [x] 2.1 Implement limited per-user scheduled-task install, status, start, stop, and uninstall actions.
+- [x] 2.2 Document the diagnostic boundary, runtime state, evidence, and non-disruptive recovery limits.
+- [x] 2.3 Keep source merge separate from live scheduled-task installation.
+
+## 3. Validation
+
+- [x] 3.1 Parse both PowerShell scripts without syntax errors and run static analysis when available.
+- [x] 3.2 Run a one-shot probe against a temporary state directory and verify its JSON contract.
+- [x] 3.3 Verify strict OpenSpec validation, diff hygiene, and absence of host-specific committed paths.

--- a/scripts/install-wsl-transport-watchdog.ps1
+++ b/scripts/install-wsl-transport-watchdog.ps1
@@ -1,0 +1,116 @@
+[CmdletBinding()]
+param(
+    [ValidateSet('Install', 'Uninstall', 'Start', 'Stop', 'Status')]
+    [string]$Action = 'Install',
+
+    [ValidatePattern('^[A-Za-z0-9][A-Za-z0-9._-]*$')]
+    [string]$Distribution = 'Ubuntu-24.04'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$taskName = 'workBenches WSL Transport Watchdog'
+$installDirectory = Join-Path $env:LOCALAPPDATA 'workBenches\wsl-transport-watchdog'
+$installedScript = Join-Path $installDirectory 'wsl-transport-watchdog.ps1'
+$sourceScript = Join-Path $PSScriptRoot 'wsl-transport-watchdog.ps1'
+$systemRoot = $env:SystemRoot
+if (-not $systemRoot) {
+    $systemRoot = [Environment]::GetEnvironmentVariable('SystemRoot', 'Machine')
+}
+if (-not $systemRoot) {
+    throw 'Unable to resolve the Windows system directory.'
+}
+$powerShellPath = Join-Path $systemRoot 'System32\WindowsPowerShell\v1.0\powershell.exe'
+
+function Get-WatchdogTask {
+    return Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+}
+
+function Show-WatchdogStatus {
+    $task = Get-WatchdogTask
+    $taskInfo = if ($null -ne $task) { Get-ScheduledTaskInfo -TaskName $taskName } else { $null }
+    $statePath = Join-Path $installDirectory 'status.json'
+    $watchdogStatus = if (Test-Path -LiteralPath $statePath) { Get-Content -LiteralPath $statePath -Raw | ConvertFrom-Json } else { $null }
+    $daemonRunning = $false
+    if ($null -ne $watchdogStatus -and $null -ne $watchdogStatus.daemon) {
+        try {
+            $daemonProcess = Get-Process -Id ([int]$watchdogStatus.daemon.process_id) -ErrorAction Stop
+            $actualStart = [DateTimeOffset]$daemonProcess.StartTime
+            $expectedStart = [DateTimeOffset]$watchdogStatus.daemon.process_start_time
+            $daemonRunning = [Math]::Abs(($actualStart - $expectedStart).TotalSeconds) -lt 1
+        }
+        catch {
+            $daemonRunning = $false
+        }
+    }
+    [ordered]@{
+        installed = ($null -ne $task)
+        task_state = if ($null -ne $task) { [string]$task.State } else { $null }
+        last_run_time = if ($null -ne $taskInfo) { $taskInfo.LastRunTime.ToString('o') } else { $null }
+        last_task_result = if ($null -ne $taskInfo) { $taskInfo.LastTaskResult } else { $null }
+        installed_script = $installedScript
+        daemon_running = $daemonRunning
+        watchdog_status = $watchdogStatus
+    } | ConvertTo-Json -Depth 8
+}
+
+if ($Action -eq 'Status') {
+    Show-WatchdogStatus
+    exit 0
+}
+
+if ($Action -eq 'Stop') {
+    $task = Get-WatchdogTask
+    if ($null -ne $task) {
+        Stop-ScheduledTask -TaskName $taskName
+    }
+    Show-WatchdogStatus
+    exit 0
+}
+
+if ($Action -eq 'Start') {
+    if ($null -eq (Get-WatchdogTask)) {
+        throw "Scheduled task '$taskName' is not installed."
+    }
+    Start-ScheduledTask -TaskName $taskName
+    Start-Sleep -Seconds 2
+    Show-WatchdogStatus
+    exit 0
+}
+
+if ($Action -eq 'Uninstall') {
+    $task = Get-WatchdogTask
+    if ($null -ne $task) {
+        Stop-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+        Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
+    }
+    [ordered]@{
+        installed = $false
+        preserved_state_directory = $installDirectory
+    } | ConvertTo-Json
+    exit 0
+}
+
+if (-not (Test-Path -LiteralPath $sourceScript)) {
+    throw "Watchdog source not found: $sourceScript"
+}
+
+New-Item -ItemType Directory -Path $installDirectory -Force | Out-Null
+$existingTask = Get-WatchdogTask
+if ($null -ne $existingTask -and $existingTask.State -eq 'Running') {
+    Stop-ScheduledTask -TaskName $taskName
+    Start-Sleep -Seconds 1
+}
+Copy-Item -LiteralPath $sourceScript -Destination $installedScript -Force
+
+$arguments = '-NoProfile -NonInteractive -ExecutionPolicy Bypass -WindowStyle Hidden -File "{0}" -Mode Daemon -Distribution "{1}"' -f $installedScript, $Distribution
+$scheduledAction = New-ScheduledTaskAction -Execute $powerShellPath -Argument $arguments
+$trigger = New-ScheduledTaskTrigger -AtLogOn -User ([Security.Principal.WindowsIdentity]::GetCurrent().Name)
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1) -ExecutionTimeLimit ([TimeSpan]::Zero)
+$principal = New-ScheduledTaskPrincipal -UserId ([Security.Principal.WindowsIdentity]::GetCurrent().Name) -LogonType Interactive -RunLevel Limited
+
+Register-ScheduledTask -TaskName $taskName -Action $scheduledAction -Trigger $trigger -Settings $settings -Principal $principal -Description 'Detects WSL host-to-guest session transport timeouts; kills only its own timed-out probe and never restarts or shuts down WSL.' -Force | Out-Null
+Start-ScheduledTask -TaskName $taskName
+Start-Sleep -Seconds 2
+Show-WatchdogStatus

--- a/scripts/install-wsl-transport-watchdog.ps1
+++ b/scripts/install-wsl-transport-watchdog.ps1
@@ -85,7 +85,12 @@ if ($Action -eq 'Uninstall') {
         Stop-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
         Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
     }
-    Remove-Item -LiteralPath $installedScript -Force -ErrorAction SilentlyContinue
+    if (Test-Path -LiteralPath $installedScript) {
+        Remove-Item -LiteralPath $installedScript -Force -ErrorAction Stop
+    }
+    if (Test-Path -LiteralPath $installedScript) {
+        throw "Unable to remove installed watchdog script: $installedScript"
+    }
     [ordered]@{
         installed = $false
         installed_script_removed = (-not (Test-Path -LiteralPath $installedScript))

--- a/scripts/install-wsl-transport-watchdog.ps1
+++ b/scripts/install-wsl-transport-watchdog.ps1
@@ -85,8 +85,10 @@ if ($Action -eq 'Uninstall') {
         Stop-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
         Unregister-ScheduledTask -TaskName $taskName -Confirm:$false
     }
+    Remove-Item -LiteralPath $installedScript -Force -ErrorAction SilentlyContinue
     [ordered]@{
         installed = $false
+        installed_script_removed = (-not (Test-Path -LiteralPath $installedScript))
         preserved_state_directory = $installDirectory
     } | ConvertTo-Json
     exit 0

--- a/scripts/wsl-transport-watchdog.ps1
+++ b/scripts/wsl-transport-watchdog.ps1
@@ -29,6 +29,7 @@ $script:EventPath = Join-Path $StateDirectory 'events.jsonl'
 $script:EvidenceDirectory = Join-Path $StateDirectory 'evidence'
 $script:HeartbeatSeconds = 600
 $script:MaxEventBytes = 5MB
+$script:MaxEvidenceFiles = 20
 $script:SystemRoot = $env:SystemRoot
 if (-not $script:SystemRoot) {
     $script:SystemRoot = [Environment]::GetEnvironmentVariable('SystemRoot', 'Machine')
@@ -187,20 +188,38 @@ function Invoke-WslTransportProbe {
 }
 
 function Get-HostSnapshot {
-    $operatingSystem = Get-CimInstance Win32_OperatingSystem
-    $computerSystem = Get-CimInstance Win32_ComputerSystem
-    $wslProcesses = @(Get-CimInstance Win32_Process -Filter "Name='wsl.exe' OR Name='wslhost.exe'" -ErrorAction SilentlyContinue)
-    $vmmem = Get-Process -Name vmmemWSL -ErrorAction SilentlyContinue
-    $wslService = Get-CimInstance Win32_Service -Filter "Name='WSLService'" -ErrorAction SilentlyContinue
-    $wslBinary = Get-Item -LiteralPath (Join-Path $script:SystemRoot 'System32\wsl.exe') -ErrorAction SilentlyContinue
+    $diagnosticErrors = [ordered]@{}
+    $operatingSystem = $null
+    $computerSystem = $null
+    $wslProcesses = @()
+    $vmmem = $null
+    $wslService = $null
+    $wslBinary = $null
+
+    try { $operatingSystem = Get-CimInstance Win32_OperatingSystem -ErrorAction Stop }
+    catch { $diagnosticErrors.operating_system = $_.Exception.GetType().Name }
+    try { $computerSystem = Get-CimInstance Win32_ComputerSystem -ErrorAction Stop }
+    catch { $diagnosticErrors.computer_system = $_.Exception.GetType().Name }
+    try { $wslProcesses = @(Get-CimInstance Win32_Process -Filter "Name='wsl.exe' OR Name='wslhost.exe'" -ErrorAction Stop) }
+    catch { $diagnosticErrors.wsl_processes = $_.Exception.GetType().Name }
+    try { $vmmem = Get-Process -Name vmmemWSL -ErrorAction Stop }
+    catch { $diagnosticErrors.vmmem = $_.Exception.GetType().Name }
+    try { $wslService = Get-CimInstance Win32_Service -Filter "Name='WSLService'" -ErrorAction Stop }
+    catch { $diagnosticErrors.wsl_service = $_.Exception.GetType().Name }
+    try { $wslBinary = Get-Item -LiteralPath (Join-Path $script:SystemRoot 'System32\wsl.exe') -ErrorAction Stop }
+    catch { $diagnosticErrors.wsl_launcher = $_.Exception.GetType().Name }
     $packagedWslPath = if ($env:ProgramFiles) { Join-Path $env:ProgramFiles 'WSL\wsl.exe' } else { $null }
-    $packagedWslBinary = if ($packagedWslPath) { Get-Item -LiteralPath $packagedWslPath -ErrorAction SilentlyContinue } else { $null }
+    $packagedWslBinary = $null
+    if ($packagedWslPath) {
+        try { $packagedWslBinary = Get-Item -LiteralPath $packagedWslPath -ErrorAction Stop }
+        catch { $diagnosticErrors.packaged_wsl = $_.Exception.GetType().Name }
+    }
 
     return [ordered]@{
         windows = [ordered]@{
-            total_visible_gib = [Math]::Round($computerSystem.TotalPhysicalMemory / 1GB, 2)
-            free_physical_gib = [Math]::Round(($operatingSystem.FreePhysicalMemory * 1KB) / 1GB, 2)
-            free_virtual_gib = [Math]::Round(($operatingSystem.FreeVirtualMemory * 1KB) / 1GB, 2)
+            total_visible_gib = if ($null -ne $computerSystem) { [Math]::Round($computerSystem.TotalPhysicalMemory / 1GB, 2) } else { $null }
+            free_physical_gib = if ($null -ne $operatingSystem) { [Math]::Round(($operatingSystem.FreePhysicalMemory * 1KB) / 1GB, 2) } else { $null }
+            free_virtual_gib = if ($null -ne $operatingSystem) { [Math]::Round(($operatingSystem.FreeVirtualMemory * 1KB) / 1GB, 2) } else { $null }
         }
         wsl_service = if ($null -ne $wslService) {
             [ordered]@{
@@ -233,6 +252,7 @@ function Get-HostSnapshot {
                 cpu_seconds = [Math]::Round($vmmem.CPU, 2)
             }
         } else { $null }
+        diagnostic_errors = $diagnosticErrors
     }
 }
 
@@ -377,6 +397,11 @@ function Save-FailureEvidence {
     )
 
     New-Item -ItemType Directory -Path $script:EvidenceDirectory -Force | Out-Null
+    $existingEvidence = @(Get-ChildItem -LiteralPath $script:EvidenceDirectory -Filter 'wsl-transport-*.json' -File |
+        Sort-Object LastWriteTimeUtc -Descending)
+    foreach ($staleEvidence in @($existingEvidence | Select-Object -Skip ($script:MaxEvidenceFiles - 1))) {
+        Remove-Item -LiteralPath $staleEvidence.FullName -Force -ErrorAction Stop
+    }
     $timestamp = [DateTimeOffset]::UtcNow
     $evidencePath = Join-Path $script:EvidenceDirectory ('wsl-transport-{0}.json' -f $timestamp.ToString('yyyyMMddTHHmmssfffZ'))
     $evidence = [ordered]@{
@@ -473,7 +498,16 @@ function Invoke-WatchdogCycle {
     if ($health -ne $PreviousHealth) {
         $transition = [DateTimeOffset]::UtcNow.ToString('o')
         if ($health -eq 'stuck') {
-            $evidencePath = Save-FailureEvidence -Probe $probe -ConsecutiveFailures $failureCount
+            try {
+                $evidencePath = Save-FailureEvidence -Probe $probe -ConsecutiveFailures $failureCount
+            }
+            catch {
+                $evidencePath = $null
+                Add-WatchdogEvent -Event 'evidence-capture-failed' -Data ([ordered]@{
+                    error = $_.Exception.GetType().Name
+                    consecutive_failures = $failureCount
+                })
+            }
         }
         Add-WatchdogEvent -Event 'health-transition' -Data ([ordered]@{
             previous_health = $PreviousHealth

--- a/scripts/wsl-transport-watchdog.ps1
+++ b/scripts/wsl-transport-watchdog.ps1
@@ -1,0 +1,573 @@
+[CmdletBinding()]
+param(
+    [ValidateSet('Daemon', 'Once', 'Status', 'GuestSnapshot')]
+    [string]$Mode = 'Daemon',
+
+    [ValidatePattern('^[A-Za-z0-9][A-Za-z0-9._-]*$')]
+    [string]$Distribution = 'Ubuntu-24.04',
+
+    [ValidateRange(5, 3600)]
+    [int]$IntervalSeconds = 30,
+
+    [ValidateRange(2, 120)]
+    [int]$ProbeTimeoutSeconds = 8,
+
+    [ValidateRange(2, 20)]
+    [int]$FailureThreshold = 2,
+
+    [string]$StateDirectory = (Join-Path $env:LOCALAPPDATA 'workBenches\wsl-transport-watchdog'),
+
+    [string]$OutputPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:Version = '1.0.0'
+$script:StatePath = Join-Path $StateDirectory 'status.json'
+$script:EventPath = Join-Path $StateDirectory 'events.jsonl'
+$script:EvidenceDirectory = Join-Path $StateDirectory 'evidence'
+$script:HeartbeatSeconds = 600
+$script:MaxEventBytes = 5MB
+$script:SystemRoot = $env:SystemRoot
+if (-not $script:SystemRoot) {
+    $script:SystemRoot = [Environment]::GetEnvironmentVariable('SystemRoot', 'Machine')
+}
+if (-not $script:SystemRoot) {
+    throw 'Unable to resolve the Windows system directory.'
+}
+
+function Write-AtomicJson {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [object]$Value
+    )
+
+    $directory = Split-Path -Parent $Path
+    New-Item -ItemType Directory -Path $directory -Force | Out-Null
+    $temporaryPath = Join-Path $directory ('.{0}.{1}.tmp' -f (Split-Path -Leaf $Path), [guid]::NewGuid().ToString('N'))
+    try {
+        $Value | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $temporaryPath -Encoding UTF8
+        Move-Item -LiteralPath $temporaryPath -Destination $Path -Force
+    }
+    finally {
+        Remove-Item -LiteralPath $temporaryPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Rotate-EventLog {
+    if (-not (Test-Path -LiteralPath $script:EventPath)) {
+        return
+    }
+
+    if ((Get-Item -LiteralPath $script:EventPath).Length -lt $script:MaxEventBytes) {
+        return
+    }
+
+    for ($index = 2; $index -ge 1; $index--) {
+        $source = '{0}.{1}' -f $script:EventPath, $index
+        $destination = '{0}.{1}' -f $script:EventPath, ($index + 1)
+        if (Test-Path -LiteralPath $source) {
+            Move-Item -LiteralPath $source -Destination $destination -Force
+        }
+    }
+    Move-Item -LiteralPath $script:EventPath -Destination ($script:EventPath + '.1') -Force
+}
+
+function Add-WatchdogEvent {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Event,
+
+        [Parameter(Mandatory = $true)]
+        [System.Collections.IDictionary]$Data
+    )
+
+    New-Item -ItemType Directory -Path $StateDirectory -Force | Out-Null
+    Rotate-EventLog
+    $payload = [ordered]@{
+        timestamp = [DateTimeOffset]::UtcNow.ToString('o')
+        version = $script:Version
+        event = $Event
+    }
+    foreach ($key in $Data.Keys) {
+        $payload[$key] = $Data[$key]
+    }
+    Add-Content -LiteralPath $script:EventPath -Value ($payload | ConvertTo-Json -Depth 10 -Compress) -Encoding UTF8
+}
+
+function Stop-OwnedProbe {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Diagnostics.Process]$Process
+    )
+
+    if ($Process.HasExited) {
+        return $false
+    }
+
+    try {
+        $Process.Kill()
+        $null = $Process.WaitForExit(3000)
+        return $true
+    }
+    catch {
+        return $false
+    }
+}
+
+function Invoke-WslTransportProbe {
+    $start = [DateTimeOffset]::UtcNow
+    $stopwatch = [Diagnostics.Stopwatch]::StartNew()
+    $process = $null
+    try {
+        $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+        $startInfo.FileName = (Join-Path $script:SystemRoot 'System32\wsl.exe')
+        # Windows PowerShell 5.1 does not expose ProcessStartInfo.ArgumentList.
+        # Distribution is constrained to a shell-safe WSL name above, so pass
+        # the four fixed arguments without quoting the distribution token.
+        $startInfo.Arguments = "--distribution $Distribution --exec /bin/true"
+        $startInfo.UseShellExecute = $false
+        $startInfo.CreateNoWindow = $true
+        $startInfo.RedirectStandardOutput = $true
+        $startInfo.RedirectStandardError = $true
+        $process = [System.Diagnostics.Process]::Start($startInfo)
+        if (-not $process.WaitForExit($ProbeTimeoutSeconds * 1000)) {
+            $probePid = $process.Id
+            $killed = Stop-OwnedProbe -Process $process
+            return [ordered]@{
+                outcome = 'timeout'
+                healthy = $false
+                latency_ms = [int]$stopwatch.ElapsedMilliseconds
+                exit_code = $null
+                probe_pid = $probePid
+                owned_probe_terminated = $killed
+                started_at = $start.ToString('o')
+            }
+        }
+
+        $standardOutput = $process.StandardOutput.ReadToEnd().Trim()
+        $standardError = $process.StandardError.ReadToEnd().Trim()
+        $errorText = if ($standardError) { $standardError } else { $standardOutput }
+        $exitCode = $process.ExitCode
+        return [ordered]@{
+            outcome = if ($exitCode -eq 0) { 'success' } else { 'exit-error' }
+            healthy = ($exitCode -eq 0)
+            latency_ms = [int]$stopwatch.ElapsedMilliseconds
+            exit_code = $exitCode
+            probe_pid = $process.Id
+            owned_probe_terminated = $false
+            error_summary = if ($errorText) { $errorText.Substring(0, [Math]::Min(500, $errorText.Length)) } else { $null }
+            started_at = $start.ToString('o')
+        }
+    }
+    catch {
+        return [ordered]@{
+            outcome = 'probe-error'
+            healthy = $false
+            latency_ms = [int]$stopwatch.ElapsedMilliseconds
+            exit_code = $null
+            probe_pid = if ($null -ne $process) { $process.Id } else { $null }
+            owned_probe_terminated = $false
+            error_summary = $_.Exception.GetType().Name
+            started_at = $start.ToString('o')
+        }
+    }
+    finally {
+        $stopwatch.Stop()
+        if ($null -ne $process) {
+            $process.Dispose()
+        }
+    }
+}
+
+function Get-HostSnapshot {
+    $operatingSystem = Get-CimInstance Win32_OperatingSystem
+    $computerSystem = Get-CimInstance Win32_ComputerSystem
+    $wslProcesses = @(Get-CimInstance Win32_Process -Filter "Name='wsl.exe' OR Name='wslhost.exe'" -ErrorAction SilentlyContinue)
+    $vmmem = Get-Process -Name vmmemWSL -ErrorAction SilentlyContinue
+    $wslService = Get-CimInstance Win32_Service -Filter "Name='WSLService'" -ErrorAction SilentlyContinue
+    $wslBinary = Get-Item -LiteralPath (Join-Path $script:SystemRoot 'System32\wsl.exe') -ErrorAction SilentlyContinue
+    $packagedWslPath = if ($env:ProgramFiles) { Join-Path $env:ProgramFiles 'WSL\wsl.exe' } else { $null }
+    $packagedWslBinary = if ($packagedWslPath) { Get-Item -LiteralPath $packagedWslPath -ErrorAction SilentlyContinue } else { $null }
+
+    return [ordered]@{
+        windows = [ordered]@{
+            total_visible_gib = [Math]::Round($computerSystem.TotalPhysicalMemory / 1GB, 2)
+            free_physical_gib = [Math]::Round(($operatingSystem.FreePhysicalMemory * 1KB) / 1GB, 2)
+            free_virtual_gib = [Math]::Round(($operatingSystem.FreeVirtualMemory * 1KB) / 1GB, 2)
+        }
+        wsl_service = if ($null -ne $wslService) {
+            [ordered]@{
+                state = $wslService.State
+                process_id = [int]$wslService.ProcessId
+                start_mode = $wslService.StartMode
+            }
+        } else { $null }
+        wsl_version = [ordered]@{
+            launcher = if ($null -ne $wslBinary) { $wslBinary.VersionInfo.ProductVersion } else { $null }
+            package = if ($null -ne $packagedWslBinary) { $packagedWslBinary.VersionInfo.ProductVersion } else { $null }
+        }
+        host_processes = [ordered]@{
+            wsl_exe = @($wslProcesses | Where-Object { $_.Name -eq 'wsl.exe' }).Count
+            wslhost_exe = @($wslProcesses | Where-Object { $_.Name -eq 'wslhost.exe' }).Count
+            identities = @($wslProcesses | ForEach-Object {
+                [ordered]@{
+                    name = $_.Name
+                    process_id = [int]$_.ProcessId
+                    parent_process_id = [int]$_.ParentProcessId
+                    creation_date = if ($null -ne $_.CreationDate) { ([DateTimeOffset]$_.CreationDate).ToString('o') } else { $null }
+                }
+            })
+        }
+        vmmem = if ($null -ne $vmmem) {
+            [ordered]@{
+                process_id = $vmmem.Id
+                working_set_gib = [Math]::Round($vmmem.WorkingSet64 / 1GB, 2)
+                private_memory_gib = [Math]::Round($vmmem.PrivateMemorySize64 / 1GB, 2)
+                cpu_seconds = [Math]::Round($vmmem.CPU, 2)
+            }
+        } else { $null }
+    }
+}
+
+function Convert-KeyValueFile {
+    param([string[]]$Lines)
+
+    $result = [ordered]@{}
+    foreach ($line in $Lines) {
+        if ($line -match '^([^:]+):\s+([0-9]+)\s*kB$') {
+            $result[$Matches[1]] = [int64]$Matches[2]
+        }
+    }
+    return $result
+}
+
+function Write-GuestSnapshot {
+    if (-not $OutputPath) {
+        throw 'GuestSnapshot requires -OutputPath.'
+    }
+
+        $distributionRoot = '\\wsl$\{0}' -f $Distribution
+    $snapshot = [ordered]@{
+        timestamp = [DateTimeOffset]::UtcNow.ToString('o')
+        distribution = $Distribution
+        filesystem_reachable = $false
+        meminfo_kib = $null
+        memory_pressure = $null
+        uptime = $null
+        relay_watchdog = $null
+        error = $null
+    }
+    try {
+        $procRoot = Join-Path $distributionRoot 'proc'
+        $snapshot.filesystem_reachable = Test-Path -LiteralPath $procRoot
+        if ($snapshot.filesystem_reachable) {
+            $snapshot.meminfo_kib = Convert-KeyValueFile -Lines (Get-Content -LiteralPath (Join-Path $procRoot 'meminfo'))
+            $snapshot.memory_pressure = Get-Content -LiteralPath (Join-Path $procRoot 'pressure\memory')
+            $snapshot.uptime = Get-Content -LiteralPath (Join-Path $procRoot 'uptime')
+        }
+        $relayStatusPath = Join-Path $distributionRoot 'run\wsl-relay-watchdog\status.json'
+        if (Test-Path -LiteralPath $relayStatusPath) {
+            $snapshot.relay_watchdog = Get-Content -LiteralPath $relayStatusPath -Raw | ConvertFrom-Json
+        }
+    }
+    catch {
+        $snapshot.error = $_.Exception.GetType().Name
+    }
+    Write-AtomicJson -Path $OutputPath -Value $snapshot
+}
+
+function Invoke-BoundedGuestSnapshot {
+    New-Item -ItemType Directory -Path $script:EvidenceDirectory -Force | Out-Null
+    $temporaryPath = Join-Path $script:EvidenceDirectory ('.guest-{0}.json' -f [guid]::NewGuid().ToString('N'))
+    $process = $null
+    try {
+        $powerShellPath = Join-Path $PSHOME 'powershell.exe'
+        if (-not (Test-Path -LiteralPath $powerShellPath)) {
+            $powerShellPath = (Get-Process -Id $PID).Path
+        }
+        $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+        $startInfo.FileName = $powerShellPath
+        $startInfo.Arguments = '-NoProfile -NonInteractive -ExecutionPolicy Bypass -File "{0}" -Mode GuestSnapshot -Distribution "{1}" -StateDirectory "{2}" -OutputPath "{3}"' -f $PSCommandPath, $Distribution, $StateDirectory, $temporaryPath
+        $startInfo.UseShellExecute = $false
+        $startInfo.CreateNoWindow = $true
+        $process = [System.Diagnostics.Process]::Start($startInfo)
+        if (-not $process.WaitForExit(5000)) {
+            $null = Stop-OwnedProbe -Process $process
+            return [ordered]@{ completed = $false; outcome = 'timeout' }
+        }
+        if ($process.ExitCode -ne 0 -or -not (Test-Path -LiteralPath $temporaryPath)) {
+            return [ordered]@{ completed = $false; outcome = 'error'; exit_code = $process.ExitCode }
+        }
+        return [ordered]@{
+            completed = $true
+            outcome = 'success'
+            snapshot = Get-Content -LiteralPath $temporaryPath -Raw | ConvertFrom-Json
+        }
+    }
+    catch {
+        return [ordered]@{ completed = $false; outcome = 'error'; error = $_.Exception.GetType().Name }
+    }
+    finally {
+        if ($null -ne $process) {
+            $process.Dispose()
+        }
+        Remove-Item -LiteralPath $temporaryPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Get-RelevantWindowsEvents {
+    $startTime = (Get-Date).AddMinutes(-10)
+    $eventSets = @()
+    $queries = @(
+        [ordered]@{ name = 'Microsoft-Windows-Host-Network-Service'; filter = @{ ProviderName = 'Microsoft-Windows-Host-Network-Service'; StartTime = $startTime } },
+        [ordered]@{ name = 'Microsoft-Windows-Hyper-V-Compute-Admin'; filter = @{ LogName = 'Microsoft-Windows-Hyper-V-Compute-Admin'; StartTime = $startTime } },
+        [ordered]@{ name = 'Microsoft-Windows-Hyper-V-Compute-Operational'; filter = @{ LogName = 'Microsoft-Windows-Hyper-V-Compute-Operational'; StartTime = $startTime } },
+        [ordered]@{ name = 'Windows power and resume'; filter = @{ LogName = 'System'; ProviderName = @('Microsoft-Windows-Kernel-Power', 'Microsoft-Windows-Power-Troubleshooter'); StartTime = $startTime } }
+    )
+    foreach ($query in $queries) {
+        try {
+            $events = @(Get-WinEvent -FilterHashtable $query.filter -MaxEvents 25 -ErrorAction Stop)
+            $eventSets += [ordered]@{
+                provider = $query.name
+                events = @($events | ForEach-Object {
+                    [ordered]@{
+                        timestamp = ([DateTimeOffset]$_.TimeCreated).ToString('o')
+                        id = $_.Id
+                        level = $_.LevelDisplayName
+                        message = if ($_.Message) { $_.Message.Substring(0, [Math]::Min(1000, $_.Message.Length)) } else { $null }
+                    }
+                })
+            }
+        }
+        catch {
+            $eventSets += [ordered]@{ provider = $query.name; events = @(); error = $_.Exception.GetType().Name }
+        }
+    }
+    return $eventSets
+}
+
+function Save-FailureEvidence {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Collections.IDictionary]$Probe,
+
+        [Parameter(Mandatory = $true)]
+        [int]$ConsecutiveFailures
+    )
+
+    New-Item -ItemType Directory -Path $script:EvidenceDirectory -Force | Out-Null
+    $timestamp = [DateTimeOffset]::UtcNow
+    $evidencePath = Join-Path $script:EvidenceDirectory ('wsl-transport-{0}.json' -f $timestamp.ToString('yyyyMMddTHHmmssfffZ'))
+    $evidence = [ordered]@{
+        timestamp = $timestamp.ToString('o')
+        classification = 'wsl-host-to-guest-session-channel-stuck'
+        consecutive_failures = $ConsecutiveFailures
+        probe = $Probe
+        host = Get-HostSnapshot
+        guest = Invoke-BoundedGuestSnapshot
+        windows_events = Get-RelevantWindowsEvents
+        recovery_boundary = [ordered]@{
+            owned_probe_terminated = [bool]$Probe.owned_probe_terminated
+            unrelated_processes_signaled = 0
+            wsl_service_restarted = $false
+            distribution_terminated = $false
+            wsl_shutdown = $false
+        }
+    }
+    Write-AtomicJson -Path $evidencePath -Value $evidence
+    return $evidencePath
+}
+
+function Read-ExistingState {
+    if (-not (Test-Path -LiteralPath $script:StatePath)) {
+        return $null
+    }
+    try {
+        return Get-Content -LiteralPath $script:StatePath -Raw | ConvertFrom-Json
+    }
+    catch {
+        return $null
+    }
+}
+
+function Write-CurrentState {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Health,
+
+        [Parameter(Mandatory = $true)]
+        [int]$ConsecutiveFailures,
+
+        [Parameter(Mandatory = $true)]
+        [System.Collections.IDictionary]$Probe,
+
+        [string]$LastEvidencePath,
+
+        [string]$LastTransition
+    )
+
+    $currentProcess = Get-Process -Id $PID
+    $state = [ordered]@{
+        version = $script:Version
+        timestamp = [DateTimeOffset]::UtcNow.ToString('o')
+        distribution = $Distribution
+        health = $Health
+        consecutive_failures = $ConsecutiveFailures
+        probe = $Probe
+        daemon = [ordered]@{
+            process_id = $PID
+            process_start_time = ([DateTimeOffset]$currentProcess.StartTime).ToString('o')
+            interval_seconds = $IntervalSeconds
+            probe_timeout_seconds = $ProbeTimeoutSeconds
+            failure_threshold = $FailureThreshold
+        }
+        last_transition = $LastTransition
+        last_evidence_path = $LastEvidencePath
+        safeguards = @(
+            'kill-only-owned-probe',
+            'never-restart-wslservice',
+            'never-terminate-distribution',
+            'never-shutdown-wsl',
+            'never-signal-named-relays-or-sessionleaders'
+        )
+    }
+    Write-AtomicJson -Path $script:StatePath -Value $state
+    return $state
+}
+
+function Invoke-WatchdogCycle {
+    param(
+        [int]$PreviousFailureCount,
+        [string]$PreviousHealth,
+        [string]$LastEvidencePath,
+        [string]$LastTransition
+    )
+
+    $probe = Invoke-WslTransportProbe
+    $failureCount = if ($probe.healthy) { 0 } else { $PreviousFailureCount + 1 }
+    $health = if ($probe.healthy) { 'healthy' } elseif ($failureCount -ge $FailureThreshold) { 'stuck' } else { 'degraded' }
+    $transition = $LastTransition
+    $evidencePath = $LastEvidencePath
+
+    if ($health -ne $PreviousHealth) {
+        $transition = [DateTimeOffset]::UtcNow.ToString('o')
+        if ($health -eq 'stuck') {
+            $evidencePath = Save-FailureEvidence -Probe $probe -ConsecutiveFailures $failureCount
+        }
+        Add-WatchdogEvent -Event 'health-transition' -Data ([ordered]@{
+            previous_health = $PreviousHealth
+            health = $health
+            consecutive_failures = $failureCount
+            probe = $probe
+            evidence_path = $evidencePath
+        })
+    }
+
+    $state = Write-CurrentState -Health $health -ConsecutiveFailures $failureCount -Probe $probe -LastEvidencePath $evidencePath -LastTransition $transition
+    return [ordered]@{
+        state = $state
+        health = $health
+        failure_count = $failureCount
+        evidence_path = $evidencePath
+        transition = $transition
+    }
+}
+
+function Test-DaemonIdentity {
+    param([object]$State)
+
+    if ($null -eq $State -or $null -eq $State.daemon) {
+        return $false
+    }
+    try {
+        $process = Get-Process -Id ([int]$State.daemon.process_id) -ErrorAction Stop
+        $actualStart = [DateTimeOffset]$process.StartTime
+        $expectedStart = [DateTimeOffset]$State.daemon.process_start_time
+        return [Math]::Abs(($actualStart - $expectedStart).TotalSeconds) -lt 1
+    }
+    catch {
+        return $false
+    }
+}
+
+function Show-Status {
+    $state = Read-ExistingState
+    if ($null -eq $state) {
+        [ordered]@{ running = $false; status = 'unavailable'; state_path = $script:StatePath } | ConvertTo-Json -Depth 6
+        return 3
+    }
+    $state | Add-Member -NotePropertyName running -NotePropertyValue (Test-DaemonIdentity -State $state) -Force
+    $state | ConvertTo-Json -Depth 10
+    if (-not $state.running) {
+        return 3
+    }
+    return 0
+}
+
+function Run-Daemon {
+    New-Item -ItemType Directory -Path $StateDirectory -Force | Out-Null
+    $createdNew = $false
+    $mutex = New-Object System.Threading.Mutex($true, 'Local\workBenches.WslTransportWatchdog', [ref]$createdNew)
+    if (-not $createdNew) {
+        $mutex.Dispose()
+        return 0
+    }
+
+    $failureCount = 0
+    $health = 'starting'
+    $lastEvidencePath = $null
+    $lastTransition = [DateTimeOffset]::UtcNow.ToString('o')
+    $lastHeartbeat = [DateTimeOffset]::MinValue
+    Add-WatchdogEvent -Event 'daemon-started' -Data ([ordered]@{ process_id = $PID; distribution = $Distribution })
+    try {
+        while ($true) {
+            $result = Invoke-WatchdogCycle -PreviousFailureCount $failureCount -PreviousHealth $health -LastEvidencePath $lastEvidencePath -LastTransition $lastTransition
+            $failureCount = $result.failure_count
+            $health = $result.health
+            $lastEvidencePath = $result.evidence_path
+            $lastTransition = $result.transition
+            $now = [DateTimeOffset]::UtcNow
+            if (($now - $lastHeartbeat).TotalSeconds -ge $script:HeartbeatSeconds) {
+                Add-WatchdogEvent -Event 'heartbeat' -Data ([ordered]@{
+                    health = $health
+                    consecutive_failures = $failureCount
+                    latency_ms = $result.state.probe.latency_ms
+                })
+                $lastHeartbeat = $now
+            }
+            Start-Sleep -Seconds $IntervalSeconds
+        }
+    }
+    finally {
+        Add-WatchdogEvent -Event 'daemon-stopped' -Data ([ordered]@{ process_id = $PID })
+        $mutex.ReleaseMutex()
+        $mutex.Dispose()
+    }
+}
+
+if ($Mode -eq 'GuestSnapshot') {
+    Write-GuestSnapshot
+    exit 0
+}
+
+if ($Mode -eq 'Status') {
+    exit (Show-Status)
+}
+
+if ($Mode -eq 'Once') {
+    $existingState = Read-ExistingState
+    $previousFailureCount = if ($null -ne $existingState) { [int]$existingState.consecutive_failures } else { 0 }
+    $previousHealth = if ($null -ne $existingState) { [string]$existingState.health } else { 'starting' }
+    $lastEvidencePath = if ($null -ne $existingState) { [string]$existingState.last_evidence_path } else { $null }
+    $lastTransition = if ($null -ne $existingState) { [string]$existingState.last_transition } else { [DateTimeOffset]::UtcNow.ToString('o') }
+    $result = Invoke-WatchdogCycle -PreviousFailureCount $previousFailureCount -PreviousHealth $previousHealth -LastEvidencePath $lastEvidencePath -LastTransition $lastTransition
+    $result.state | ConvertTo-Json -Depth 10
+    exit $(if ($result.health -eq 'healthy') { 0 } else { 2 })
+}
+
+exit (Run-Daemon)

--- a/scripts/wsl-transport-watchdog.ps1
+++ b/scripts/wsl-transport-watchdog.ps1
@@ -111,8 +111,10 @@ function Stop-OwnedProbe {
 
     try {
         $Process.Kill()
-        $null = $Process.WaitForExit(3000)
-        return $true
+        if (-not $Process.WaitForExit(3000)) {
+            return $false
+        }
+        return $Process.HasExited
     }
     catch {
         return $false
@@ -251,7 +253,7 @@ function Write-GuestSnapshot {
         throw 'GuestSnapshot requires -OutputPath.'
     }
 
-        $distributionRoot = '\\wsl$\{0}' -f $Distribution
+    $distributionRoot = '\\wsl$\{0}' -f $Distribution
     $snapshot = [ordered]@{
         timestamp = [DateTimeOffset]::UtcNow.ToString('o')
         distribution = $Distribution
@@ -290,15 +292,29 @@ function Invoke-BoundedGuestSnapshot {
         if (-not (Test-Path -LiteralPath $powerShellPath)) {
             $powerShellPath = (Get-Process -Id $PID).Path
         }
+        $quoteLiteral = {
+            param([string]$Value)
+            return "'" + $Value.Replace("'", "''") + "'"
+        }
+        $quotedScriptPath = & $quoteLiteral $PSCommandPath
+        $quotedDistribution = & $quoteLiteral $Distribution
+        $quotedStateDirectory = & $quoteLiteral $StateDirectory
+        $quotedTemporaryPath = & $quoteLiteral $temporaryPath
+        $childCommand = '& {0} -Mode GuestSnapshot -Distribution {1} -StateDirectory {2} -OutputPath {3}' -f $quotedScriptPath, $quotedDistribution, $quotedStateDirectory, $quotedTemporaryPath
+        $encodedCommand = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($childCommand))
         $startInfo = New-Object System.Diagnostics.ProcessStartInfo
         $startInfo.FileName = $powerShellPath
-        $startInfo.Arguments = '-NoProfile -NonInteractive -ExecutionPolicy Bypass -File "{0}" -Mode GuestSnapshot -Distribution "{1}" -StateDirectory "{2}" -OutputPath "{3}"' -f $PSCommandPath, $Distribution, $StateDirectory, $temporaryPath
+        $startInfo.Arguments = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand $encodedCommand"
         $startInfo.UseShellExecute = $false
         $startInfo.CreateNoWindow = $true
         $process = [System.Diagnostics.Process]::Start($startInfo)
         if (-not $process.WaitForExit(5000)) {
-            $null = Stop-OwnedProbe -Process $process
-            return [ordered]@{ completed = $false; outcome = 'timeout' }
+            $terminated = Stop-OwnedProbe -Process $process
+            return [ordered]@{
+                completed = $false
+                outcome = if ($terminated) { 'timeout' } else { 'timeout-process-still-running' }
+                owned_probe_terminated = $terminated
+            }
         }
         if ($process.ExitCode -ne 0 -or -not (Test-Path -LiteralPath $temporaryPath)) {
             return [ordered]@{ completed = $false; outcome = 'error'; exit_code = $process.ExitCode }
@@ -495,18 +511,19 @@ function Test-DaemonIdentity {
     }
 }
 
-function Show-Status {
+function Get-StatusResult {
     $state = Read-ExistingState
     if ($null -eq $state) {
-        [ordered]@{ running = $false; status = 'unavailable'; state_path = $script:StatePath } | ConvertTo-Json -Depth 6
-        return 3
+        return [ordered]@{
+            exit_code = 3
+            payload = [ordered]@{ running = $false; status = 'unavailable'; state_path = $script:StatePath }
+        }
     }
     $state | Add-Member -NotePropertyName running -NotePropertyValue (Test-DaemonIdentity -State $state) -Force
-    $state | ConvertTo-Json -Depth 10
-    if (-not $state.running) {
-        return 3
+    return [ordered]@{
+        exit_code = if ($state.running) { 0 } else { 3 }
+        payload = $state
     }
-    return 0
 }
 
 function Run-Daemon {
@@ -556,7 +573,9 @@ if ($Mode -eq 'GuestSnapshot') {
 }
 
 if ($Mode -eq 'Status') {
-    exit (Show-Status)
+    $statusResult = Get-StatusResult
+    $statusResult.payload | ConvertTo-Json -Depth 10
+    exit ([int]$statusResult.exit_code)
 }
 
 if ($Mode -eq 'Once') {

--- a/scripts/wsl-transport-watchdog.ps1
+++ b/scripts/wsl-transport-watchdog.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [ValidateSet('Daemon', 'Once', 'Status', 'GuestSnapshot')]
+    [ValidateSet('Daemon', 'Once', 'Status', 'GuestSnapshot', 'DiagnosticSnapshot')]
     [string]$Mode = 'Daemon',
 
     [ValidatePattern('^[A-Za-z0-9][A-Za-z0-9._-]*$')]
@@ -30,6 +30,7 @@ $script:EvidenceDirectory = Join-Path $StateDirectory 'evidence'
 $script:HeartbeatSeconds = 600
 $script:MaxEventBytes = 5MB
 $script:MaxEvidenceFiles = 20
+$script:HostDiagnosticTimeoutMilliseconds = 10000
 $script:SystemRoot = $env:SystemRoot
 if (-not $script:SystemRoot) {
     $script:SystemRoot = [Environment]::GetEnvironmentVariable('SystemRoot', 'Machine')
@@ -387,6 +388,69 @@ function Get-RelevantWindowsEvents {
     return $eventSets
 }
 
+function Write-DiagnosticSnapshot {
+    if (-not $OutputPath) {
+        throw 'DiagnosticSnapshot requires -OutputPath.'
+    }
+
+    Write-AtomicJson -Path $OutputPath -Value ([ordered]@{
+        host = Get-HostSnapshot
+        windows_events = Get-RelevantWindowsEvents
+    })
+}
+
+function Invoke-BoundedDiagnosticSnapshot {
+    New-Item -ItemType Directory -Path $script:EvidenceDirectory -Force | Out-Null
+    $temporaryPath = Join-Path $script:EvidenceDirectory ('.diagnostics-{0}.json' -f [guid]::NewGuid().ToString('N'))
+    $process = $null
+    try {
+        $powerShellPath = Join-Path $PSHOME 'powershell.exe'
+        if (-not (Test-Path -LiteralPath $powerShellPath)) {
+            $powerShellPath = (Get-Process -Id $PID).Path
+        }
+        $quoteLiteral = {
+            param([string]$Value)
+            return "'" + $Value.Replace("'", "''") + "'"
+        }
+        $quotedScriptPath = & $quoteLiteral $PSCommandPath
+        $quotedStateDirectory = & $quoteLiteral $StateDirectory
+        $quotedTemporaryPath = & $quoteLiteral $temporaryPath
+        $childCommand = '& {0} -Mode DiagnosticSnapshot -StateDirectory {1} -OutputPath {2}' -f $quotedScriptPath, $quotedStateDirectory, $quotedTemporaryPath
+        $encodedCommand = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($childCommand))
+        $startInfo = New-Object System.Diagnostics.ProcessStartInfo
+        $startInfo.FileName = $powerShellPath
+        $startInfo.Arguments = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand $encodedCommand"
+        $startInfo.UseShellExecute = $false
+        $startInfo.CreateNoWindow = $true
+        $process = [System.Diagnostics.Process]::Start($startInfo)
+        if (-not $process.WaitForExit($script:HostDiagnosticTimeoutMilliseconds)) {
+            $terminated = Stop-OwnedProbe -Process $process
+            return [ordered]@{
+                completed = $false
+                outcome = if ($terminated) { 'timeout' } else { 'timeout-process-still-running' }
+                owned_process_terminated = $terminated
+            }
+        }
+        if ($process.ExitCode -ne 0 -or -not (Test-Path -LiteralPath $temporaryPath)) {
+            return [ordered]@{ completed = $false; outcome = 'error'; exit_code = $process.ExitCode }
+        }
+        return [ordered]@{
+            completed = $true
+            outcome = 'success'
+            snapshot = Get-Content -LiteralPath $temporaryPath -Raw | ConvertFrom-Json
+        }
+    }
+    catch {
+        return [ordered]@{ completed = $false; outcome = 'error'; error = $_.Exception.GetType().Name }
+    }
+    finally {
+        if ($null -ne $process) {
+            $process.Dispose()
+        }
+        Remove-Item -LiteralPath $temporaryPath -Force -ErrorAction SilentlyContinue
+    }
+}
+
 function Save-FailureEvidence {
     param(
         [Parameter(Mandatory = $true)]
@@ -403,15 +467,16 @@ function Save-FailureEvidence {
         Remove-Item -LiteralPath $staleEvidence.FullName -Force -ErrorAction Stop
     }
     $timestamp = [DateTimeOffset]::UtcNow
+    $diagnostics = Invoke-BoundedDiagnosticSnapshot
     $evidencePath = Join-Path $script:EvidenceDirectory ('wsl-transport-{0}.json' -f $timestamp.ToString('yyyyMMddTHHmmssfffZ'))
     $evidence = [ordered]@{
         timestamp = $timestamp.ToString('o')
         classification = 'wsl-host-to-guest-session-channel-stuck'
         consecutive_failures = $ConsecutiveFailures
         probe = $Probe
-        host = Get-HostSnapshot
+        host = if ($diagnostics.completed) { $diagnostics.snapshot.host } else { [ordered]@{ capture = $diagnostics } }
         guest = Invoke-BoundedGuestSnapshot
-        windows_events = Get-RelevantWindowsEvents
+        windows_events = if ($diagnostics.completed) { $diagnostics.snapshot.windows_events } else { @() }
         recovery_boundary = [ordered]@{
             owned_probe_terminated = [bool]$Probe.owned_probe_terminated
             unrelated_processes_signaled = 0
@@ -603,6 +668,11 @@ function Run-Daemon {
 
 if ($Mode -eq 'GuestSnapshot') {
     Write-GuestSnapshot
+    exit 0
+}
+
+if ($Mode -eq 'DiagnosticSnapshot') {
+    Write-DiagnosticSnapshot
     exit 0
 }
 


### PR DESCRIPTION
Lane: workbenches-sync
Claim: https://github.com/opensoft/workBenches/issues/23#issuecomment-5593664129

## Summary

- add a bounded Windows-side WSL process-creation watchdog that kills only its own timed-out probe
- classify health after consecutive failures and capture bounded host/guest transition evidence
- encode child PowerShell commands so paths cannot alter argument boundaries
- provide explicit install, status, start, stop, and uninstall actions; uninstall removes the installed executable while preserving diagnostics
- keep WSL service restart, distribution termination, and shutdown outside the watchdog authority

## Validation

- Windows PowerShell AST parsing passed for both scripts
- two bounded failed probes against a nonexistent test distribution produced transition evidence without leaving child probes
- encoded guest snapshot completed successfully from a temporary state path
- Status emitted parseable JSON separately from exit code 3 when no daemon identity was active
- strict OpenSpec validation and git diff checks passed
- the existing scheduled task was not installed, started, stopped, or uninstalled during source validation

## Summary by Sourcery

Add a bounded Windows WSL transport watchdog that detects process-creation failures, records actionable evidence, and offers explicit non-disruptive lifecycle management.

New Features:
- Add a Windows-side WSL transport watchdog that performs deadline-bound process-creation probes and classifies consecutive failures.
- Add bounded host, guest, and Windows-event evidence capture when transport health becomes stuck.
- Provide explicit per-user scheduled-task installation and lifecycle actions for installing, checking, starting, stopping, and uninstalling the watchdog.

Enhancements:
- Preserve unrelated WSL workloads by limiting termination to watchdog-owned probe and diagnostic child processes and excluding service, distribution, and relay recovery actions.
- Sanitize child PowerShell invocation and diagnostic state while adding atomic status writes, bounded event rotation, and evidence retention.
- Document transport failure boundaries, operational state, diagnosis, and controlled recovery limitations.

Documentation:
- Document watchdog operation, runtime files, evidence, failure boundaries, and recovery guidance.

Tests:
- Validate PowerShell parsing, bounded probe behavior, status output and exit-code handling, encoded child arguments, diagnostic deadlines, and evidence retention.