### PR TITLE
Harden Wave dotNetBench launcher boundaries

### DIFF
--- a/devcontainer.test/test-wave-container-shell.sh
+++ b/devcontainer.test/test-wave-container-shell.sh
@@ -26,11 +26,14 @@ run_launcher_case() {
     local mock_bin="$case_root/bin"
     local docker_log="$case_root/docker.log"
     local prepare_log="$case_root/prepare.log"
-    mkdir -p "$fake_home" "$fake_root/devBenches/pyBench/.devcontainer" "$fake_root/devBenches/dotNetBench/.devcontainer" "$fake_root/scripts" "$mock_bin"
+    mkdir -p "$fake_home" "$fake_root/devBenches/pyBench/.devcontainer" "$fake_root/devBenches/dotNetBench/.devcontainer" "$fake_root/devBenches/rustBench/.devcontainer" "$fake_root/scripts" "$mock_bin"
     : > "$fake_root/devBenches/pyBench/.devcontainer/devcontainer.json"
     : > "$fake_root/devBenches/pyBench/.devcontainer/docker-compose.yml"
     : > "$fake_root/devBenches/dotNetBench/.devcontainer/devcontainer.json"
     : > "$fake_root/devBenches/dotNetBench/.devcontainer/docker-compose.yml"
+    : > "$fake_root/devBenches/rustBench/.devcontainer/devcontainer.json"
+    : > "$fake_root/devBenches/rustBench/.devcontainer/docker-compose.yml"
+    : > "$fake_root/devBenches/rustBench/.devcontainer/docker-compose.wslg.yml"
     : > "$fake_root/custom-compose.yml"
 
     cat > "$fake_root/scripts/prepare-bench-start.sh" <<'PREPARE'
@@ -188,5 +191,9 @@ grep -q -- "compose -f .*/custom-compose.yml" <<<"$CASE_DOCKER_LOG" \
 if grep -q '^devcontainer ' <<<"$CASE_DOCKER_LOG"; then
     fail "first creation ignored the explicit Compose file through Dev Containers CLI"
 fi
+
+CASE_CONTAINER_EXISTS=false CASE_EXPLICIT_COMPOSE=true run_launcher_case rust-explicit-compose-first-create false missing false false rustBench
+grep -q -- "compose -f .*/custom-compose.yml -f .*/devBenches/rustBench/.devcontainer/docker-compose.wslg.yml" <<<"$CASE_DOCKER_LOG" \
+    || fail "rustBench resolved its WSLg override relative to the explicit Compose file"
 
 echo "PASS: wave container launcher lifecycle tests"

--- a/devcontainer.test/test-wave-container-shell.sh
+++ b/devcontainer.test/test-wave-container-shell.sh
@@ -31,6 +31,7 @@ run_launcher_case() {
     : > "$fake_root/devBenches/pyBench/.devcontainer/docker-compose.yml"
     : > "$fake_root/devBenches/dotNetBench/.devcontainer/devcontainer.json"
     : > "$fake_root/devBenches/dotNetBench/.devcontainer/docker-compose.yml"
+    : > "$fake_root/custom-compose.yml"
 
     cat > "$fake_root/scripts/prepare-bench-start.sh" <<'PREPARE'
 #!/usr/bin/env bash
@@ -91,6 +92,11 @@ exit 0
 MOCK
     chmod +x "$mock_bin/docker"
 
+    local launcher_args=()
+    if [[ "${CASE_EXPLICIT_COMPOSE:-false}" == true ]]; then
+        launcher_args+=(--compose-file "$fake_root/custom-compose.yml")
+    fi
+
     local output
     if ! output="$(
         env \
@@ -108,6 +114,7 @@ MOCK
                 --workbenches-root "$fake_root" \
                 --shell sh \
                 --check \
+                "${launcher_args[@]}" \
                 "$@" \
                 "$bench" 2>&1
     )"; then
@@ -159,5 +166,9 @@ fi
 run_launcher_case dotnet-defaults false missing false false dotNetBench
 grep -q -- '--container dotnet-bench --base dotnet-bench:latest --user tester --project dev-benches --service dotnet-bench' <<<"$CASE_PREPARE_LOG" \
     || fail "safe startup helper did not receive the dotNetBench lifecycle contract"
+
+CASE_EXPLICIT_COMPOSE=true run_launcher_case dotnet-explicit-compose false missing false false dotNetBench
+grep -q -- "compose -f .*/custom-compose.yml" <<<"$CASE_DOCKER_LOG" \
+    || fail "dotNetBench replaced the explicitly supplied Compose file"
 
 echo "PASS: wave container launcher lifecycle tests"

--- a/devcontainer.test/test-wave-container-shell.sh
+++ b/devcontainer.test/test-wave-container-shell.sh
@@ -16,7 +16,8 @@ run_launcher_case() {
     local mounts="$3"
     local rm_refuse="$4"
     local after_refusal_running="$5"
-    shift 5
+    local bench="$6"
+    shift 6
 
     local case_root
     case_root="$(mktemp -d)"
@@ -25,9 +26,11 @@ run_launcher_case() {
     local mock_bin="$case_root/bin"
     local docker_log="$case_root/docker.log"
     local prepare_log="$case_root/prepare.log"
-    mkdir -p "$fake_home" "$fake_root/devBenches/pyBench/.devcontainer" "$fake_root/scripts" "$mock_bin"
+    mkdir -p "$fake_home" "$fake_root/devBenches/pyBench/.devcontainer" "$fake_root/devBenches/dotNetBench/.devcontainer" "$fake_root/scripts" "$mock_bin"
     : > "$fake_root/devBenches/pyBench/.devcontainer/devcontainer.json"
     : > "$fake_root/devBenches/pyBench/.devcontainer/docker-compose.yml"
+    : > "$fake_root/devBenches/dotNetBench/.devcontainer/devcontainer.json"
+    : > "$fake_root/devBenches/dotNetBench/.devcontainer/docker-compose.yml"
 
     cat > "$fake_root/scripts/prepare-bench-start.sh" <<'PREPARE'
 #!/usr/bin/env bash
@@ -106,7 +109,7 @@ MOCK
                 --shell sh \
                 --check \
                 "$@" \
-                py-bench 2>&1
+                "$bench" 2>&1
     )"; then
         echo "$output" >&2
         rm -rf "$case_root"
@@ -121,8 +124,11 @@ MOCK
 
 bash -n "$launcher"
 "$launcher" --help | grep -q -- '--repair' || fail "help does not document --repair"
+if grep -Fq 'ln -sfn /usr/local/bin/claude "$HOME/.local/bin/claude"' "$launcher"; then
+    fail "launcher can overwrite the host Claude binary link through a writable home mount"
+fi
 
-run_launcher_case preserve-running true missing true true
+run_launcher_case preserve-running true missing true true py-bench
 grep -q -- '--container py-bench --base py-bench:latest --user tester --project dev-benches --service py-bench' <<<"$CASE_PREPARE_LOG" \
     || fail "safe startup helper did not receive the pyBench lifecycle contract"
 grep -q 'preserving the live container' <<<"$CASE_OUTPUT" || fail "running container was not preserved with a warning"
@@ -133,15 +139,15 @@ if grep -q '^compose ' <<<"$CASE_DOCKER_LOG"; then
     fail "normal launch recreated a running container"
 fi
 
-run_launcher_case explicit-repair true complete false true --repair
+run_launcher_case explicit-repair true complete false true py-bench --repair
 grep -q '^rm -f py-bench$' <<<"$CASE_DOCKER_LOG" || fail "--repair did not remove the existing container"
 grep -q '^compose ' <<<"$CASE_DOCKER_LOG" || fail "--repair did not recreate the container"
 
-run_launcher_case stopped-auto-repair false missing false false
+run_launcher_case stopped-auto-repair false missing false false py-bench
 grep -q '^rm py-bench$' <<<"$CASE_DOCKER_LOG" || fail "stopped container with missing mounts was not removed safely"
 grep -q '^compose ' <<<"$CASE_DOCKER_LOG" || fail "stopped container with missing mounts was not recreated"
 
-run_launcher_case started-during-check false missing true true
+run_launcher_case started-during-check false missing true true py-bench
 grep -q 'started while Wave mounts were being checked' <<<"$CASE_OUTPUT" || fail "container start race was not reported"
 if grep -q '^rm -f py-bench$' <<<"$CASE_DOCKER_LOG"; then
     fail "automatic repair force-removed a container that started during checks"
@@ -149,5 +155,9 @@ fi
 if grep -q '^compose ' <<<"$CASE_DOCKER_LOG"; then
     fail "automatic repair recreated a container that started during checks"
 fi
+
+run_launcher_case dotnet-defaults false missing false false dotNetBench
+grep -q -- '--container dotnet-bench --base dotnet-bench:latest --user tester --project dev-benches --service dotnet-bench' <<<"$CASE_PREPARE_LOG" \
+    || fail "safe startup helper did not receive the dotNetBench lifecycle contract"
 
 echo "PASS: wave container launcher lifecycle tests"

--- a/devcontainer.test/test-wave-container-shell.sh
+++ b/devcontainer.test/test-wave-container-shell.sh
@@ -26,7 +26,10 @@ run_launcher_case() {
     local mock_bin="$case_root/bin"
     local docker_log="$case_root/docker.log"
     local prepare_log="$case_root/prepare.log"
-    mkdir -p "$fake_home" "$fake_root/devBenches/pyBench/.devcontainer" "$fake_root/devBenches/dotNetBench/.devcontainer" "$fake_root/devBenches/rustBench/.devcontainer" "$fake_root/scripts" "$mock_bin"
+    local wslg_root="$case_root/no-wslg"
+    local explicit_compose="$fake_root/custom-compose.yml"
+    local expected_env_dir=""
+    mkdir -p "$fake_home" "$fake_root/devBenches/pyBench/.devcontainer" "$fake_root/devBenches/dotNetBench/.devcontainer" "$fake_root/devBenches/rustBench/.devcontainer" "$fake_root/customBench/.devcontainer" "$fake_root/scripts" "$mock_bin"
     : > "$fake_root/devBenches/pyBench/.devcontainer/devcontainer.json"
     : > "$fake_root/devBenches/pyBench/.devcontainer/docker-compose.yml"
     : > "$fake_root/devBenches/dotNetBench/.devcontainer/devcontainer.json"
@@ -35,6 +38,16 @@ run_launcher_case() {
     : > "$fake_root/devBenches/rustBench/.devcontainer/docker-compose.yml"
     : > "$fake_root/devBenches/rustBench/.devcontainer/docker-compose.wslg.yml"
     : > "$fake_root/custom-compose.yml"
+    : > "$fake_root/customBench/.devcontainer/docker-compose.yml"
+    printf '%s\n' 'CUSTOM_BENCH_VALUE=present' > "$fake_root/customBench/.env"
+    if [[ "${CASE_GENERIC_COMPOSE:-false}" == true ]]; then
+        explicit_compose="$fake_root/customBench/.devcontainer/docker-compose.yml"
+        expected_env_dir="$fake_root/customBench/.devcontainer"
+    fi
+    if [[ "${CASE_WSLG_ENABLED:-false}" == true ]]; then
+        wslg_root="$fake_root/wslg"
+        mkdir -p "$wslg_root"
+    fi
 
     cat > "$fake_root/scripts/prepare-bench-start.sh" <<'PREPARE'
 #!/usr/bin/env bash
@@ -47,6 +60,11 @@ PREPARE
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> "$MOCK_DOCKER_LOG"
+
+if [[ "${1:-}" == "compose" && -n "$MOCK_EXPECT_ENV_DIR" ]]; then
+    [[ -f "$MOCK_EXPECT_ENV_DIR/.env" ]] || exit 1
+    printf '%s\n' compose-env-present >> "$MOCK_DOCKER_LOG"
+fi
 
 if [[ "${1:-}" == "container" && "${2:-}" == "inspect" ]]; then
     if [[ "$MOCK_CONTAINER_EXISTS" != true ]]; then
@@ -107,7 +125,7 @@ MOCK
 
     local launcher_args=()
     if [[ "${CASE_EXPLICIT_COMPOSE:-false}" == true ]]; then
-        launcher_args+=(--compose-file "$fake_root/custom-compose.yml")
+        launcher_args+=(--compose-file "$explicit_compose")
     fi
 
     local output
@@ -117,6 +135,8 @@ MOCK
             USER=tester \
             PATH="$mock_bin:$PATH" \
             MOCK_DOCKER_LOG="$docker_log" \
+            MOCK_EXPECT_ENV_DIR="$expected_env_dir" \
+            WAVE_WSLG_ROOT="$wslg_root" \
             MOCK_CONTAINER_EXISTS="${CASE_CONTAINER_EXISTS:-true}" \
             MOCK_PREPARE_LOG="$prepare_log" \
             MOCK_RUNNING="$running" \
@@ -192,8 +212,12 @@ if grep -q '^devcontainer ' <<<"$CASE_DOCKER_LOG"; then
     fail "first creation ignored the explicit Compose file through Dev Containers CLI"
 fi
 
-CASE_CONTAINER_EXISTS=false CASE_EXPLICIT_COMPOSE=true run_launcher_case rust-explicit-compose-first-create false missing false false rustBench
+CASE_CONTAINER_EXISTS=false CASE_EXPLICIT_COMPOSE=true CASE_WSLG_ENABLED=true run_launcher_case rust-explicit-compose-first-create false missing false false rustBench
 grep -q -- "compose -f .*/custom-compose.yml -f .*/devBenches/rustBench/.devcontainer/docker-compose.wslg.yml" <<<"$CASE_DOCKER_LOG" \
     || fail "rustBench resolved its WSLg override relative to the explicit Compose file"
+
+CASE_CONTAINER_EXISTS=false CASE_EXPLICIT_COMPOSE=true CASE_GENERIC_COMPOSE=true run_launcher_case generic-explicit-compose-first-create false missing false false custom-bench
+grep -q '^compose-env-present$' <<<"$CASE_DOCKER_LOG" \
+    || fail "generic container did not copy its bench-root .env beside the Compose file"
 
 echo "PASS: wave container launcher lifecycle tests"

--- a/devcontainer.test/test-wave-container-shell.sh
+++ b/devcontainer.test/test-wave-container-shell.sh
@@ -46,6 +46,9 @@ set -euo pipefail
 printf '%s\n' "$*" >> "$MOCK_DOCKER_LOG"
 
 if [[ "${1:-}" == "container" && "${2:-}" == "inspect" ]]; then
+    if [[ "$MOCK_CONTAINER_EXISTS" != true ]]; then
+        exit 1
+    fi
     if [[ "${3:-}" == "-f" ]]; then
         case "${4:-}" in
             *State.Running*)
@@ -92,6 +95,13 @@ exit 0
 MOCK
     chmod +x "$mock_bin/docker"
 
+    cat > "$mock_bin/devcontainer" <<'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'devcontainer %s\n' "$*" >> "$MOCK_DOCKER_LOG"
+MOCK
+    chmod +x "$mock_bin/devcontainer"
+
     local launcher_args=()
     if [[ "${CASE_EXPLICIT_COMPOSE:-false}" == true ]]; then
         launcher_args+=(--compose-file "$fake_root/custom-compose.yml")
@@ -104,6 +114,7 @@ MOCK
             USER=tester \
             PATH="$mock_bin:$PATH" \
             MOCK_DOCKER_LOG="$docker_log" \
+            MOCK_CONTAINER_EXISTS="${CASE_CONTAINER_EXISTS:-true}" \
             MOCK_PREPARE_LOG="$prepare_log" \
             MOCK_RUNNING="$running" \
             MOCK_MOUNTS="$mounts" \
@@ -170,5 +181,12 @@ grep -q -- '--container dotnet-bench --base dotnet-bench:latest --user tester --
 CASE_EXPLICIT_COMPOSE=true run_launcher_case dotnet-explicit-compose false missing false false dotNetBench
 grep -q -- "compose -f .*/custom-compose.yml" <<<"$CASE_DOCKER_LOG" \
     || fail "dotNetBench replaced the explicitly supplied Compose file"
+
+CASE_CONTAINER_EXISTS=false CASE_EXPLICIT_COMPOSE=true run_launcher_case dotnet-explicit-compose-first-create false missing false false dotNetBench
+grep -q -- "compose -f .*/custom-compose.yml" <<<"$CASE_DOCKER_LOG" \
+    || fail "first creation did not use the explicitly supplied Compose file"
+if grep -q '^devcontainer ' <<<"$CASE_DOCKER_LOG"; then
+    fail "first creation ignored the explicit Compose file through Dev Containers CLI"
+fi
 
 echo "PASS: wave container launcher lifecycle tests"

--- a/scripts/wave-container-shell.sh
+++ b/scripts/wave-container-shell.sh
@@ -15,8 +15,10 @@ check_only=false
 repair_requested=false
 profile_launcher_marker="/usr/local/share/workbenches/profile-launchers.sha256"
 bench_dir="$workbenches_root/devBenches/pyBench"
+bench_dir_resolved=false
 compose_file="$bench_dir/.devcontainer/docker-compose.yml"
 compose_file_explicit=false
+wslg_root="${WAVE_WSLG_ROOT:-/mnt/wslg}"
 base_image="py-bench:latest"
 layer3_chown=""
 compose_project="dev-benches"
@@ -26,6 +28,7 @@ resolve_bench_defaults() {
         pyBench|py-bench)
             container="py-bench"
             bench_dir="$workbenches_root/devBenches/pyBench"
+            bench_dir_resolved=true
             [[ "$compose_file_explicit" == true ]] || compose_file="$bench_dir/.devcontainer/docker-compose.yml"
             base_image="py-bench:latest"
             layer3_chown=""
@@ -34,6 +37,7 @@ resolve_bench_defaults() {
         dotNetBench|dotnetBench|dotnet-bench)
             container="dotnet-bench"
             bench_dir="$workbenches_root/devBenches/dotNetBench"
+            bench_dir_resolved=true
             [[ "$compose_file_explicit" == true ]] || compose_file="$bench_dir/.devcontainer/docker-compose.yml"
             base_image="dotnet-bench:latest"
             layer3_chown=""
@@ -42,6 +46,7 @@ resolve_bench_defaults() {
         cppBench|C++Bench|c++Bench|cpp-bench)
             container="cpp-bench"
             bench_dir="$workbenches_root/devBenches/cppBench"
+            bench_dir_resolved=true
             [[ "$compose_file_explicit" == true ]] || compose_file="$bench_dir/.devcontainer/docker-compose.yml"
             base_image="cpp-bench:latest"
             layer3_chown="/opt/vcpkg"
@@ -50,6 +55,7 @@ resolve_bench_defaults() {
         rustBench|rust-bench)
             container="rust-bench"
             bench_dir="$workbenches_root/devBenches/rustBench"
+            bench_dir_resolved=true
             [[ "$compose_file_explicit" == true ]] || compose_file="$bench_dir/.devcontainer/docker-compose.yml"
             base_image="rust-bench:latest"
             layer3_chown="/opt/rust"
@@ -58,6 +64,7 @@ resolve_bench_defaults() {
         flutterBench|flutter-bench)
             container="flutter-bench"
             bench_dir="$workbenches_root/devBenches/flutterBench"
+            bench_dir_resolved=true
             [[ "$compose_file_explicit" == true ]] || compose_file="$bench_dir/.devcontainer/docker-compose.yml"
             base_image="flutter-bench:latest"
             layer3_chown="/opt/flutter /opt/flutter-3.27.0 /opt/android-sdk"
@@ -66,6 +73,7 @@ resolve_bench_defaults() {
         cloudBench|cloud-bench)
             container="cloud-bench"
             bench_dir="$workbenches_root/sysBenches/cloudBench/devcontainer.example"
+            bench_dir_resolved=true
             [[ "$compose_file_explicit" == true ]] || compose_file="$bench_dir/docker-compose.yml"
             base_image="cloud-bench:latest"
             layer3_chown=""
@@ -74,6 +82,7 @@ resolve_bench_defaults() {
         365Bench|m365Bench|m365-bench)
             container="m365-bench"
             bench_dir="$workbenches_root/sysBenches/365Bench"
+            bench_dir_resolved=true
             [[ "$compose_file_explicit" == true ]] || compose_file="$bench_dir/.devcontainer/docker-compose.yml"
             base_image="m365-bench:latest"
             layer3_chown=""
@@ -285,17 +294,22 @@ create_with_compose() {
         exit 1
     fi
 
-    local compose_dir
+    local compose_dir compose_bench_dir
     compose_dir="$(dirname "$compose_file")"
-    if [[ ! -f "$compose_dir/.env" && -f "$bench_dir/.env" ]]; then
-        cp "$bench_dir/.env" "$compose_dir/.env"
+    if [[ "$bench_dir_resolved" == true ]]; then
+        compose_bench_dir="$bench_dir"
+    else
+        compose_bench_dir="$(dirname "$compose_dir")"
+    fi
+    if [[ ! -f "$compose_dir/.env" && -f "$compose_bench_dir/.env" ]]; then
+        cp "$compose_bench_dir/.env" "$compose_dir/.env"
     fi
 
     local override_file
     local compose_args
     override_file="$(write_wave_compose_override)"
     compose_args=(-f "$compose_file")
-    if [[ "$container" == "rust-bench" && -d /mnt/wslg ]]; then
+    if [[ "$container" == "rust-bench" && -d "$wslg_root" ]]; then
         local wslg_compose_file="$bench_dir/.devcontainer/docker-compose.wslg.yml"
         if [[ ! -f "$wslg_compose_file" ]]; then
             echo "rustBench WSLg override is missing: $wslg_compose_file" >&2

--- a/scripts/wave-container-shell.sh
+++ b/scripts/wave-container-shell.sh
@@ -30,6 +30,14 @@ resolve_bench_defaults() {
             layer3_chown=""
             compose_project="dev-benches"
             ;;
+        dotNetBench|dotnetBench|dotnet-bench)
+            container="dotnet-bench"
+            bench_dir="$workbenches_root/devBenches/dotNetBench"
+            compose_file="$bench_dir/.devcontainer/docker-compose.yml"
+            base_image="dotnet-bench:latest"
+            layer3_chown=""
+            compose_project="dev-benches"
+            ;;
         cppBench|C++Bench|c++Bench|cpp-bench)
             container="cpp-bench"
             bench_dir="$workbenches_root/devBenches/cppBench"
@@ -494,10 +502,6 @@ install_ai_profile_launchers() {
 
     docker exec --user root "$container" sh -c \
         "mkdir -p '/home/${container_user}/.local/bin' '/home/${container_user}/.local/state' && chown '${container_user}:${container_user}' '/home/${container_user}/.local' '/home/${container_user}/.local/bin' '/home/${container_user}/.local/state'"
-    if [[ -f "$claude_launcher" ]]; then
-        docker exec --user "$container_user" "$container" sh -c \
-            'ln -sfn /usr/local/bin/claude "$HOME/.local/bin/claude"'
-    fi
 }
 
 ensure_user_cargo_cache

--- a/scripts/wave-container-shell.sh
+++ b/scripts/wave-container-shell.sh
@@ -287,7 +287,6 @@ create_with_compose() {
 
     local compose_dir
     compose_dir="$(dirname "$compose_file")"
-    bench_dir="$(dirname "$compose_dir")"
     if [[ ! -f "$compose_dir/.env" && -f "$bench_dir/.env" ]]; then
         cp "$bench_dir/.env" "$compose_dir/.env"
     fi

--- a/scripts/wave-container-shell.sh
+++ b/scripts/wave-container-shell.sh
@@ -395,7 +395,9 @@ fi
 if [[ "$repair_requested" == true && "$container_exists" == true ]]; then
     recreate_with_compose
 elif [[ "$container_exists" != true ]]; then
-    if [[ -f "$bench_dir/.devcontainer/devcontainer.json" ]]; then
+    if [[ "$compose_file_explicit" == true ]]; then
+        create_with_compose
+    elif [[ -f "$bench_dir/.devcontainer/devcontainer.json" ]]; then
         echo "Creating $container with Dev Containers CLI..."
         if ! run_devcontainer_up; then
             echo "Dev Containers CLI did not complete; creating $container with Wave compose mounts." >&2

--- a/scripts/wave-container-shell.sh
+++ b/scripts/wave-container-shell.sh
@@ -16,6 +16,7 @@ repair_requested=false
 profile_launcher_marker="/usr/local/share/workbenches/profile-launchers.sha256"
 bench_dir="$workbenches_root/devBenches/pyBench"
 compose_file="$bench_dir/.devcontainer/docker-compose.yml"
+compose_file_explicit=false
 base_image="py-bench:latest"
 layer3_chown=""
 compose_project="dev-benches"
@@ -25,7 +26,7 @@ resolve_bench_defaults() {
         pyBench|py-bench)
             container="py-bench"
             bench_dir="$workbenches_root/devBenches/pyBench"
-            compose_file="$bench_dir/.devcontainer/docker-compose.yml"
+            [[ "$compose_file_explicit" == true ]] || compose_file="$bench_dir/.devcontainer/docker-compose.yml"
             base_image="py-bench:latest"
             layer3_chown=""
             compose_project="dev-benches"
@@ -33,7 +34,7 @@ resolve_bench_defaults() {
         dotNetBench|dotnetBench|dotnet-bench)
             container="dotnet-bench"
             bench_dir="$workbenches_root/devBenches/dotNetBench"
-            compose_file="$bench_dir/.devcontainer/docker-compose.yml"
+            [[ "$compose_file_explicit" == true ]] || compose_file="$bench_dir/.devcontainer/docker-compose.yml"
             base_image="dotnet-bench:latest"
             layer3_chown=""
             compose_project="dev-benches"
@@ -41,7 +42,7 @@ resolve_bench_defaults() {
         cppBench|C++Bench|c++Bench|cpp-bench)
             container="cpp-bench"
             bench_dir="$workbenches_root/devBenches/cppBench"
-            compose_file="$bench_dir/.devcontainer/docker-compose.yml"
+            [[ "$compose_file_explicit" == true ]] || compose_file="$bench_dir/.devcontainer/docker-compose.yml"
             base_image="cpp-bench:latest"
             layer3_chown="/opt/vcpkg"
             compose_project="dev-benches"
@@ -49,7 +50,7 @@ resolve_bench_defaults() {
         rustBench|rust-bench)
             container="rust-bench"
             bench_dir="$workbenches_root/devBenches/rustBench"
-            compose_file="$bench_dir/.devcontainer/docker-compose.yml"
+            [[ "$compose_file_explicit" == true ]] || compose_file="$bench_dir/.devcontainer/docker-compose.yml"
             base_image="rust-bench:latest"
             layer3_chown="/opt/rust"
             compose_project="dev-benches"
@@ -57,7 +58,7 @@ resolve_bench_defaults() {
         flutterBench|flutter-bench)
             container="flutter-bench"
             bench_dir="$workbenches_root/devBenches/flutterBench"
-            compose_file="$bench_dir/.devcontainer/docker-compose.yml"
+            [[ "$compose_file_explicit" == true ]] || compose_file="$bench_dir/.devcontainer/docker-compose.yml"
             base_image="flutter-bench:latest"
             layer3_chown="/opt/flutter /opt/flutter-3.27.0 /opt/android-sdk"
             compose_project="dev-benches"
@@ -65,7 +66,7 @@ resolve_bench_defaults() {
         cloudBench|cloud-bench)
             container="cloud-bench"
             bench_dir="$workbenches_root/sysBenches/cloudBench/devcontainer.example"
-            compose_file="$bench_dir/docker-compose.yml"
+            [[ "$compose_file_explicit" == true ]] || compose_file="$bench_dir/docker-compose.yml"
             base_image="cloud-bench:latest"
             layer3_chown=""
             compose_project="sys-benches"
@@ -73,7 +74,7 @@ resolve_bench_defaults() {
         365Bench|m365Bench|m365-bench)
             container="m365-bench"
             bench_dir="$workbenches_root/sysBenches/365Bench"
-            compose_file="$bench_dir/.devcontainer/docker-compose.yml"
+            [[ "$compose_file_explicit" == true ]] || compose_file="$bench_dir/.devcontainer/docker-compose.yml"
             base_image="m365-bench:latest"
             layer3_chown=""
             compose_project="sys-benches"
@@ -106,7 +107,7 @@ EOF
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --workbenches-root) workbenches_root="$2"; shift 2 ;;
-        --compose-file) compose_file="$2"; shift 2 ;;
+        --compose-file) compose_file="$2"; compose_file_explicit=true; shift 2 ;;
         --user) container_user="$2"; shift 2 ;;
         --workdir) workdir="$2"; shift 2 ;;
         --shell) shell_path="$2"; shift 2 ;;


### PR DESCRIPTION
Lane: workbenches-sync
Claim: https://github.com/opensoft/workBenches/issues/23#issuecomment-5593664129

## Summary

- map dotNetBench aliases to the dotnet-bench image, service, checkout, and Compose defaults
- preserve an explicitly supplied Compose file for dotNetBench and every other recognized bench alias
- stop the Wave launcher from replacing the host Claude compatibility link through the mounted home directory
- extend the launcher lifecycle regression suite for dotNet defaults and explicit Compose overrides

## Validation

- Wave container launcher lifecycle tests passed
- shell syntax and git diff checks passed
- the existing dotnet-bench container was not recreated

## Summary by Sourcery

Harden Wave bench launching by adding dotNetBench support, honoring explicit Compose configuration, and protecting host-mounted Claude links.

New Features:
- Add dotNetBench aliases with dotnet-bench container, image, service, checkout, and Compose defaults.

Bug Fixes:
- Preserve explicitly supplied Compose files for recognized and generic bench aliases, including correct environment-file and Rust WSLg override resolution.
- Prevent launcher startup from overwriting the host Claude compatibility link through the mounted home directory.

Enhancements:
- Expand launcher lifecycle coverage for dotNetBench defaults, explicit Compose files, first creation, generic benches, and WSLg overrides.

Tests:
- Extend Wave container launcher regression tests for alias defaults, Compose overrides, environment handling, and host-link protection.