### PR TITLE
feat(speckit-git): park and resume — WIP commit + push, recreate worktrees from pushed branches, refuse on divergence (#30)

### DIFF
--- a/devBenches/base-image/files/openspeckit/setup-openspeckit
+++ b/devBenches/base-image/files/openspeckit/setup-openspeckit
@@ -34,6 +34,9 @@ OVERLAY_SHAPE_MARKER: Final = "# speckit-overlay-shape: 1"
 OVERLAY_SHAPE_MARKER_FILES: Final = (
     "scripts/bash/create-new-feature.sh",
     "scripts/bash/git-common.sh",
+    "scripts/bash/park.sh",
+    "scripts/bash/resume.sh",
+    "scripts/bash/workspace-common.sh",
 )
 DIRECTORY_OPEN_FLAGS: Final = (
     os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
@@ -44,13 +47,18 @@ WORKTREE_GIT_OVERLAY_REQUIRED_FILES: Final = (
     "commands/speckit.git.commit.md",
     "commands/speckit.git.feature.md",
     "commands/speckit.git.initialize.md",
+    "commands/speckit.git.park.md",
     "commands/speckit.git.remote.md",
+    "commands/speckit.git.resume.md",
     "commands/speckit.git.validate.md",
     "scripts/bash/auto-commit.sh",
     "scripts/bash/create-new-feature.sh",
     "scripts/bash/get-last-worktree.sh",
     "scripts/bash/git-common.sh",
     "scripts/bash/initialize-repo.sh",
+    "scripts/bash/park.sh",
+    "scripts/bash/resume.sh",
+    "scripts/bash/workspace-common.sh",
     "scripts/powershell/auto-commit.ps1",
     "scripts/powershell/create-new-feature.ps1",
     "scripts/powershell/git-common.ps1",

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/README.md
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/README.md
@@ -201,7 +201,11 @@ Inside whichever repository is chosen, the manifest is
 else `workspaces/<org>/<project id>.yaml`. `<org>` is the owner segment of the
 family holder's or the project's declared `repository:` (`opensoft/openRepoShape`
 → `opensoft`), falling back to the root's `origin` remote and then to `local`
-for a checkout that declares no owner at all — one workspace repository can
+for a checkout that declares no owner at all. `local` therefore appears only
+when neither `family.yaml` nor `project.yaml` carries a `repository:` and the
+`origin` remote is a filesystem path rather than a hosted URL — a single
+repository cloned from a path on the same machine, say. One workspace
+repository can
 track work across several orgs, and two projects that share an id in different
 orgs must never share a file. Any segment outside `[A-Za-z0-9._-]+` is refused
 rather than sanitised. The file records branches, commits and a relative

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/README.md
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/README.md
@@ -21,6 +21,8 @@ This extension provides Git operations as an optional, self-contained module. It
 | `speckit.git.validate` | Validate current branch follows feature branch naming conventions |
 | `speckit.git.remote` | Detect Git remote URL for GitHub integration |
 | `speckit.git.commit` | Auto-commit changes (configurable per-command enable/disable and messages) |
+| `speckit.git.park` | Park every open feature so another workstation can pick it up |
+| `speckit.git.resume` | Recreate parked worktrees and un-commit the parked work |
 
 ## Hooks
 
@@ -130,5 +132,109 @@ The extension bundles cross-platform scripts:
 
 - `scripts/bash/create-new-feature.sh` — Bash implementation
 - `scripts/bash/git-common.sh` — Shared Git utilities (Bash)
+- `scripts/bash/workspace-common.sh` — Workspace manifest helpers for park and resume (Bash, sourced)
+- `scripts/bash/park.sh` — Park open features (Bash)
+- `scripts/bash/resume.sh` — Resume parked features (Bash)
 - `scripts/powershell/create-new-feature.ps1` — PowerShell implementation
 - `scripts/powershell/git-common.ps1` — Shared Git utilities (PowerShell)
+
+## park and resume
+
+`park` and `resume` carry in-flight worktrees between workstations. Worktrees
+are git-ignored and never synced, so moving to another machine used to mean
+losing them; `park` commits the work in progress on each feature branch,
+pushes it, and records the feature list in a **private repository the person
+owns**, and `resume` recreates the worktrees from those pushed branches and
+un-commits the work again. Nothing is ever copied, moved or synced, and
+nothing under `worktree_root` is ever committed at the root: `park` commits
+only *inside* the leg worktrees, on the feature branch.
+
+Both are shape-aware. In a three-leg project a feature is
+`<worktree_root>/<branch>/{spec,code}` and both legs are parked together; in a
+single repository a feature is one worktree under `worktree_root`, recorded as
+one leg with `role: repo`. `checkout_mode: branch` is refused in both shapes —
+there is no worktree to park.
+
+```
+park.sh   [--json] [--dry-run] [--feature <branch>]... [--lane <name>]
+          [--message <text>] [--no-push] [--workspace <path>]
+          [--retire-parked-wip] [-h|--help]
+
+resume.sh [--json] [--dry-run] [--feature <branch>]... [--workspace <path>]
+          [--keep-staged] [-h|--help]
+```
+
+The workspace repository is named once, by the person, in
+`${AGENT_PROTOCOL_ROOT:-$HOME/.agents}/workspace.yaml`:
+
+```yaml
+repository: opensoft/brett-wip
+path: ~/projects/brett-wip
+orgs:                       # optional: an org whose work must stay inside that org
+  MedxSoft:
+    repository: MedxSoft/brett-wip
+    path: ~/projects/MedxSoft-wip
+```
+
+The two top-level keys are the default. The optional `orgs:` map gives one org
+a workspace repository of its own, so a confidential org's feature list is
+never indexed in the home repository. The override applies to everything that
+lives in a workspace repository — the manifests under `workspaces/` and the
+handoffs under `handoffs/<estate>/` alike (`park` and `resume` never write a
+handoff; a handoff is a document a person wrote). The resolved order is:
+
+1. `--workspace <path>` — wins over everything;
+2. `$SPECKIT_WORKSPACE_PATH` — a whole-run override;
+3. `orgs.<org>` in the config — an org whose work must stay inside that org;
+4. the config's top-level — the default workspace;
+5. nothing — refuse, naming the two lines to write.
+
+A malformed `orgs:` block is a named refusal (`workspace-config-invalid`, exit
+2) and never a silent fall-through to the default. `SPECKIT_WORKSPACE_REPOSITORY`
+overrides the repository slug used in the clone remediation, which otherwise
+names whichever repository was chosen — so on a fresh machine the refusal says
+exactly which `<org>/<user>-wip` to clone. `park` prints the choice on its
+`WORKSPACE:` line and in `--json` as `WORKSPACE_SOURCE`.
+
+Inside whichever repository is chosen, the manifest is
+`workspaces/<org>/<Family>.yaml` when the project is a member of a family,
+else `workspaces/<org>/<project id>.yaml`. `<org>` is the owner segment of the
+family holder's or the project's declared `repository:` (`opensoft/openRepoShape`
+→ `opensoft`), falling back to the root's `origin` remote and then to `local`
+for a checkout that declares no owner at all — one workspace repository can
+track work across several orgs, and two projects that share an id in different
+orgs must never share a file. Any segment outside `[A-Za-z0-9._-]+` is refused
+rather than sanitised. The file records branches, commits and a relative
+`root` — never an absolute path, because a linked worktree's absolute path is
+machine plumbing and `resume` recreates at the *local* `worktree_root`.
+
+`park` never force-pushes. When a previous `resume` has left the branch behind
+the remote by this workspace's own parked WIP commits, `park` refuses and
+prints the exact `--force-with-lease=<branch>:<recorded parked commit>`
+command; `--retire-parked-wip` lets it run that one leased push itself. It is
+off by default, and it is the only force-push in this extension.
+
+`resume` **refuses on divergence**: if `origin/<branch>` is not the commit the
+manifest recorded, that feature is not recreated and the message names the
+parked commit, the current tip and the reconciliation commands. Nothing is
+ever reset over commits this workspace did not park. A parked WIP commit is
+recognised by three facts together — the `wip: park ` subject prefix, the sha
+matching the recorded `parked_commit`, and a single parent on each of the
+`wip_depth` tip commits — never by the prefix alone.
+
+Both scripts extend the extension's exit-code convention, which is otherwise
+only 0 and 1, because they need a third state:
+
+| Code | Meaning |
+|------|---------|
+| 0 | Everything asked for was parked / resumed, or there was nothing to do |
+| 1 | Usage or environment error: bad flag, not inside a Speckit checkout, `checkout_mode: branch`, an uninitialised leg, no Python 3 |
+| 2 | A refusal before anything was done, or every feature was refused |
+| 3 | Partial: at least one feature succeeded and at least one was refused |
+
+Both require Python 3: the manifest and the last-worktree state file are
+published through it.
+
+**The PowerShell mirror has neither.** `scripts/powershell/*.ps1` are not
+shape-aware and gain nothing here: **native Windows parks nothing.** Use the
+dev container, or WSL, on Windows.

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/README.md
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/README.md
@@ -189,6 +189,12 @@ handoff; a handoff is a document a person wrote). The resolved order is:
 4. the config's top-level — the default workspace;
 5. nothing — refuse, naming the two lines to write.
 
+Org names are matched case-insensitively, because GitHub's are: `orgs:
+medxsoft:` selects the workspace for a `repository: MedxSoft/...`. The
+directory inside that workspace always uses the one canonical spelling — the
+owner segment exactly as written in `repository:` — so the same org never ends
+up split across `workspaces/MedxSoft/` and `workspaces/medxsoft/`.
+
 A malformed `orgs:` block is a named refusal (`workspace-config-invalid`, exit
 2) and never a silent fall-through to the default. `SPECKIT_WORKSPACE_REPOSITORY`
 overrides the repository slug used in the clone remediation, which otherwise
@@ -211,6 +217,20 @@ orgs must never share a file. Any segment outside `[A-Za-z0-9._-]+` is refused
 rather than sanitised. The file records branches, commits and a relative
 `root` — never an absolute path, because a linked worktree's absolute path is
 machine plumbing and `resume` recreates at the *local* `worktree_root`.
+
+`park` writes in the workspace repository under a `mkdir` mutex, and it
+touches nothing outside `workspaces/`. It brings the checkout up to date
+before it reads the manifest, so a stale clone can never drop a feature it
+could not park from the recorded list. That rebase needs a clean working tree,
+so an uncommitted change to a tracked file elsewhere in the repository — a
+handoff you are half-way through, say — is a named refusal
+(`workspace-dirty`, exit 2) that lists the paths, rather than a misreported
+rebase conflict. Untracked files are never in the way.
+
+When `park` rewrites a project's block it re-emits the file from the schema
+below, so an unknown top-level key someone added to a manifest by hand is
+dropped. Other projects' blocks are preserved verbatim; these files are
+written by `speckit park` and are not hand-edited.
 
 `park` never force-pushes. When a previous `resume` has left the branch behind
 the remote by this workspace's own parked WIP commits, `park` refuses and

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/commands/speckit.git.park.md
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/commands/speckit.git.park.md
@@ -1,0 +1,89 @@
+---
+description: "Park every open feature: commit the work in progress, push it, and record the feature list"
+---
+
+# Park Open Features
+
+Commit, push and record every open feature of this project, so the work can be
+picked up on another workstation with `/speckit.git.resume`.
+
+## Prerequisites
+
+- The Speckit worktree overlay must be installed:
+  `.specify/extensions/git/scripts/bash/park.sh` must exist and be executable.
+  If it does not, tell the operator to run `setup-openspeckit` and stop.
+- `checkout_mode: worktree` in `.specify/extensions/git/git-config.yml`. In
+  `branch` mode there is no worktree to park and the script refuses.
+- Python 3, and a Git checkout with a `.specify/` directory.
+- A workspace repository, named once by the operator in
+  `${AGENT_PROTOCOL_ROOT:-$HOME/.agents}/workspace.yaml`:
+
+  ```yaml
+  repository: <owner>/<repo>
+  path: ~/projects/<repo>
+  orgs:                     # optional: an org with a workspace of its own
+    <Org>:
+      repository: <Org>/<repo>
+      path: ~/projects/<repo>
+  ```
+
+  The resolved order is `--workspace`, then `$SPECKIT_WORKSPACE_PATH`, then
+  `orgs.<org>` for the project's own org, then the top-level default. A
+  malformed `orgs:` block refuses by name (`workspace-config-invalid`, exit 2)
+  rather than falling back to the default.
+
+  This file is the operator's. **Never write it for them** — a person names
+  their own private repository.
+
+## Execution
+
+Run from the project root (the assembly root in a three-leg project):
+
+```bash
+.specify/extensions/git/scripts/bash/park.sh --json
+```
+
+Useful flags:
+
+| Flag | Effect |
+|------|--------|
+| `--dry-run` | Print the plan; commit, push and write nothing |
+| `--feature <branch>` | Park only this feature; repeatable |
+| `--lane <name>` | Lane recorded in the WIP subject (else `$SPECKIT_LANE`, `$LANE`, `unknown`) |
+| `--message <text>` | Provenance appended after the fixed WIP subject prefix |
+| `--no-push` | Commit locally and record `pushed: false`; `resume` refuses those entries |
+| `--workspace <path>` | Workspace checkout, overriding the user config |
+| `--retire-parked-wip` | Allow the single leased push described under R8 below |
+
+## How to read the exit code
+
+| Code | Meaning | What to do |
+|------|---------|------------|
+| 0 | Everything asked for was parked, or there was nothing to park | Report the branches and the manifest commit |
+| 1 | Usage or environment error | Fix what the message names; nothing was changed |
+| 2 | A refusal before anything was done, or every feature was refused | Report the refusal verbatim; nothing was recorded |
+| 3 | Partial: some parked, some refused | Report both lists; the refusals are printed with their remediation |
+
+## What to tell the operator on each refusal
+
+Print the script's own message verbatim — it already carries the exact
+commands. Then add the one-line reading below.
+
+| Refusal | Reading |
+|---------|---------|
+| no workspace repository is configured | They must create `~/.agents/workspace.yaml` themselves; offer the two lines, do not write the file |
+| the workspace checkout is not a Git checkout | The `path:` chosen for this project's org names something that is not a clone; the message prints the exact `git clone` |
+| `workspace-config-invalid` | The config's `orgs:` block is malformed. It refuses rather than falling back to the default workspace, because a confidential org's work must never be indexed in the wrong repository |
+| a merge, rebase or cherry-pick is in progress | Nothing was committed in that leg. A WIP commit over an unresolved index would park a conflicted tree as if it were work |
+| unmerged paths | The same: resolve or reset first |
+| no `origin` remote | `resume` rebuilds from pushed branches, so a leg with no remote cannot travel |
+| the push was refused | **The work is not lost** — it is committed locally at the sha the message names. `park` never force-pushes |
+| behind by parked WIP commits | The remote still carries this workspace's own parked WIP. The message prints the exact `--force-with-lease` command; `--retire-parked-wip` lets `park` run that one push itself. Never run a force-push on the operator's behalf without it |
+| a leg worktree is missing | The feature directory exists with only one leg; recreate it or remove the directory |
+
+A `[specify] Warning:` line is never a refusal. The one about
+`.specify/feature.json` means the recorded feature is not open any more;
+`park` enumerates from `git worktree list`, so the parked list is still right.
+
+A refused feature keeps whatever an earlier `park` recorded for it: a refusal
+never erases the entry another workstation would resume from.

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/commands/speckit.git.resume.md
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/commands/speckit.git.resume.md
@@ -1,0 +1,75 @@
+---
+description: "Resume parked features: recreate the worktrees, restore the state, and un-commit the parked work"
+---
+
+# Resume Parked Features
+
+Recreate the worktrees `/speckit.git.park` recorded, restore
+`.specify/feature.json` and the last-worktree state file, and un-commit the
+parked work so it comes back exactly as it was left.
+
+## Prerequisites
+
+- The Speckit worktree overlay must be installed:
+  `.specify/extensions/git/scripts/bash/resume.sh` must exist and be
+  executable. If it does not, tell the operator to run `setup-openspeckit`
+  and stop.
+- `checkout_mode: worktree`, Python 3, and a Git checkout with `.specify/`.
+- In a three-leg project the legs must be initialised first
+  (`git submodule update --init`, or `make bootstrap`).
+- The same workspace repository as `park`, named in
+  `${AGENT_PROTOCOL_ROOT:-$HOME/.agents}/workspace.yaml`. **Never write that
+  file for the operator.** The resolved order is `--workspace`, then
+  `$SPECKIT_WORKSPACE_PATH`, then `orgs.<org>` for the project's own org, then
+  the top-level default; a malformed `orgs:` block refuses by name
+  (`workspace-config-invalid`, exit 2) rather than falling back to the default.
+
+## Execution
+
+Run from the project root (the assembly root in a three-leg project):
+
+```bash
+.specify/extensions/git/scripts/bash/resume.sh --json
+```
+
+Useful flags:
+
+| Flag | Effect |
+|------|--------|
+| `--dry-run` | Print the plan; create, write and reset nothing |
+| `--feature <branch>` | Resume only this feature; repeatable |
+| `--workspace <path>` | Workspace checkout, overriding the user config |
+| `--keep-staged` | Stop after the soft reset, leaving the work staged |
+
+The staged/unstaged split does not survive a park: one commit cannot carry two
+states. The default restores everything unstaged; `--keep-staged` gives the
+staged form back.
+
+## How to read the exit code
+
+| Code | Meaning | What to do |
+|------|---------|------------|
+| 0 | Everything asked for was resumed, or there was nothing to resume | Report the branches, `FEATURE_JSON` and `STATE_FILE` |
+| 1 | Usage or environment error | Fix what the message names; nothing was changed |
+| 2 | A refusal before anything was done, or every feature was refused | Report the refusal verbatim |
+| 3 | Partial: some resumed, some refused | Report both lists |
+
+## What to tell the operator on each refusal
+
+Print the script's own message verbatim, then add the reading below.
+
+| Refusal | Reading |
+|---------|---------|
+| the branch has moved since it was parked | **The ruling on `openRepoShape#77`: nothing is ever reset over commits this workspace did not park.** The message names the parked commit, the current tip and the reconciliation commands. Offer to run the `log` command; never reset, never force |
+| the branch is no longer on origin | Either the feature landed — remove its block from the manifest — or it was deleted by mistake and must be pushed again from the workstation that parked it |
+| a path is already there | Something that is not this feature's worktree occupies the path. Nothing here overwrites a directory it did not create |
+| the local branch is BEHIND the parked commit | This workstation had the feature before the other one parked newer work. The remediation is the fast-forward the message prints, then `make resume` again — not a deletion |
+| the local branch diverged | Local commits exist that the parked commit does not contain. Rename or delete that branch; look first with the printed `log` command |
+| parked with `--no-push` | The parked commit exists only on the workstation that parked it. Push it there, re-run `park`, then resume here |
+| the workspace has no entry for this project | Either nothing was parked for it, or it was parked into a differently named file; the message prints the `grep` over that org's directory |
+| `workspace-config-invalid` | The config's `orgs:` block is malformed. It refuses rather than falling back to the default workspace, because a confidential org's work must never be indexed in the wrong repository |
+
+`[specify]` lines are not refusals. `worktree already registered … left as it
+is` means `resume` is idempotent and touched nothing; a warning that HEAD is
+not the parked commit means the un-commit was skipped on purpose, so a second
+`resume` never double-resets.

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/extension.yml
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/extension.yml
@@ -32,6 +32,12 @@ provides:
     - name: speckit.git.commit
       file: commands/speckit.git.commit.md
       description: "Auto-commit changes after a Spec Kit command completes"
+    - name: speckit.git.park
+      file: commands/speckit.git.park.md
+      description: "Park every open feature: commit the work in progress, push it, and record the feature list"
+    - name: speckit.git.resume
+      file: commands/speckit.git.resume.md
+      description: "Resume parked features: recreate the worktrees, restore the state, and un-commit the parked work"
 
   config:
     - name: "git-config.yml"

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/create-new-feature.sh
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/create-new-feature.sh
@@ -386,35 +386,6 @@ fi
 
 CONFIG_FILE="$REPO_ROOT/.specify/extensions/git/git-config.yml"
 
-get_config_value() {
-    local key="$1"
-    local default_value="$2"
-    local env_override_name="${3:-}"
-
-    if [ -n "$env_override_name" ]; then
-        local override_value="${!env_override_name:-}"
-        if [ -n "$override_value" ]; then
-            printf '%s\n' "$override_value"
-            return 0
-        fi
-    fi
-
-    if [ -f "$CONFIG_FILE" ]; then
-        local line
-        line=$(grep -E "^[[:space:]]*$key:[[:space:]]*" "$CONFIG_FILE" | tail -n 1 || true)
-        if [ -n "$line" ]; then
-            local value="${line#*:}"
-            value=$(printf '%s' "$value" | sed -E "s/[[:space:]]+#.*$//; s/^[[:space:]]+//; s/[[:space:]]+$//; s/^['\"]//; s/['\"]$//")
-            if [ -n "$value" ]; then
-                printf '%s\n' "$value"
-                return 0
-            fi
-        fi
-    fi
-
-    printf '%s\n' "$default_value"
-}
-
 branch_token() {
     local value="$1"
     local fallback="$2"
@@ -542,35 +513,6 @@ extract_feature_num_from_branch() {
     printf '%s\n' "$branch_name"
 }
 
-resolve_path_from_repo_root() {
-    local raw_path="$1"
-    if [[ "$raw_path" == /* ]]; then
-        printf '%s\n' "$raw_path"
-    elif command -v python3 >/dev/null 2>&1; then
-        python3 - "$REPO_ROOT" "$raw_path" <<'PY'
-import os
-import sys
-
-print(os.path.abspath(os.path.join(sys.argv[1], sys.argv[2])))
-PY
-    else
-        printf '%s\n' "$REPO_ROOT/$raw_path"
-    fi
-}
-
-resolve_git_common_dir() {
-    local common_dir
-    common_dir=$(git rev-parse --git-common-dir 2>/dev/null || true)
-    if [ -z "$common_dir" ]; then
-        return 1
-    fi
-    if [[ "$common_dir" == /* ]]; then
-        printf '%s\n' "$common_dir"
-    else
-        printf '%s\n' "$REPO_ROOT/$common_dir"
-    fi
-}
-
 resolve_base_ref() {
     local base_ref="$1"
 
@@ -671,34 +613,6 @@ shape_branch_exists_in_leg() {
     git -C "$leg" show-ref --verify --quiet "refs/heads/$branch"
 }
 
-shape_add_leg_worktree() {
-    local leg="$1"
-    local role="$2"
-    local path="$3"
-    local base_ref="$4"
-    local create_branch="$5"
-    local worktree_error=""
-
-    if [ "$create_branch" = true ]; then
-        if ! worktree_error=$(git -C "$leg" worktree add -b "$BRANCH_NAME" "$path" "$base_ref" 2>&1); then
-            >&2 echo "Error: Failed to create the $role leg worktree '$path' from '$base_ref'."
-            if [ -n "$worktree_error" ]; then
-                >&2 printf '%s\n' "$worktree_error"
-            fi
-            return 1
-        fi
-        return 0
-    fi
-
-    if ! worktree_error=$(git -C "$leg" worktree add "$path" "$BRANCH_NAME" 2>&1); then
-        >&2 echo "Error: Failed to add the $role leg worktree '$path' for existing branch '$BRANCH_NAME'."
-        if [ -n "$worktree_error" ]; then
-            >&2 printf '%s\n' "$worktree_error"
-        fi
-        return 1
-    fi
-}
-
 shape_rollback_spec_worktree() {
     local created_branch="$1"
 
@@ -710,37 +624,6 @@ shape_rollback_spec_worktree() {
         git -C "$SPEC_LEG" branch -D "$BRANCH_NAME" >/dev/null 2>&1 || true
     fi
     rmdir "$WORKTREE_PATH" >/dev/null 2>&1 || true
-}
-
-# Record the resolved feature directory in the ROOT's .specify/feature.json so
-# core check-prerequisites.sh resolves FEATURE_DIR without any change to core.
-shape_persist_feature_json() {
-    local relative_dir="$1"
-    local feature_json="$REPO_ROOT/.specify/feature.json"
-
-    if [ "$(type -t _persist_feature_json 2>/dev/null || true)" = "function" ]; then
-        _persist_feature_json "$REPO_ROOT" "$relative_dir"
-        return 0
-    fi
-
-    mkdir -p "$REPO_ROOT/.specify"
-    if command -v jq >/dev/null 2>&1; then
-        jq -cn --arg fd "$relative_dir" '{feature_directory:$fd}' > "$feature_json"
-    elif [ "$(type -t json_escape 2>/dev/null || true)" = "function" ]; then
-        printf '{"feature_directory":"%s"}\n' "$(json_escape "$relative_dir")" > "$feature_json"
-    elif command -v python3 >/dev/null 2>&1; then
-        python3 - "$feature_json" "$relative_dir" <<'PY'
-import json
-import sys
-
-with open(sys.argv[1], "w", encoding="utf-8") as stream:
-    json.dump({"feature_directory": sys.argv[2]}, stream)
-    stream.write("\n")
-PY
-    else
-        >&2 echo "Error: Writing .specify/feature.json requires jq or Python 3."
-        return 1
-    fi
 }
 
 shape_create_feature_worktrees() {
@@ -809,124 +692,6 @@ find_worktree_for_branch() {
     done
 
     return 1
-}
-
-select_json_encoder() {
-    if command -v jq >/dev/null 2>&1; then
-        printf '%s\n' jq
-    elif [ "$(type -t json_escape 2>/dev/null || true)" = "function" ]; then
-        printf '%s\n' json_escape
-    elif command -v python3 >/dev/null 2>&1; then
-        printf '%s\n' python3
-    else
-        return 1
-    fi
-}
-
-assert_state_file_safe() {
-    local state_file="$1"
-
-    if [ -L "$state_file" ] || { [ -e "$state_file" ] && [ ! -f "$state_file" ]; }; then
-        printf 'Error: Speckit state path must be a regular file or missing: %s\n' "$state_file" >&2
-        return 1
-    fi
-}
-
-write_last_worktree_state() {
-    local branch_name="$1"
-    local worktree_path="$2"
-    local base_branch="$3"
-    local state_file="$STATE_FILE"
-
-    [ -n "$state_file" ] || return 0
-    local common_dir="${state_file%/*}"
-    local updated_at
-    updated_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
-
-    if ! python3 - "$common_dir" "${state_file##*/}" "$branch_name" "$worktree_path" "$base_branch" "$REPO_ROOT" "$updated_at" <<'PY'
-import errno
-import json
-import os
-import secrets
-import stat
-import sys
-from contextlib import ExitStack
-
-common_dir = sys.argv[1]
-state_name = sys.argv[2]
-payload = {
-    "BRANCH_NAME": sys.argv[3],
-    "WORKTREE_PATH": sys.argv[4],
-    "BASE_BRANCH": sys.argv[5],
-    "REPO_ROOT": sys.argv[6],
-    "UPDATED_AT": sys.argv[7],
-}
-serialized = (json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n").encode()
-directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
-temporary_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
-
-with ExitStack() as descriptors:
-    directory_fd = os.open("/", directory_flags)
-    descriptors.callback(os.close, directory_fd)
-    for component in common_dir.split("/"):
-        if component in ("", "."):
-            continue
-        directory_fd = os.open(component, directory_flags, dir_fd=directory_fd)
-        descriptors.callback(os.close, directory_fd)
-
-    temporary_name = ""
-    temporary_fd = -1
-    temporary_identity = None
-    try:
-        for _ in range(128):
-            temporary_name = ".speckit-last-worktree.json.tmp." + secrets.token_hex(8)
-            try:
-                temporary_fd = os.open(temporary_name, temporary_flags, 0o600, dir_fd=directory_fd)
-                break
-            except FileExistsError:
-                continue
-        else:
-            raise FileExistsError(errno.EEXIST, "could not create a unique state temporary")
-
-        descriptors.callback(os.close, temporary_fd)
-        temporary_identity = os.fstat(temporary_fd)
-        offset = 0
-        while offset < len(serialized):
-            offset += os.write(temporary_fd, serialized[offset:])
-        os.fchmod(temporary_fd, 0o600)
-        os.fsync(temporary_fd)
-
-        temporary_leaf = os.stat(temporary_name, dir_fd=directory_fd, follow_symlinks=False)
-        if not stat.S_ISREG(temporary_leaf.st_mode) or (
-            temporary_leaf.st_dev,
-            temporary_leaf.st_ino,
-        ) != (temporary_identity.st_dev, temporary_identity.st_ino):
-            raise OSError(errno.EPERM, "state temporary was replaced before publication")
-
-        try:
-            state_leaf = os.stat(state_name, dir_fd=directory_fd, follow_symlinks=False)
-        except FileNotFoundError:
-            state_leaf = None
-        if state_leaf is not None and not stat.S_ISREG(state_leaf.st_mode):
-            raise OSError(errno.EPERM, "Speckit state path must be a regular file or missing")
-
-        os.replace(temporary_name, state_name, src_dir_fd=directory_fd, dst_dir_fd=directory_fd)
-        temporary_name = ""
-    finally:
-        if temporary_name and temporary_identity is not None:
-            try:
-                temporary_leaf = os.stat(temporary_name, dir_fd=directory_fd, follow_symlinks=False)
-            except FileNotFoundError:
-                temporary_leaf = None
-            if temporary_leaf is not None and (
-                temporary_leaf.st_dev,
-                temporary_leaf.st_ino,
-            ) == (temporary_identity.st_dev, temporary_identity.st_ino):
-                os.unlink(temporary_name, dir_fd=directory_fd)
-PY
-    then
-        return 1
-    fi
 }
 
 cd "$REPO_ROOT"

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/create-new-feature.sh
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/create-new-feature.sh
@@ -384,6 +384,8 @@ else
     HAS_GIT=false
 fi
 
+# get_config_value in git-common.sh reads CONFIG_FILE.
+# shellcheck disable=SC2034
 CONFIG_FILE="$REPO_ROOT/.specify/extensions/git/git-config.yml"
 
 branch_token() {

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/git-common.sh
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/git-common.sh
@@ -674,3 +674,257 @@ load_git_worktrees() {
     _git_worktree_remove_temp_file "$output_file" || return 1
     return 1
 }
+
+# ---------------------------------------------------------------------------
+# Configuration, path, JSON and state helpers.
+#
+# Moved here from create-new-feature.sh so park.sh and resume.sh can use the
+# same implementations instead of carrying second copies (openRepoShape#77,
+# Brett Heap's ruling of 2026-09-09, point 2). Each one reads globals its
+# caller must set first:
+#
+#   get_config_value              CONFIG_FILE   (may be absent; then defaults win)
+#   resolve_path_from_repo_root   REPO_ROOT
+#   resolve_git_common_dir        REPO_ROOT, and a working directory inside it
+#   select_json_encoder           -             (uses json_escape when defined)
+#   assert_state_file_safe        -
+#   write_last_worktree_state     STATE_FILE, REPO_ROOT
+#   shape_add_leg_worktree        BRANCH_NAME
+#   shape_persist_feature_json    REPO_ROOT     (uses _persist_feature_json or
+#                                                json_escape when defined)
+# ---------------------------------------------------------------------------
+
+get_config_value() {
+    local key="$1"
+    local default_value="$2"
+    local env_override_name="${3:-}"
+
+    if [ -n "$env_override_name" ]; then
+        local override_value="${!env_override_name:-}"
+        if [ -n "$override_value" ]; then
+            printf '%s\n' "$override_value"
+            return 0
+        fi
+    fi
+
+    if [ -f "${CONFIG_FILE:-}" ]; then
+        local line
+        line=$(grep -E "^[[:space:]]*$key:[[:space:]]*" "$CONFIG_FILE" | tail -n 1 || true)
+        if [ -n "$line" ]; then
+            local value="${line#*:}"
+            value=$(printf '%s' "$value" | sed -E "s/[[:space:]]+#.*$//; s/^[[:space:]]+//; s/[[:space:]]+$//; s/^['\"]//; s/['\"]$//")
+            if [ -n "$value" ]; then
+                printf '%s\n' "$value"
+                return 0
+            fi
+        fi
+    fi
+
+    printf '%s\n' "$default_value"
+}
+
+resolve_path_from_repo_root() {
+    local raw_path="$1"
+    if [[ "$raw_path" == /* ]]; then
+        printf '%s\n' "$raw_path"
+    elif command -v python3 >/dev/null 2>&1; then
+        python3 - "$REPO_ROOT" "$raw_path" <<'PY'
+import os
+import sys
+
+print(os.path.abspath(os.path.join(sys.argv[1], sys.argv[2])))
+PY
+    else
+        printf '%s\n' "$REPO_ROOT/$raw_path"
+    fi
+}
+
+resolve_git_common_dir() {
+    local common_dir
+    common_dir=$(git rev-parse --git-common-dir 2>/dev/null || true)
+    if [ -z "$common_dir" ]; then
+        return 1
+    fi
+    if [[ "$common_dir" == /* ]]; then
+        printf '%s\n' "$common_dir"
+    else
+        printf '%s\n' "$REPO_ROOT/$common_dir"
+    fi
+}
+
+select_json_encoder() {
+    if command -v jq >/dev/null 2>&1; then
+        printf '%s\n' jq
+    elif [ "$(type -t json_escape 2>/dev/null || true)" = "function" ]; then
+        printf '%s\n' json_escape
+    elif command -v python3 >/dev/null 2>&1; then
+        printf '%s\n' python3
+    else
+        return 1
+    fi
+}
+
+assert_state_file_safe() {
+    local state_file="$1"
+
+    if [ -L "$state_file" ] || { [ -e "$state_file" ] && [ ! -f "$state_file" ]; }; then
+        printf 'Error: Speckit state path must be a regular file or missing: %s\n' "$state_file" >&2
+        return 1
+    fi
+}
+
+write_last_worktree_state() {
+    local branch_name="$1"
+    local worktree_path="$2"
+    local base_branch="$3"
+    local state_file="${STATE_FILE:-}"
+
+    [ -n "$state_file" ] || return 0
+    local common_dir="${state_file%/*}"
+    local updated_at
+    updated_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
+
+    if ! python3 - "$common_dir" "${state_file##*/}" "$branch_name" "$worktree_path" "$base_branch" "$REPO_ROOT" "$updated_at" <<'PY'
+import errno
+import json
+import os
+import secrets
+import stat
+import sys
+from contextlib import ExitStack
+
+common_dir = sys.argv[1]
+state_name = sys.argv[2]
+payload = {
+    "BRANCH_NAME": sys.argv[3],
+    "WORKTREE_PATH": sys.argv[4],
+    "BASE_BRANCH": sys.argv[5],
+    "REPO_ROOT": sys.argv[6],
+    "UPDATED_AT": sys.argv[7],
+}
+serialized = (json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n").encode()
+directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+temporary_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW
+
+with ExitStack() as descriptors:
+    directory_fd = os.open("/", directory_flags)
+    descriptors.callback(os.close, directory_fd)
+    for component in common_dir.split("/"):
+        if component in ("", "."):
+            continue
+        directory_fd = os.open(component, directory_flags, dir_fd=directory_fd)
+        descriptors.callback(os.close, directory_fd)
+
+    temporary_name = ""
+    temporary_fd = -1
+    temporary_identity = None
+    try:
+        for _ in range(128):
+            temporary_name = ".speckit-last-worktree.json.tmp." + secrets.token_hex(8)
+            try:
+                temporary_fd = os.open(temporary_name, temporary_flags, 0o600, dir_fd=directory_fd)
+                break
+            except FileExistsError:
+                continue
+        else:
+            raise FileExistsError(errno.EEXIST, "could not create a unique state temporary")
+
+        descriptors.callback(os.close, temporary_fd)
+        temporary_identity = os.fstat(temporary_fd)
+        offset = 0
+        while offset < len(serialized):
+            offset += os.write(temporary_fd, serialized[offset:])
+        os.fchmod(temporary_fd, 0o600)
+        os.fsync(temporary_fd)
+
+        temporary_leaf = os.stat(temporary_name, dir_fd=directory_fd, follow_symlinks=False)
+        if not stat.S_ISREG(temporary_leaf.st_mode) or (
+            temporary_leaf.st_dev,
+            temporary_leaf.st_ino,
+        ) != (temporary_identity.st_dev, temporary_identity.st_ino):
+            raise OSError(errno.EPERM, "state temporary was replaced before publication")
+
+        try:
+            state_leaf = os.stat(state_name, dir_fd=directory_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            state_leaf = None
+        if state_leaf is not None and not stat.S_ISREG(state_leaf.st_mode):
+            raise OSError(errno.EPERM, "Speckit state path must be a regular file or missing")
+
+        os.replace(temporary_name, state_name, src_dir_fd=directory_fd, dst_dir_fd=directory_fd)
+        temporary_name = ""
+    finally:
+        if temporary_name and temporary_identity is not None:
+            try:
+                temporary_leaf = os.stat(temporary_name, dir_fd=directory_fd, follow_symlinks=False)
+            except FileNotFoundError:
+                temporary_leaf = None
+            if temporary_leaf is not None and (
+                temporary_leaf.st_dev,
+                temporary_leaf.st_ino,
+            ) == (temporary_identity.st_dev, temporary_identity.st_ino):
+                os.unlink(temporary_name, dir_fd=directory_fd)
+PY
+    then
+        return 1
+    fi
+}
+
+shape_add_leg_worktree() {
+    local leg="$1"
+    local role="$2"
+    local path="$3"
+    local base_ref="$4"
+    local create_branch="$5"
+    local worktree_error=""
+
+    if [ "$create_branch" = true ]; then
+        if ! worktree_error=$(git -C "$leg" worktree add -b "$BRANCH_NAME" "$path" "$base_ref" 2>&1); then
+            >&2 echo "Error: Failed to create the $role leg worktree '$path' from '$base_ref'."
+            if [ -n "$worktree_error" ]; then
+                >&2 printf '%s\n' "$worktree_error"
+            fi
+            return 1
+        fi
+        return 0
+    fi
+
+    if ! worktree_error=$(git -C "$leg" worktree add "$path" "$BRANCH_NAME" 2>&1); then
+        >&2 echo "Error: Failed to add the $role leg worktree '$path' for existing branch '$BRANCH_NAME'."
+        if [ -n "$worktree_error" ]; then
+            >&2 printf '%s\n' "$worktree_error"
+        fi
+        return 1
+    fi
+}
+
+# Record the resolved feature directory in the ROOT's .specify/feature.json so
+# core check-prerequisites.sh resolves FEATURE_DIR without any change to core.
+shape_persist_feature_json() {
+    local relative_dir="$1"
+    local feature_json="$REPO_ROOT/.specify/feature.json"
+
+    if [ "$(type -t _persist_feature_json 2>/dev/null || true)" = "function" ]; then
+        _persist_feature_json "$REPO_ROOT" "$relative_dir"
+        return 0
+    fi
+
+    mkdir -p "$REPO_ROOT/.specify"
+    if command -v jq >/dev/null 2>&1; then
+        jq -cn --arg fd "$relative_dir" '{feature_directory:$fd}' > "$feature_json"
+    elif [ "$(type -t json_escape 2>/dev/null || true)" = "function" ]; then
+        printf '{"feature_directory":"%s"}\n' "$(json_escape "$relative_dir")" > "$feature_json"
+    elif command -v python3 >/dev/null 2>&1; then
+        python3 - "$feature_json" "$relative_dir" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "w", encoding="utf-8") as stream:
+    json.dump({"feature_directory": sys.argv[2]}, stream)
+    stream.write("\n")
+PY
+    else
+        >&2 echo "Error: Writing .specify/feature.json requires jq or Python 3."
+        return 1
+    fi
+}

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/park.sh
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/park.sh
@@ -1,0 +1,1102 @@
+#!/usr/bin/env bash
+# speckit-overlay-shape: 1
+# Git extension: park.sh
+#
+# Commit, push and record every open feature of this project, so the work can
+# be picked up on another workstation with resume.sh. Implements
+# openRepoShape#77 as ruled by Brett Heap on 2026-09-09: Speckit owns the
+# mechanics, park refuses by default rather than force-pushing, and the
+# feature list is recorded in the private repository the person owns.
+#
+# Nothing under the worktree root is ever committed at the root: park commits
+# only INSIDE the leg worktrees, on the feature branch.
+
+set -e
+
+JSON_MODE=false
+DRY_RUN=false
+NO_PUSH=false
+RETIRE_PARKED_WIP=false
+LANE_ARG=""
+MESSAGE_ARG=""
+WORKSPACE_ARG=""
+REQUESTED_BRANCHES=()
+
+usage() {
+    echo "Usage: $0 [--json] [--dry-run] [--feature <branch>]... [--lane <name>]"
+    echo "          [--message <text>] [--no-push] [--workspace <path>]"
+    echo "          [--retire-parked-wip] [-h|--help]"
+    echo ""
+    echo "Commit, push and record every open feature so another workstation can resume it."
+    echo ""
+    echo "Options:"
+    echo "  --json                 Output in JSON format"
+    echo "  --dry-run              Print the plan; commit, push and write nothing"
+    echo "  --feature <branch>     Park only this feature; repeatable. Default: every open feature"
+    echo "  --lane <name>          Lane recorded in the WIP commit subject and the manifest"
+    echo "  --message <text>       Provenance appended after the fixed WIP subject prefix"
+    echo "  --no-push              Commit locally and record pushed: false; resume refuses those"
+    echo "  --workspace <path>     Workspace checkout to record into, overriding the user config"
+    echo "  --retire-parked-wip    Allow the single leased push that retires this workspace's"
+    echo "                         own parked WIP commit from the remote (default off)"
+    echo "  --help, -h             Show this help message"
+    echo ""
+    echo "Exit codes:"
+    echo "  0  everything asked for was parked, or there was nothing to park"
+    echo "  1  usage or environment error"
+    echo "  2  a refusal before anything was done, or every feature was refused"
+    echo "  3  partial: at least one feature was parked and at least one refused"
+    echo ""
+    echo "Environment variables:"
+    echo "  SPECKIT_WORKSPACE_PATH        Workspace checkout, overriding the user config"
+    echo "  SPECKIT_WORKSPACE_REPOSITORY  Workspace repository, for the clone remediation"
+    echo "  SPECKIT_LANE, LANE            Lane, when --lane is not given"
+    echo "  SPECKIT_WORKSTATION           Workstation name recorded as parked_on"
+    echo "  AGENT_PROTOCOL_ROOT           Home of workspace.yaml (default ~/.agents)"
+    echo "  SPECKIT_GIT_WORKTREE_ROOT     Override worktree_root"
+    echo "  SPECKIT_GIT_BASE_BRANCH       Override base_branch"
+    echo ""
+    echo "The user config is \${AGENT_PROTOCOL_ROOT:-\$HOME/.agents}/workspace.yaml:"
+    echo ""
+    echo "  repository: <owner>/<repo>"
+    echo "  path: ~/projects/<repo>"
+}
+
+i=1
+while [ $i -le $# ]; do
+    arg="${!i}"
+    case "$arg" in
+        --json) JSON_MODE=true ;;
+        --dry-run) DRY_RUN=true ;;
+        --no-push) NO_PUSH=true ;;
+        --retire-parked-wip) RETIRE_PARKED_WIP=true ;;
+        --feature|--lane|--message|--workspace)
+            if [ $((i + 1)) -gt $# ]; then
+                echo "Error: $arg requires a value" >&2
+                exit 1
+            fi
+            i=$((i + 1))
+            next_arg="${!i}"
+            case "$next_arg" in
+                --*)
+                    echo "Error: $arg requires a value" >&2
+                    exit 1
+                    ;;
+            esac
+            case "$arg" in
+                --feature) REQUESTED_BRANCHES[${#REQUESTED_BRANCHES[@]}]="$next_arg" ;;
+                --lane) LANE_ARG="$next_arg" ;;
+                --message) MESSAGE_ARG="$next_arg" ;;
+                --workspace) WORKSPACE_ARG="$next_arg" ;;
+            esac
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: unknown option: $arg" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+    i=$((i + 1))
+done
+
+# ---------------------------------------------------------------------------
+# Locate the checkout and the helpers, exactly as get-last-worktree.sh does.
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(CDPATH="" cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_REPO_ROOT="$(CDPATH="" cd -- "$SCRIPT_DIR/../../../../.." && pwd 2>/dev/null || true)"
+if [ ! -f "$SCRIPT_DIR/git-common.sh" ]; then
+    echo "Error: Could not locate git-common.sh next to park.sh." >&2
+    exit 1
+fi
+source "$SCRIPT_DIR/git-common.sh"
+if [ ! -f "$SCRIPT_DIR/workspace-common.sh" ]; then
+    echo "Error: Could not locate workspace-common.sh next to park.sh." >&2
+    exit 1
+fi
+source "$SCRIPT_DIR/workspace-common.sh"
+
+if REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+else
+    REPO_ROOT=""
+fi
+[ -n "$REPO_ROOT" ] || REPO_ROOT="$SCRIPT_REPO_ROOT"
+if [ -z "$REPO_ROOT" ] || [ ! -d "$REPO_ROOT/.specify" ]; then
+    echo "Error: not inside a Git repository or Speckit checkout." >&2
+    exit 1
+fi
+
+cd "$REPO_ROOT"
+load_repo_shape "$REPO_ROOT"
+# get_config_value in git-common.sh reads CONFIG_FILE.
+# shellcheck disable=SC2034
+CONFIG_FILE="$REPO_ROOT/.specify/extensions/git/git-config.yml"
+
+CHECKOUT_MODE=$(get_config_value "checkout_mode" "branch" "SPECKIT_GIT_CHECKOUT_MODE")
+CHECKOUT_MODE=$(printf '%s' "$CHECKOUT_MODE" | tr '[:upper:]' '[:lower:]')
+BASE_BRANCH=$(get_config_value "base_branch" "main" "SPECKIT_GIT_BASE_BRANCH")
+DEFAULT_WORKTREE_ROOT="../${REPO_ROOT##*/}-worktrees"
+if [ "$REPO_SHAPE" = "three-leg" ]; then
+    DEFAULT_WORKTREE_ROOT="worktrees"
+fi
+WORKTREE_ROOT_RAW=$(get_config_value "worktree_root" "$DEFAULT_WORKTREE_ROOT" "SPECKIT_GIT_WORKTREE_ROOT")
+WORKTREE_ROOT=$(resolve_path_from_repo_root "$WORKTREE_ROOT_RAW")
+
+if [ "$CHECKOUT_MODE" != "worktree" ]; then
+    echo "Error: checkout_mode '$CHECKOUT_MODE' has no worktree to park; nothing was parked." >&2
+    echo "park and resume carry linked worktrees between workstations. Set checkout_mode: worktree in .specify/extensions/git/git-config.yml." >&2
+    exit 1
+fi
+
+if [ "$REPO_SHAPE" = "three-leg" ]; then
+    if ! shape_leg_is_checkout "$SPEC_LEG"; then
+        echo "Error: the spec leg '$SHAPE_SPEC_PATH' is not an initialised Git checkout at '$SPEC_LEG'." >&2
+        echo "Run 'git submodule update --init' (or 'make bootstrap') in the project root first." >&2
+        exit 1
+    fi
+    if ! shape_leg_is_checkout "$CODE_LEG"; then
+        echo "Error: the code leg '$SHAPE_CODE_PATH' is not an initialised Git checkout at '$CODE_LEG'." >&2
+        echo "Run 'git submodule update --init' (or 'make bootstrap') in the project root first." >&2
+        exit 1
+    fi
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "Error: park requires Python 3 for safe manifest and state publication." >&2
+    exit 1
+fi
+if [ "$JSON_MODE" = true ] && ! select_json_encoder >/dev/null; then
+    echo "Error: JSON output requires jq, a trusted json_escape function, or Python 3; no JSON encoder is available." >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# The workspace, and this project's manifest file.
+# ---------------------------------------------------------------------------
+workspace_project_id "$REPO_ROOT"
+PROJECT_ID="$WORKSPACE_PROJECT_ID"
+workspace_family_name "$REPO_ROOT" "$PROJECT_ID"
+MANIFEST_NAME="$WORKSPACE_FAMILY"
+[ -n "$MANIFEST_NAME" ] || MANIFEST_NAME="$PROJECT_ID"
+# One private workspace repository tracks work across several orgs, so the
+# manifest is filed under the owner of the declared repository: two projects
+# that share an id in different orgs never share a file. The same org also
+# selects the workspace, when the config gives that org one of its own.
+workspace_org_for "$REPO_ROOT" "$WORKSPACE_FAMILY_MANIFEST"
+# shellcheck disable=SC2153  # workspace_org_for in workspace-common.sh sets it
+MANIFEST_ORG="$WORKSPACE_ORG"
+if ! workspace_name_is_safe "$MANIFEST_ORG"; then
+    echo "Error: '$MANIFEST_ORG' is not a usable workspace org name; nothing was parked." >&2
+    echo "The org is the owner segment of repository: in project.yaml (or in the family's family.yaml) and must match [A-Za-z0-9._-]+." >&2
+    echo "Correct that repository: value, then re-run \`make park\`." >&2
+    exit 2
+fi
+
+WORKSPACE_RESOLVE_STATUS=0
+workspace_resolve "$WORKSPACE_ARG" "$MANIFEST_ORG" || WORKSPACE_RESOLVE_STATUS=$?
+if [ "$WORKSPACE_RESOLVE_STATUS" -eq 2 ]; then
+    workspace_refuse_invalid_config parked park
+    exit 2
+elif [ "$WORKSPACE_RESOLVE_STATUS" -ne 0 ]; then
+    workspace_refuse_no_config parked park
+    exit 2
+fi
+if ! workspace_is_checkout "$WORKSPACE_PATH"; then
+    workspace_refuse_not_a_checkout parked
+    exit 2
+fi
+
+if ! workspace_name_is_safe "$MANIFEST_NAME"; then
+    echo "Error: '$MANIFEST_NAME' is not a usable workspace manifest name; nothing was parked." >&2
+    echo "A manifest file is named for the family or the project id and must match [A-Za-z0-9._-]+." >&2
+    echo "Rename the id: in project.yaml (or in the family's family.yaml), then re-run \`make park\`." >&2
+    exit 2
+fi
+MANIFEST_RELATIVE="workspaces/$MANIFEST_ORG/$MANIFEST_NAME.yaml"
+MANIFEST_PATH="$WORKSPACE_PATH/$MANIFEST_RELATIVE"
+
+# What this workspace recorded last time, for the WIP depth and the R8 lease.
+workspace_load_project "$MANIFEST_PATH" "$PROJECT_ID" || true
+
+recorded_leg_index() {
+    local branch="$1"
+    local role="$2"
+    local index=0
+    local feature
+
+    RECORDED_INDEX=-1
+    while [ "$index" -lt "${#MANIFEST_LEG_ROLE[@]}" ]; do
+        feature="${MANIFEST_LEG_FEATURE[$index]}"
+        if [ "${MANIFEST_LEG_ROLE[$index]}" = "$role" ] \
+            && [ "${MANIFEST_FEATURE_BRANCHES[$feature]}" = "$branch" ]; then
+            RECORDED_INDEX=$index
+            return 0
+        fi
+        index=$((index + 1))
+    done
+    return 1
+}
+
+recorded_leg_commit() {
+    RECORDED_COMMIT=""
+    recorded_leg_index "$1" "$2" || return 1
+    RECORDED_COMMIT="${MANIFEST_LEG_COMMIT[$RECORDED_INDEX]}"
+    [ -n "$RECORDED_COMMIT" ]
+}
+
+recorded_leg_depth() {
+    RECORDED_DEPTH=0
+    recorded_leg_index "$1" "$2" || return 1
+    RECORDED_DEPTH="${MANIFEST_LEG_DEPTH[$RECORDED_INDEX]}"
+    case "$RECORDED_DEPTH" in
+        ''|*[!0-9]*) RECORDED_DEPTH=0 ;;
+    esac
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Enumerate open features FROM GIT, never from memory and never from
+# feature.json.
+# ---------------------------------------------------------------------------
+FEATURE_DIRS=()
+FEATURE_BRANCHES=()
+
+root_relative() {
+    local path="$1"
+
+    case "$path" in
+        "$REPO_ROOT") printf '%s\n' "." ;;
+        "$REPO_ROOT"/*) printf '%s\n' "${path#"$REPO_ROOT/"}" ;;
+        *) printf '%s\n' "$path" ;;
+    esac
+}
+
+if [ "$REPO_SHAPE" = "three-leg" ]; then
+    if ! shape_load_features "$WORKTREE_ROOT"; then
+        echo "Error: Failed to list Git worktrees." >&2
+        exit 1
+    fi
+    index=0
+    while [ "$index" -lt "${#SHAPE_FEATURE_PATHS[@]}" ]; do
+        FEATURE_DIRS[${#FEATURE_DIRS[@]}]="${SHAPE_FEATURE_PATHS[$index]}"
+        FEATURE_BRANCHES[${#FEATURE_BRANCHES[@]}]="${SHAPE_FEATURE_BRANCHES[$index]}"
+        index=$((index + 1))
+    done
+else
+    if ! load_git_worktrees "$REPO_ROOT"; then
+        echo "Error: Failed to list Git worktrees." >&2
+        exit 1
+    fi
+    SINGLE_PATHS=()
+    SINGLE_BRANCHES=()
+    SINGLE_MTIMES=()
+    index=0
+    while [ "$index" -lt "${#GIT_WORKTREE_PATHS[@]}" ]; do
+        candidate="${GIT_WORKTREE_PATHS[$index]}"
+        head="${GIT_WORKTREE_HEADS[$index]}"
+        branch_ref="${GIT_WORKTREE_BRANCH_REFS[$index]}"
+        detached="${GIT_WORKTREE_DETACHED[$index]}"
+        index=$((index + 1))
+        if verify_git_worktree_candidate "$REPO_ROOT" "$WORKTREE_ROOT" \
+            "$candidate" "$head" "$branch_ref" "$detached" \
+            && [ -n "$GIT_WORKTREE_VERIFIED_BRANCH_REF" ]; then
+            mtime="$(_shape_mtime_for_path "$GIT_WORKTREE_VERIFIED_PATH" 2>/dev/null || true)"
+            [ -n "$mtime" ] || continue
+            SHAPE_FEATURE_PATHS=("${SINGLE_PATHS[@]}")
+            SHAPE_FEATURE_BRANCHES=("${SINGLE_BRANCHES[@]}")
+            SHAPE_FEATURE_MTIMES=("${SINGLE_MTIMES[@]}")
+            shape_insert_feature "$GIT_WORKTREE_VERIFIED_PATH" \
+                "${GIT_WORKTREE_VERIFIED_BRANCH_REF#refs/heads/}" "$mtime"
+            SINGLE_PATHS=("${SHAPE_FEATURE_PATHS[@]}")
+            SINGLE_BRANCHES=("${SHAPE_FEATURE_BRANCHES[@]}")
+            SINGLE_MTIMES=("${SHAPE_FEATURE_MTIMES[@]}")
+        fi
+    done
+    index=0
+    while [ "$index" -lt "${#SINGLE_PATHS[@]}" ]; do
+        FEATURE_DIRS[${#FEATURE_DIRS[@]}]="${SINGLE_PATHS[$index]}"
+        FEATURE_BRANCHES[${#FEATURE_BRANCHES[@]}]="${SINGLE_BRANCHES[$index]}"
+        index=$((index + 1))
+    done
+fi
+
+OPEN_BRANCHES=""
+index=0
+while [ "$index" -lt "${#FEATURE_BRANCHES[@]}" ]; do
+    OPEN_BRANCHES="$OPEN_BRANCHES ${FEATURE_BRANCHES[$index]} "
+    index=$((index + 1))
+done
+
+# --feature restricts the set; a name that is not open is a usage error.
+if [ "${#REQUESTED_BRANCHES[@]}" -gt 0 ]; then
+    index=0
+    while [ "$index" -lt "${#REQUESTED_BRANCHES[@]}" ]; do
+        case "$OPEN_BRANCHES" in
+            *" ${REQUESTED_BRANCHES[$index]} "*) ;;
+            *)
+                echo "Error: '${REQUESTED_BRANCHES[$index]}' is not an open feature under '$(root_relative "$WORKTREE_ROOT")'; nothing was parked." >&2
+                echo "  look:  git -C . worktree list" >&2
+                exit 1
+                ;;
+        esac
+        index=$((index + 1))
+    done
+    SELECTED_DIRS=()
+    SELECTED_BRANCHES=()
+    index=0
+    while [ "$index" -lt "${#FEATURE_BRANCHES[@]}" ]; do
+        wanted=false
+        inner=0
+        while [ "$inner" -lt "${#REQUESTED_BRANCHES[@]}" ]; do
+            if [ "${REQUESTED_BRANCHES[$inner]}" = "${FEATURE_BRANCHES[$index]}" ]; then
+                wanted=true
+                break
+            fi
+            inner=$((inner + 1))
+        done
+        if [ "$wanted" = true ]; then
+            SELECTED_DIRS[${#SELECTED_DIRS[@]}]="${FEATURE_DIRS[$index]}"
+            SELECTED_BRANCHES[${#SELECTED_BRANCHES[@]}]="${FEATURE_BRANCHES[$index]}"
+        fi
+        index=$((index + 1))
+    done
+    PARK_DIRS=("${SELECTED_DIRS[@]}")
+    PARK_BRANCHES=("${SELECTED_BRANCHES[@]}")
+else
+    PARK_DIRS=("${FEATURE_DIRS[@]}")
+    PARK_BRANCHES=("${FEATURE_BRANCHES[@]}")
+fi
+
+# ---------------------------------------------------------------------------
+# Feature directories that shape_load_features cannot count as open features,
+# and that must be refused rather than silently skipped:
+#
+#   missing   one leg worktree is absent (R7);
+#   detached  a leg worktree is on a detached HEAD, which is what an in-flight
+#             rebase looks like from `git worktree list` (R4).
+# ---------------------------------------------------------------------------
+BLOCKED_DIRS=()
+BLOCKED_BRANCHES=()
+BLOCKED_KINDS=()
+BLOCKED_ROLES=()
+BLOCKED_MOUNTS=()
+BLOCKED_TREES=()
+
+blocked_dir_seen() {
+    local wanted="$1"
+    local index=0
+
+    while [ "$index" -lt "${#BLOCKED_DIRS[@]}" ]; do
+        [ "${BLOCKED_DIRS[$index]}" = "$wanted" ] && return 0
+        index=$((index + 1))
+    done
+    return 1
+}
+
+# The branch a detached leg worktree belongs to: the rebase's own record of it,
+# else the feature directory's name, which IS the branch by construction.
+detached_branch_for() {
+    local tree="$1"
+    local feature_dir="$2"
+    local git_dir head_name
+
+    DETACHED_BRANCH="${feature_dir#"$WORKTREE_ROOT/"}"
+    git_dir="$(git -C "$tree" rev-parse --absolute-git-dir 2>/dev/null || true)"
+    [ -n "$git_dir" ] || return 0
+    for head_name in "$git_dir/rebase-merge/head-name" "$git_dir/rebase-apply/head-name"; do
+        if [ -f "$head_name" ]; then
+            DETACHED_BRANCH="$(sed -n '1s|^refs/heads/||p' "$head_name")"
+            [ -n "$DETACHED_BRANCH" ] || DETACHED_BRANCH="${feature_dir#"$WORKTREE_ROOT/"}"
+            return 0
+        fi
+    done
+}
+
+if [ "$REPO_SHAPE" = "three-leg" ] && [ "${#REQUESTED_BRANCHES[@]}" -eq 0 ]; then
+    scan_blocked_features() {
+        local leg="$1"
+        local role="$2"
+        local mount="$3"
+        local sibling_role="$4"
+        local sibling_mount="$5"
+        local index=0
+        local path branch feature_dir
+
+        load_git_worktrees "$leg" || return 0
+        while [ "$index" -lt "${#GIT_WORKTREE_PATHS[@]}" ]; do
+            path="${GIT_WORKTREE_PATHS[$index]}"
+            branch="${GIT_WORKTREE_BRANCH_REFS[$index]#refs/heads/}"
+            index=$((index + 1))
+            case "$path" in
+                */"$mount") feature_dir="${path%/"$mount"}" ;;
+                *) continue ;;
+            esac
+            case "$feature_dir" in
+                "$WORKTREE_ROOT"/*) ;;
+                *) continue ;;
+            esac
+            blocked_dir_seen "$feature_dir" && continue
+            if [ -z "$branch" ]; then
+                detached_branch_for "$path" "$feature_dir"
+                BLOCKED_DIRS[${#BLOCKED_DIRS[@]}]="$feature_dir"
+                BLOCKED_BRANCHES[${#BLOCKED_BRANCHES[@]}]="$DETACHED_BRANCH"
+                BLOCKED_KINDS[${#BLOCKED_KINDS[@]}]="detached"
+                BLOCKED_ROLES[${#BLOCKED_ROLES[@]}]="$role"
+                BLOCKED_MOUNTS[${#BLOCKED_MOUNTS[@]}]="$mount"
+                BLOCKED_TREES[${#BLOCKED_TREES[@]}]="$path"
+                continue
+            fi
+            [ -d "$feature_dir/$sibling_mount" ] && continue
+            BLOCKED_DIRS[${#BLOCKED_DIRS[@]}]="$feature_dir"
+            BLOCKED_BRANCHES[${#BLOCKED_BRANCHES[@]}]="$branch"
+            BLOCKED_KINDS[${#BLOCKED_KINDS[@]}]="missing"
+            BLOCKED_ROLES[${#BLOCKED_ROLES[@]}]="$sibling_role"
+            BLOCKED_MOUNTS[${#BLOCKED_MOUNTS[@]}]="$sibling_mount"
+            BLOCKED_TREES[${#BLOCKED_TREES[@]}]="$feature_dir/$sibling_mount"
+        done
+    }
+    scan_blocked_features "$SPEC_LEG" spec "$SHAPE_SPEC_PATH" code "$SHAPE_CODE_PATH"
+    scan_blocked_features "$CODE_LEG" code "$SHAPE_CODE_PATH" spec "$SHAPE_SPEC_PATH"
+fi
+
+# ---------------------------------------------------------------------------
+# Per-leg helpers.
+# ---------------------------------------------------------------------------
+WIP_PREFIX='wip: park '
+
+leg_in_progress_operation() {
+    local tree="$1"
+    local git_dir
+
+    LEG_OPERATION=""
+    git_dir="$(git -C "$tree" rev-parse --absolute-git-dir 2>/dev/null || true)"
+    [ -n "$git_dir" ] || return 1
+    if [ -e "$git_dir/rebase-merge" ] || [ -e "$git_dir/rebase-apply" ]; then
+        LEG_OPERATION="rebase"
+        return 0
+    fi
+    if [ -e "$git_dir/MERGE_HEAD" ]; then
+        LEG_OPERATION="merge"
+        return 0
+    fi
+    if [ -e "$git_dir/CHERRY_PICK_HEAD" ]; then
+        LEG_OPERATION="cherry-pick"
+        return 0
+    fi
+    return 1
+}
+
+leg_has_unmerged_paths() {
+    local tree="$1"
+
+    [ -n "$(git -C "$tree" ls-files -u 2>/dev/null || true)" ]
+}
+
+leg_is_dirty() {
+    local tree="$1"
+
+    [ -n "$(git -C "$tree" status --porcelain 2>/dev/null || true)" ]
+}
+
+commit_subject_is_wip() {
+    local tree="$1"
+    local revision="$2"
+    local subject
+
+    subject="$(git -C "$tree" log -1 --format=%s "$revision" 2>/dev/null || true)"
+    case "$subject" in
+        "$WIP_PREFIX"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Refusal bookkeeping and output.
+# ---------------------------------------------------------------------------
+REFUSED_BRANCHES=()
+REFUSED_REASONS=()
+PARKED_COUNT=0
+
+record_refusal() {
+    REFUSED_BRANCHES[${#REFUSED_BRANCHES[@]}]="$1"
+    REFUSED_REASONS[${#REFUSED_REASONS[@]}]="$2"
+    REFUSED_REMEDIATIONS[${#REFUSED_REMEDIATIONS[@]}]="$3"
+}
+REFUSED_REMEDIATIONS=()
+
+TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")"
+LANE="$(workspace_lane "$LANE_ARG")"
+WORKSTATION="$(workspace_workstation)"
+WIP_SUBJECT="$WIP_PREFIX$TIMESTAMP — lane $LANE"
+if [ -n "$MESSAGE_ARG" ]; then
+    WIP_SUBJECT="$WIP_SUBJECT — $MESSAGE_ARG"
+fi
+
+_git_worktree_create_temp_file || {
+    echo "Error: could not create a temporary file for the workspace record." >&2
+    exit 1
+}
+RECORD_FILE="$_GIT_WORKTREE_OUTPUT_FILE"
+# shellcheck disable=SC2329  # an EXIT trap handler
+cleanup() {
+    workspace_unlock
+    [ -n "${RECORD_FILE:-}" ] && rm -f "$RECORD_FILE" 2>/dev/null || true
+    return 0
+}
+trap cleanup EXIT
+
+# A refused feature keeps whatever an earlier park recorded for it: a refusal
+# must never erase the entry another workstation would resume from. A feature
+# that is simply gone is dropped, which is what leaves `features: []` behind.
+emit_recorded_feature() {
+    local branch="$1"
+    local feature_index=-1
+    local index=0
+
+    while [ "$index" -lt "${#MANIFEST_FEATURE_BRANCHES[@]}" ]; do
+        if [ "${MANIFEST_FEATURE_BRANCHES[$index]}" = "$branch" ]; then
+            feature_index=$index
+            break
+        fi
+        index=$((index + 1))
+    done
+    [ "$feature_index" -ge 0 ] || return 0
+
+    workspace_record_section "$RECORD_FILE" feature
+    workspace_record_put "$RECORD_FILE" branch "$branch"
+    if [ -n "${MANIFEST_FEATURE_DIRECTORIES[$feature_index]}" ]; then
+        workspace_record_put "$RECORD_FILE" _feature_directory \
+            "${MANIFEST_FEATURE_DIRECTORIES[$feature_index]}"
+    fi
+    index=0
+    while [ "$index" -lt "${#MANIFEST_LEG_ROLE[@]}" ]; do
+        if [ "${MANIFEST_LEG_FEATURE[$index]}" = "$feature_index" ]; then
+            workspace_record_section "$RECORD_FILE" leg
+            workspace_record_put "$RECORD_FILE" role "${MANIFEST_LEG_ROLE[$index]}"
+            workspace_record_put "$RECORD_FILE" _remote "${MANIFEST_LEG_REMOTE[$index]}"
+            workspace_record_put "$RECORD_FILE" parked_commit "${MANIFEST_LEG_COMMIT[$index]}"
+            workspace_record_put "$RECORD_FILE" wip "${MANIFEST_LEG_WIP[$index]}"
+            workspace_record_put "$RECORD_FILE" wip_depth "${MANIFEST_LEG_DEPTH[$index]}"
+            workspace_record_put "$RECORD_FILE" pushed "${MANIFEST_LEG_PUSHED[$index]}"
+        fi
+        index=$((index + 1))
+    done
+}
+
+# Lines that describe a parked feature, printed after the refusals so a
+# refusal is never buried.
+PARK_REPORT=""
+append_report() {
+    PARK_REPORT="$PARK_REPORT$1
+"
+}
+
+# ---------------------------------------------------------------------------
+# Park each feature.
+# ---------------------------------------------------------------------------
+LEG_ROLES=()
+LEG_REPOS=()
+LEG_TREES=()
+LEG_MOUNTS=()
+
+# LEG_REPOS is read by the R8 probe and the push, through the loop indices.
+# shellcheck disable=SC2034
+#
+# The role is what the manifest records (spec, code, or repo for a single
+# repository); the mount is where the leg checkout sits, which is what a
+# copy-pasteable `git -C` command needs.
+build_legs() {
+    local feature_dir="$1"
+
+    LEG_ROLES=()
+    LEG_REPOS=()
+    LEG_TREES=()
+    LEG_MOUNTS=()
+    if [ "$REPO_SHAPE" = "three-leg" ]; then
+        LEG_ROLES=("spec" "code")
+        LEG_REPOS=("$SPEC_LEG" "$CODE_LEG")
+        LEG_TREES=("$feature_dir/$SHAPE_SPEC_PATH" "$feature_dir/$SHAPE_CODE_PATH")
+        LEG_MOUNTS=("$SHAPE_SPEC_PATH" "$SHAPE_CODE_PATH")
+    else
+        LEG_ROLES=("repo")
+        LEG_REPOS=("$REPO_ROOT")
+        LEG_TREES=("$feature_dir")
+        LEG_MOUNTS=(".")
+    fi
+}
+
+# The blocked directories first: they are refusals about the layout and about
+# unresolved state, not about work that could have been committed.
+index=0
+while [ "$index" -lt "${#BLOCKED_DIRS[@]}" ]; do
+    blocked_dir="${BLOCKED_DIRS[$index]}"
+    blocked_branch="${BLOCKED_BRANCHES[$index]}"
+    blocked_kind="${BLOCKED_KINDS[$index]}"
+    blocked_role="${BLOCKED_ROLES[$index]}"
+    blocked_mount="${BLOCKED_MOUNTS[$index]}"
+    blocked_tree="${BLOCKED_TREES[$index]}"
+    index=$((index + 1))
+    if [ "$blocked_kind" = "detached" ]; then
+        blocked_operation="rebase"
+        if leg_in_progress_operation "$blocked_tree"; then
+            blocked_operation="$LEG_OPERATION"
+        fi
+        blocked_tree_print="$(root_relative "$blocked_tree")"
+        >&2 echo "Error: $blocked_branch ($blocked_role leg) has a $blocked_operation in progress; that feature was NOT parked."
+        >&2 echo "A WIP commit over an unresolved index would park a conflicted tree as if it were work."
+        >&2 echo "  finish it:  git -C $blocked_tree_print $blocked_operation --continue"
+        >&2 echo "  or drop it: git -C $blocked_tree_print $blocked_operation --abort"
+        >&2 echo "Then re-run \`make park\`."
+        record_refusal "$blocked_branch" "$blocked_operation in progress" \
+            "git -C $blocked_tree_print $blocked_operation --continue"
+        emit_recorded_feature "$blocked_branch"
+        continue
+    fi
+    >&2 echo "Error: $(root_relative "$blocked_dir") has no $blocked_role leg worktree; that feature was NOT parked."
+    >&2 echo "  recreate it:  git -C $blocked_mount worktree add $(root_relative "$blocked_dir")/$blocked_mount $blocked_branch"
+    >&2 echo "  or remove the feature directory and re-run \`make park\`."
+    record_refusal "$blocked_branch" "missing $blocked_role leg worktree" \
+        "git -C $blocked_mount worktree add $(root_relative "$blocked_dir")/$blocked_mount $blocked_branch"
+    emit_recorded_feature "$blocked_branch"
+done
+
+feature_index=0
+while [ "$feature_index" -lt "${#PARK_BRANCHES[@]}" ]; do
+    branch="${PARK_BRANCHES[$feature_index]}"
+    feature_dir="${PARK_DIRS[$feature_index]}"
+    feature_index=$((feature_index + 1))
+    build_legs "$feature_dir"
+
+    # Blockers for EVERY leg before a single commit is made.
+    refused=false
+    leg=0
+    while [ "$leg" -lt "${#LEG_ROLES[@]}" ]; do
+        role="${LEG_ROLES[$leg]}"
+        tree="${LEG_TREES[$leg]}"
+        tree_print="$(root_relative "$tree")"
+        leg_print="${LEG_MOUNTS[$leg]}"
+        leg=$((leg + 1))
+        if [ ! -d "$tree" ]; then
+            >&2 echo "Error: $(root_relative "$feature_dir") has no $role leg worktree; that feature was NOT parked."
+            >&2 echo "  recreate it:  git -C $leg_print worktree add $(root_relative "$feature_dir")/$leg_print $branch"
+            >&2 echo "  or remove the feature directory and re-run \`make park\`."
+            record_refusal "$branch" "missing $role leg worktree" \
+                "git -C $leg_print worktree add $(root_relative "$feature_dir")/$leg_print $branch"
+            refused=true
+            break
+        fi
+        if leg_in_progress_operation "$tree"; then
+            >&2 echo "Error: $branch ($role leg) has a $LEG_OPERATION in progress; that feature was NOT parked."
+            >&2 echo "A WIP commit over an unresolved index would park a conflicted tree as if it were work."
+            >&2 echo "  finish it:  git -C $tree_print $LEG_OPERATION --continue"
+            >&2 echo "  or drop it: git -C $tree_print $LEG_OPERATION --abort"
+            >&2 echo "Then re-run \`make park\`."
+            record_refusal "$branch" "$LEG_OPERATION in progress" \
+                "git -C $tree_print $LEG_OPERATION --continue"
+            refused=true
+            break
+        fi
+        if leg_has_unmerged_paths "$tree"; then
+            >&2 echo "Error: $branch ($role leg) has unmerged paths; that feature was NOT parked."
+            >&2 echo "A WIP commit over an unresolved index would park a conflicted tree as if it were work."
+            >&2 echo "  look:     git -C $tree_print status"
+            >&2 echo "  resolve:  git -C $tree_print add <path>"
+            >&2 echo "Then re-run \`make park\`."
+            record_refusal "$branch" "unmerged paths" "git -C $tree_print status"
+            refused=true
+            break
+        fi
+        if ! git -C "$tree" remote get-url origin >/dev/null 2>&1; then
+            >&2 echo "Error: $branch ($role leg) has no 'origin' remote; that feature was NOT parked."
+            >&2 echo "resume rebuilds worktrees from pushed branches, so a leg with no remote cannot travel."
+            >&2 echo "  git -C $leg_print remote add origin <url>"
+            record_refusal "$branch" "no origin remote" "git -C $leg_print remote add origin <url>"
+            refused=true
+            break
+        fi
+    done
+    [ "$refused" = false ] || { emit_recorded_feature "$branch"; continue; }
+
+    # R8: behind origin by this workspace's own parked WIP commits.
+    LEG_RETIRE_LEASE=()
+    leg=0
+    while [ "$leg" -lt "${#LEG_ROLES[@]}" ]; do
+        role="${LEG_ROLES[$leg]}"
+        tree="${LEG_TREES[$leg]}"
+        tree_print="$(root_relative "$tree")"
+        LEG_RETIRE_LEASE[leg]=""
+        leg=$((leg + 1))
+        [ "$NO_PUSH" = false ] || continue
+        [ "$DRY_RUN" = false ] || continue
+        # A probe, not a requirement: on a first park the branch is not on
+        # origin yet, and an unreachable origin is reported honestly by the
+        # push itself (R6) rather than by a warning here.
+        GIT_TERMINAL_PROMPT=0 git -C "$tree" fetch -q origin "$branch" >/dev/null 2>&1 || continue
+        remote_tip="$(git -C "$tree" rev-parse --verify --quiet FETCH_HEAD 2>/dev/null || true)"
+        [ -n "$remote_tip" ] || continue
+        local_head="$(git -C "$tree" rev-parse --verify HEAD 2>/dev/null || true)"
+        [ -n "$local_head" ] || continue
+        [ "$local_head" != "$remote_tip" ] || continue
+        git -C "$tree" merge-base --is-ancestor "$local_head" "$remote_tip" 2>/dev/null || continue
+        behind="$(git -C "$tree" rev-list --count "$local_head..$remote_tip" 2>/dev/null || echo 0)"
+        [ "$behind" -gt 0 ] || continue
+        all_wip=true
+        step=0
+        while [ "$step" -lt "$behind" ]; do
+            if ! commit_subject_is_wip "$tree" "$remote_tip~$step"; then
+                all_wip=false
+                break
+            fi
+            step=$((step + 1))
+        done
+        [ "$all_wip" = true ] || continue
+        if ! recorded_leg_commit "$branch" "$role" || [ "$RECORDED_COMMIT" != "$remote_tip" ]; then
+            continue
+        fi
+        if [ "$RETIRE_PARKED_WIP" = true ]; then
+            LEG_RETIRE_LEASE[leg - 1]="$remote_tip"
+            continue
+        fi
+        >&2 echo "Error: $branch ($role leg) is behind origin by $behind parked WIP commit(s); that feature was NOT parked."
+        >&2 echo "The parked commit $remote_tip is still the remote tip and this workspace recorded it, so retiring it"
+        >&2 echo "cannot destroy anyone else's work:"
+        >&2 echo "  git -C $tree_print push --force-with-lease=$branch:$remote_tip origin $branch"
+        >&2 echo "park does not force-push on your behalf. Re-run \`make park\` afterwards, or pass"
+        >&2 echo "--retire-parked-wip to let park do exactly that one push."
+        record_refusal "$branch" "behind by $behind parked WIP commit(s)" \
+            "git -C $tree_print push --force-with-lease=$branch:$remote_tip origin $branch"
+        refused=true
+        break
+    done
+    [ "$refused" = false ] || { emit_recorded_feature "$branch"; continue; }
+
+    # Commit, then push, per leg.
+    LEG_COMMIT=()
+    LEG_WIP=()
+    LEG_DEPTH=()
+    LEG_PUSHED=()
+    leg=0
+    while [ "$leg" -lt "${#LEG_ROLES[@]}" ]; do
+        role="${LEG_ROLES[$leg]}"
+        tree="${LEG_TREES[$leg]}"
+        tree_print="$(root_relative "$tree")"
+        lease="${LEG_RETIRE_LEASE[$leg]:-}"
+        leg=$((leg + 1))
+
+        head_before="$(git -C "$tree" rev-parse --verify HEAD 2>/dev/null || true)"
+        wip=false
+        depth=0
+        parked_commit="$head_before"
+        if leg_is_dirty "$tree"; then
+            if [ "$DRY_RUN" = true ]; then
+                wip=true
+                depth=1
+                parked_commit="(dry-run)"
+            else
+                if ! commit_error="$( { git -C "$tree" add -A && git -C "$tree" commit -q -m "$WIP_SUBJECT"; } 2>&1 )"; then
+                    >&2 echo "Error: committing $branch ($role leg) failed; that feature was NOT parked."
+                    if [ -n "$commit_error" ]; then
+                        >&2 printf '  %s\n' "$commit_error"
+                    fi
+                    >&2 echo "  set your identity:  git -C $tree_print config user.email <you>"
+                    record_refusal "$branch" "commit failed" \
+                        "git -C $tree_print config user.email <you>"
+                    refused=true
+                    break
+                fi
+                wip=true
+                depth=1
+                if commit_subject_is_wip "$tree" "$head_before" \
+                    && recorded_leg_commit "$branch" "$role" \
+                    && [ "$RECORDED_COMMIT" = "$head_before" ]; then
+                    recorded_leg_depth "$branch" "$role"
+                    depth=$((RECORDED_DEPTH + 1))
+                fi
+                parked_commit="$(git -C "$tree" rev-parse --verify HEAD)"
+            fi
+        elif recorded_leg_commit "$branch" "$role" \
+            && [ "$RECORDED_COMMIT" = "$head_before" ] \
+            && commit_subject_is_wip "$tree" HEAD; then
+            # Clean, and HEAD is still this workspace's own parked WIP commit:
+            # make no commit, and keep the recorded depth. Recording wip: false
+            # here would disarm resume's un-commit for work that is still
+            # parked, and would make a second park rewrite the manifest for
+            # nothing.
+            recorded_leg_depth "$branch" "$role"
+            if [ "$RECORDED_DEPTH" -gt 0 ]; then
+                wip=true
+                depth="$RECORDED_DEPTH"
+            fi
+        fi
+
+        pushed=false
+        if [ "$NO_PUSH" = true ]; then
+            pushed=false
+        elif [ "$DRY_RUN" = true ]; then
+            pushed=true
+        else
+            if [ -n "$lease" ]; then
+                push_ok=false
+                if push_error="$(GIT_TERMINAL_PROMPT=0 git -C "$tree" push --force-with-lease="$branch:$lease" origin "$branch" 2>&1)"; then
+                    push_ok=true
+                fi
+            else
+                push_ok=false
+                if push_error="$(GIT_TERMINAL_PROMPT=0 git -C "$tree" push origin "$branch" 2>&1)"; then
+                    push_ok=true
+                fi
+            fi
+            if [ "$push_ok" != true ]; then
+                >&2 echo "Error: pushing $branch to origin refused in the $role leg; that feature was NOT parked."
+                if [ -n "$push_error" ]; then
+                    >&2 printf '  %s\n' "$push_error"
+                fi
+                >&2 echo "Your work is NOT lost: it is committed locally at $parked_commit. park never force-pushes."
+                >&2 echo "  look:  git -C $tree_print fetch origin && git -C $tree_print log --oneline $parked_commit..origin/$branch"
+                >&2 echo "Then reconcile by hand and re-run \`make park\`."
+                record_refusal "$branch" "push refused" \
+                    "git -C $tree_print fetch origin && git -C $tree_print log --oneline $parked_commit..origin/$branch"
+                refused=true
+                break
+            fi
+            pushed=true
+        fi
+
+        LEG_COMMIT[${#LEG_COMMIT[@]}]="$parked_commit"
+        LEG_WIP[${#LEG_WIP[@]}]="$wip"
+        LEG_DEPTH[${#LEG_DEPTH[@]}]="$depth"
+        LEG_PUSHED[${#LEG_PUSHED[@]}]="$pushed"
+    done
+    [ "$refused" = false ] || { emit_recorded_feature "$branch"; continue; }
+
+    # Recorded, and reported.
+    workspace_record_section "$RECORD_FILE" feature
+    workspace_record_put "$RECORD_FILE" branch "$branch"
+    if [ "$REPO_SHAPE" = "three-leg" ]; then
+        shape_feature_paths_for "$REPO_ROOT" "$feature_dir" "$branch"
+        workspace_record_put "$RECORD_FILE" _feature_directory "$SHAPE_FEATURE_DIR_RELATIVE"
+    fi
+    append_report "PARKED: $branch"
+    leg=0
+    while [ "$leg" -lt "${#LEG_ROLES[@]}" ]; do
+        role="${LEG_ROLES[$leg]}"
+        workspace_record_section "$RECORD_FILE" leg
+        workspace_record_put "$RECORD_FILE" role "$role"
+        workspace_record_put "$RECORD_FILE" _remote origin
+        workspace_record_put "$RECORD_FILE" parked_commit "${LEG_COMMIT[$leg]}"
+        workspace_record_put "$RECORD_FILE" wip "${LEG_WIP[$leg]}"
+        workspace_record_put "$RECORD_FILE" wip_depth "${LEG_DEPTH[$leg]}"
+        workspace_record_put "$RECORD_FILE" pushed "${LEG_PUSHED[$leg]}"
+        if [ "${LEG_PUSHED[$leg]}" = true ]; then
+            append_report "  $role  wip ${LEG_DEPTH[$leg]}  ${LEG_COMMIT[$leg]}  pushed origin/$branch"
+        else
+            append_report "  $role  wip ${LEG_DEPTH[$leg]}  ${LEG_COMMIT[$leg]}  NOT pushed"
+        fi
+        leg=$((leg + 1))
+    done
+    PARKED_COUNT=$((PARKED_COUNT + 1))
+done
+
+if [ "${#PARK_BRANCHES[@]}" -eq 0 ] && [ "${#BLOCKED_DIRS[@]}" -eq 0 ]; then
+    echo "[specify] No open features under '$(root_relative "$WORKTREE_ROOT")'; nothing to park." >&2
+fi
+
+# ---------------------------------------------------------------------------
+# The active feature: the state file first, the newest open feature second,
+# exactly the two steps get-last-worktree.sh already uses, so park and cts
+# never disagree.
+# ---------------------------------------------------------------------------
+ACTIVE_FEATURE=""
+ACTIVE_FEATURE_SOURCE="worktree_root_fallback"
+STATE_COMMON_DIR="$(resolve_git_common_dir || true)"
+STATE_FILE=""
+if [ -n "$STATE_COMMON_DIR" ]; then
+    STATE_FILE="$STATE_COMMON_DIR/speckit-last-worktree.json"
+fi
+if [ -n "$STATE_FILE" ] && workspace_read_state_field "$STATE_FILE" BRANCH_NAME; then
+    case "$OPEN_BRANCHES" in
+        *" $WORKSPACE_STATE_VALUE "*)
+            ACTIVE_FEATURE="$WORKSPACE_STATE_VALUE"
+            ACTIVE_FEATURE_SOURCE="state_file"
+            ;;
+    esac
+fi
+if [ -z "$ACTIVE_FEATURE" ] && [ "${#FEATURE_BRANCHES[@]}" -gt 0 ]; then
+    ACTIVE_FEATURE="${FEATURE_BRANCHES[0]}"
+    ACTIVE_FEATURE_SOURCE="worktree_root_fallback"
+fi
+
+# W1: feature.json disagrees. park enumerates from git, so this is a warning
+# and never a refusal.
+if [ "$REPO_SHAPE" = "three-leg" ] && [ -f "$REPO_ROOT/.specify/feature.json" ]; then
+    recorded_dir="$(python3 - "$REPO_ROOT/.specify/feature.json" <<'PY'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as stream:
+        payload = json.load(stream)
+except (OSError, ValueError):
+    raise SystemExit(0)
+if isinstance(payload, dict):
+    value = payload.get("feature_directory", "")
+    if isinstance(value, str):
+        sys.stdout.write(value)
+PY
+    )" || recorded_dir=""
+    if [ -n "$recorded_dir" ]; then
+        known=false
+        index=0
+        while [ "$index" -lt "${#FEATURE_DIRS[@]}" ]; do
+            shape_feature_paths_for "$REPO_ROOT" "${FEATURE_DIRS[$index]}" "${FEATURE_BRANCHES[$index]}"
+            if [ "$SHAPE_FEATURE_DIR_RELATIVE" = "$recorded_dir" ]; then
+                known=true
+                break
+            fi
+            index=$((index + 1))
+        done
+        if [ "$known" = false ]; then
+            echo "[specify] Warning: .specify/feature.json names '$recorded_dir', which is not an open feature under '$(root_relative "$WORKTREE_ROOT")'." >&2
+            echo "[specify] Recorded active_feature_source: stale-feature-json; resume will select '$ACTIVE_FEATURE' instead." >&2
+            ACTIVE_FEATURE_SOURCE="stale-feature-json"
+        fi
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# The manifest: written under a mutex, committed with an explicit pathspec,
+# pushed with a race retry. Never `git add -A`, never a bare `git commit`,
+# never `git stash`, never a force-push in the workspace repository.
+# ---------------------------------------------------------------------------
+TRACKING_BRANCH="$BASE_BRANCH"
+if [ -f "$REPO_ROOT/project.yaml" ] \
+    && workspace_read_scalar "$REPO_ROOT/project.yaml" tracking_branch \
+    && [ -n "$WORKSPACE_SCALAR" ]; then
+    TRACKING_BRANCH="$WORKSPACE_SCALAR"
+fi
+workspace_project_repository "$REPO_ROOT"
+PROJECT_REPOSITORY="$WORKSPACE_PROJECT_REPOSITORY"
+
+HEADER_FILE="$RECORD_FILE.header"
+{
+    printf 'repo_shape\t%s\n' "$REPO_SHAPE"
+    printf 'project_id\t%s\n' "$PROJECT_ID"
+    printf 'workspace_path\t%s\n' "$WORKSPACE_PATH"
+    printf 'workspace_source\t%s\n' "$WORKSPACE_SOURCE_LABEL"
+    printf 'manifest_path\t%s\n' "$MANIFEST_RELATIVE"
+    printf 'active_feature\t%s\n' "$ACTIVE_FEATURE"
+    printf 'active_feature_source\t%s\n' "$ACTIVE_FEATURE_SOURCE"
+    printf '_family\t%s\n' "$WORKSPACE_FAMILY"
+    printf '_repository\t%s\n' "$PROJECT_REPOSITORY"
+    printf '_shape\t%s\n' "$REPO_SHAPE"
+    printf '_root\t%s\n' "$(workspace_manifest_root_value "$REPO_ROOT" "$WORKSPACE_FAMILY_DIR")"
+    printf '_tracking_branch\t%s\n' "$TRACKING_BRANCH"
+    printf '_worktree_root\t%s\n' "$WORKTREE_ROOT_RAW"
+    printf '_parked_at\t%s\n' "$TIMESTAMP"
+    printf '_parked_on\t%s\n' "$WORKSTATION"
+    printf '_parked_by_lane\t%s\n' "$LANE"
+    if [ "$DRY_RUN" = true ]; then
+        printf 'dry_run\ttrue\n'
+    fi
+} > "$HEADER_FILE"
+cat "$RECORD_FILE" >> "$HEADER_FILE"
+index=0
+while [ "$index" -lt "${#REFUSED_BRANCHES[@]}" ]; do
+    {
+        printf '[refused]\n'
+        printf 'branch\t%s\n' "${REFUSED_BRANCHES[$index]}"
+        printf 'reason\t%s\n' "${REFUSED_REASONS[$index]}"
+        printf 'remediation\t%s\n' "${REFUSED_REMEDIATIONS[$index]}"
+    } >> "$HEADER_FILE"
+    index=$((index + 1))
+done
+mv "$HEADER_FILE" "$RECORD_FILE"
+
+MANIFEST_STATE="dry-run"
+MANIFEST_COMMIT=""
+PUSH_STATE="not-pushed"
+if [ "$DRY_RUN" != true ]; then
+    if ! workspace_lock "$WORKSPACE_PATH"; then
+        >&2 echo "Error: another park or resume holds '$WORKSPACE_PATH/.workspaces.lock'; nothing was recorded."
+        >&2 echo "  If no other run is active, remove it:  rmdir $WORKSPACE_PATH/.workspaces.lock"
+        exit 3
+    fi
+    if ! workspace_commit_pre_existing "$WORKSPACE_PATH" "$WORKSTATION"; then
+        >&2 echo "Error: could not commit the pre-existing changes under '$WORKSPACE_PATH/workspaces'; nothing was recorded."
+        exit 3
+    fi
+    if ! workspace_sync "$WORKSPACE_PATH"; then
+        exit 3
+    fi
+    if ! MANIFEST_STATE="$(workspace_write_manifest "$MANIFEST_PATH" "$RECORD_FILE")"; then
+        >&2 echo "Error: could not write '$MANIFEST_PATH'; nothing was recorded."
+        exit 3
+    fi
+    if [ "$MANIFEST_STATE" = "changed" ]; then
+        if ! workspace_only_our_file_changed "$WORKSPACE_PATH" "$MANIFEST_RELATIVE"; then
+            >&2 echo "Error: writing '$MANIFEST_RELATIVE' left other changes under '$WORKSPACE_PATH/workspaces'; nothing was committed."
+            >&2 echo "  look:  git -C $WORKSPACE_PATH status --porcelain -- workspaces"
+            exit 3
+        fi
+        if ! workspace_commit_manifest "$WORKSPACE_PATH" "$MANIFEST_RELATIVE" \
+            "park($PROJECT_ID@$WORKSTATION): $PARKED_COUNT feature(s)"; then
+            >&2 echo "Error: could not commit '$MANIFEST_RELATIVE' in '$WORKSPACE_PATH'."
+            exit 3
+        fi
+        MANIFEST_COMMIT="$(git -C "$WORKSPACE_PATH" rev-parse --short HEAD)"
+        if workspace_push_manifest "$WORKSPACE_PATH"; then
+            PUSH_STATE="$WORKSPACE_PUSH_RESULT"
+        else
+            PUSH_STATE="$WORKSPACE_PUSH_RESULT"
+            workspace_unlock
+            exit 3
+        fi
+    fi
+    workspace_unlock
+fi
+
+# ---------------------------------------------------------------------------
+# Output.
+# ---------------------------------------------------------------------------
+if [ "$JSON_MODE" = true ]; then
+    workspace_emit_json "$RECORD_FILE" PARKED
+else
+    echo "REPO_SHAPE: $REPO_SHAPE"
+    echo "PROJECT_ID: $PROJECT_ID"
+    echo "WORKSPACE: $WORKSPACE_PATH ($WORKSPACE_SOURCE_LABEL)"
+    echo "MANIFEST: $MANIFEST_RELATIVE"
+    if [ -n "$PARK_REPORT" ]; then
+        printf '%s' "$PARK_REPORT"
+    fi
+    if [ -n "$ACTIVE_FEATURE" ]; then
+        echo "ACTIVE_FEATURE: $ACTIVE_FEATURE ($ACTIVE_FEATURE_SOURCE)"
+    fi
+    index=0
+    while [ "$index" -lt "${#REFUSED_BRANCHES[@]}" ]; do
+        echo "REFUSED: ${REFUSED_BRANCHES[$index]} — ${REFUSED_REASONS[$index]}"
+        index=$((index + 1))
+    done
+    if [ "$DRY_RUN" = true ]; then
+        echo "COMMITTED: nothing (--dry-run)"
+    elif [ "$MANIFEST_STATE" = "changed" ]; then
+        if [ "$PUSH_STATE" = "pushed" ]; then
+            echo "COMMITTED: $MANIFEST_RELATIVE @ $MANIFEST_COMMIT (pushed)"
+        else
+            echo "COMMITTED: $MANIFEST_RELATIVE @ $MANIFEST_COMMIT (not pushed)"
+        fi
+    else
+        echo "COMMITTED: $MANIFEST_RELATIVE unchanged (no commit)"
+    fi
+fi
+
+if [ "${#REFUSED_BRANCHES[@]}" -eq 0 ]; then
+    exit 0
+fi
+if [ "$PARKED_COUNT" -eq 0 ]; then
+    exit 2
+fi
+exit 3

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/park.sh
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/park.sh
@@ -219,7 +219,63 @@ fi
 MANIFEST_RELATIVE="workspaces/$MANIFEST_ORG/$MANIFEST_NAME.yaml"
 MANIFEST_PATH="$WORKSPACE_PATH/$MANIFEST_RELATIVE"
 
-# What this workspace recorded last time, for the WIP depth and the R8 lease.
+WIP_PREFIX='wip: park '
+TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")"
+LANE="$(workspace_lane "$LANE_ARG")"
+WORKSTATION="$(workspace_workstation)"
+WIP_SUBJECT="$WIP_PREFIX$TIMESTAMP — lane $LANE"
+if [ -n "$MESSAGE_ARG" ]; then
+    WIP_SUBJECT="$WIP_SUBJECT — $MESSAGE_ARG"
+fi
+
+# The temporaries and the EXIT trap come before the lock, so the lock is never
+# taken by a run that cannot release it.
+_git_worktree_create_temp_file || {
+    echo "Error: could not create a temporary file for the workspace record." >&2
+    exit 1
+}
+RECORD_FILE="$_GIT_WORKTREE_OUTPUT_FILE"
+_git_worktree_create_temp_file || {
+    echo "Error: could not create a temporary file for the workspace record." >&2
+    exit 1
+}
+HEADER_FILE="$_GIT_WORKTREE_OUTPUT_FILE"
+# shellcheck disable=SC2329  # an EXIT trap handler
+cleanup() {
+    workspace_unlock
+    [ -n "${RECORD_FILE:-}" ] && rm -f "$RECORD_FILE" 2>/dev/null || true
+    [ -n "${HEADER_FILE:-}" ] && rm -f "$HEADER_FILE" 2>/dev/null || true
+    return 0
+}
+trap cleanup EXIT
+
+# The workspace is locked, drained of a peer's in-flight edit and brought up
+# to date BEFORE the manifest is read. Reading a stale clone would make every
+# "what did this workspace record last time" decision wrong, and the worst of
+# those is silent: a feature this workstation cannot park would be dropped
+# from the block instead of carried forward, erasing the entry the other
+# workstation resumes from.
+if [ "$DRY_RUN" != true ]; then
+    if ! workspace_lock "$WORKSPACE_PATH"; then
+        >&2 echo "Error: another park or resume holds '$WORKSPACE_PATH/.workspaces.lock'; nothing was parked."
+        >&2 echo "  If no other run is active, remove it:  rmdir $WORKSPACE_PATH/.workspaces.lock"
+        exit 3
+    fi
+    if ! workspace_commit_pre_existing "$WORKSPACE_PATH" "$WORKSTATION"; then
+        >&2 echo "Error: could not commit the pre-existing changes under '$WORKSPACE_PATH/workspaces'; nothing was parked."
+        exit 3
+    fi
+    SYNC_STATUS=0
+    workspace_sync "$WORKSPACE_PATH" || SYNC_STATUS=$?
+    if [ "$SYNC_STATUS" -eq 2 ]; then
+        workspace_refuse_dirty "$WORKSPACE_PATH" parked
+        exit 2
+    elif [ "$SYNC_STATUS" -ne 0 ]; then
+        exit 3
+    fi
+fi
+
+# What this workspace recorded last time, for the R8 lease.
 workspace_load_project "$MANIFEST_PATH" "$PROJECT_ID" || true
 
 recorded_leg_index() {
@@ -246,16 +302,6 @@ recorded_leg_commit() {
     recorded_leg_index "$1" "$2" || return 1
     RECORDED_COMMIT="${MANIFEST_LEG_COMMIT[$RECORDED_INDEX]}"
     [ -n "$RECORDED_COMMIT" ]
-}
-
-recorded_leg_depth() {
-    RECORDED_DEPTH=0
-    recorded_leg_index "$1" "$2" || return 1
-    RECORDED_DEPTH="${MANIFEST_LEG_DEPTH[$RECORDED_INDEX]}"
-    case "$RECORDED_DEPTH" in
-        ''|*[!0-9]*) RECORDED_DEPTH=0 ;;
-    esac
-    return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -466,8 +512,6 @@ fi
 # ---------------------------------------------------------------------------
 # Per-leg helpers.
 # ---------------------------------------------------------------------------
-WIP_PREFIX='wip: park '
-
 leg_in_progress_operation() {
     local tree="$1"
     local git_dir
@@ -502,6 +546,37 @@ leg_is_dirty() {
     [ -n "$(git -C "$tree" status --porcelain 2>/dev/null || true)" ]
 }
 
+commit_has_one_parent() {
+    local tree="$1"
+    local revision="$2"
+    local parents
+
+    parents="$(git -C "$tree" log -1 --format=%P "$revision" 2>/dev/null || true)"
+    case "$parents" in
+        '') return 1 ;;
+        *' '*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# How many parked WIP commits sit on the tip of this branch, read from the
+# BRANCH and never from the manifest: a stale or missing manifest entry must
+# not make park record a one-commit stack over a two-commit one, which would
+# leave a resume elsewhere sitting on the older WIP commit with the first
+# park's work still committed.
+count_wip_tip_commits() {
+    local tree="$1"
+    local start="$2"
+    local depth=0
+
+    while [ "$depth" -lt 100 ]; do
+        commit_subject_is_wip "$tree" "$start~$depth" || break
+        commit_has_one_parent "$tree" "$start~$depth" || break
+        depth=$((depth + 1))
+    done
+    WIP_TIP_DEPTH=$depth
+}
+
 commit_subject_is_wip() {
     local tree="$1"
     local revision="$2"
@@ -527,27 +602,6 @@ record_refusal() {
     REFUSED_REMEDIATIONS[${#REFUSED_REMEDIATIONS[@]}]="$3"
 }
 REFUSED_REMEDIATIONS=()
-
-TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")"
-LANE="$(workspace_lane "$LANE_ARG")"
-WORKSTATION="$(workspace_workstation)"
-WIP_SUBJECT="$WIP_PREFIX$TIMESTAMP — lane $LANE"
-if [ -n "$MESSAGE_ARG" ]; then
-    WIP_SUBJECT="$WIP_SUBJECT — $MESSAGE_ARG"
-fi
-
-_git_worktree_create_temp_file || {
-    echo "Error: could not create a temporary file for the workspace record." >&2
-    exit 1
-}
-RECORD_FILE="$_GIT_WORKTREE_OUTPUT_FILE"
-# shellcheck disable=SC2329  # an EXIT trap handler
-cleanup() {
-    workspace_unlock
-    [ -n "${RECORD_FILE:-}" ] && rm -f "$RECORD_FILE" 2>/dev/null || true
-    return 0
-}
-trap cleanup EXIT
 
 # A refused feature keeps whatever an earlier park recorded for it: a refusal
 # must never erase the entry another workstation would resume from. A feature
@@ -731,12 +785,18 @@ while [ "$feature_index" -lt "${#PARK_BRANCHES[@]}" ]; do
         LEG_RETIRE_LEASE[leg]=""
         leg=$((leg + 1))
         [ "$NO_PUSH" = false ] || continue
-        [ "$DRY_RUN" = false ] || continue
         # A probe, not a requirement: on a first park the branch is not on
         # origin yet, and an unreachable origin is reported honestly by the
-        # push itself (R6) rather than by a warning here.
-        GIT_TERMINAL_PROMPT=0 git -C "$tree" fetch -q origin "$branch" >/dev/null 2>&1 || continue
-        remote_tip="$(git -C "$tree" rev-parse --verify --quiet FETCH_HEAD 2>/dev/null || true)"
+        # push itself (R6) rather than by a warning here. A dry run previews
+        # the refusal from the remote-tracking ref it already has rather than
+        # fetching: R8 is the refusal a person most wants previewed, and a dry
+        # run still writes nothing at all.
+        if [ "$DRY_RUN" = true ]; then
+            remote_tip="$(git -C "$tree" rev-parse --verify --quiet "refs/remotes/origin/$branch" 2>/dev/null || true)"
+        else
+            GIT_TERMINAL_PROMPT=0 git -C "$tree" fetch -q origin "$branch" >/dev/null 2>&1 || continue
+            remote_tip="$(git -C "$tree" rev-parse --verify --quiet FETCH_HEAD 2>/dev/null || true)"
+        fi
         [ -n "$remote_tip" ] || continue
         local_head="$(git -C "$tree" rev-parse --verify HEAD 2>/dev/null || true)"
         [ -n "$local_head" ] || continue
@@ -809,27 +869,19 @@ while [ "$feature_index" -lt "${#PARK_BRANCHES[@]}" ]; do
                     break
                 fi
                 wip=true
-                depth=1
-                if commit_subject_is_wip "$tree" "$head_before" \
-                    && recorded_leg_commit "$branch" "$role" \
-                    && [ "$RECORDED_COMMIT" = "$head_before" ]; then
-                    recorded_leg_depth "$branch" "$role"
-                    depth=$((RECORDED_DEPTH + 1))
-                fi
+                count_wip_tip_commits "$tree" HEAD
+                depth="$WIP_TIP_DEPTH"
                 parked_commit="$(git -C "$tree" rev-parse --verify HEAD)"
             fi
-        elif recorded_leg_commit "$branch" "$role" \
-            && [ "$RECORDED_COMMIT" = "$head_before" ] \
-            && commit_subject_is_wip "$tree" HEAD; then
-            # Clean, and HEAD is still this workspace's own parked WIP commit:
-            # make no commit, and keep the recorded depth. Recording wip: false
-            # here would disarm resume's un-commit for work that is still
-            # parked, and would make a second park rewrite the manifest for
-            # nothing.
-            recorded_leg_depth "$branch" "$role"
-            if [ "$RECORDED_DEPTH" -gt 0 ]; then
+        else
+            # Clean. When HEAD is still a parked WIP commit the work is parked
+            # and not landed, so it keeps wip: true and the depth the BRANCH
+            # says: recording wip: false here would disarm resume's un-commit
+            # for work that is still parked.
+            count_wip_tip_commits "$tree" HEAD
+            if [ "$WIP_TIP_DEPTH" -gt 0 ]; then
                 wip=true
-                depth="$RECORDED_DEPTH"
+                depth="$WIP_TIP_DEPTH"
             fi
         fi
 
@@ -981,7 +1033,6 @@ fi
 workspace_project_repository "$REPO_ROOT"
 PROJECT_REPOSITORY="$WORKSPACE_PROJECT_REPOSITORY"
 
-HEADER_FILE="$RECORD_FILE.header"
 {
     printf 'repo_shape\t%s\n' "$REPO_SHAPE"
     printf 'project_id\t%s\n' "$PROJECT_ID"
@@ -1020,18 +1071,8 @@ MANIFEST_STATE="dry-run"
 MANIFEST_COMMIT=""
 PUSH_STATE="not-pushed"
 if [ "$DRY_RUN" != true ]; then
-    if ! workspace_lock "$WORKSPACE_PATH"; then
-        >&2 echo "Error: another park or resume holds '$WORKSPACE_PATH/.workspaces.lock'; nothing was recorded."
-        >&2 echo "  If no other run is active, remove it:  rmdir $WORKSPACE_PATH/.workspaces.lock"
-        exit 3
-    fi
-    if ! workspace_commit_pre_existing "$WORKSPACE_PATH" "$WORKSTATION"; then
-        >&2 echo "Error: could not commit the pre-existing changes under '$WORKSPACE_PATH/workspaces'; nothing was recorded."
-        exit 3
-    fi
-    if ! workspace_sync "$WORKSPACE_PATH"; then
-        exit 3
-    fi
+    # The lock is still held and this is still the checkout that was synced
+    # above, so the write lands on what origin already holds.
     if ! MANIFEST_STATE="$(workspace_write_manifest "$MANIFEST_PATH" "$RECORD_FILE")"; then
         >&2 echo "Error: could not write '$MANIFEST_PATH'; nothing was recorded."
         exit 3
@@ -1052,6 +1093,11 @@ if [ "$DRY_RUN" != true ]; then
             PUSH_STATE="$WORKSPACE_PUSH_RESULT"
         else
             PUSH_STATE="$WORKSPACE_PUSH_RESULT"
+            if [ "$PUSH_STATE" = "dirty" ]; then
+                workspace_refuse_dirty "$WORKSPACE_PATH" parked
+                workspace_unlock
+                exit 2
+            fi
             workspace_unlock
             exit 3
         fi

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/resume.sh
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/resume.sh
@@ -1,0 +1,844 @@
+#!/usr/bin/env bash
+# speckit-overlay-shape: 1
+# Git extension: resume.sh
+#
+# Recreate the worktrees park.sh recorded, restore .specify/feature.json and
+# the last-worktree state file, and un-commit the parked WIP so the work comes
+# back exactly as it was left. Implements openRepoShape#77 as ruled by Brett
+# Heap on 2026-09-09, point 2: resume REFUSES on divergence and never resets
+# over commits this workspace did not park.
+
+set -e
+
+JSON_MODE=false
+DRY_RUN=false
+KEEP_STAGED=false
+WORKSPACE_ARG=""
+REQUESTED_BRANCHES=()
+
+usage() {
+    echo "Usage: $0 [--json] [--dry-run] [--feature <branch>]... [--workspace <path>]"
+    echo "          [--keep-staged] [-h|--help]"
+    echo ""
+    echo "Recreate the worktrees this workspace parked, and un-commit the parked WIP."
+    echo ""
+    echo "Options:"
+    echo "  --json                 Output in JSON format"
+    echo "  --dry-run              Print the plan; create, write and reset nothing"
+    echo "  --feature <branch>     Resume only this feature; repeatable. Default: every"
+    echo "                         manifest entry for this project"
+    echo "  --workspace <path>     Workspace checkout to read, overriding the user config"
+    echo "  --keep-staged          Stop after the soft reset, leaving the work staged"
+    echo "  --help, -h             Show this help message"
+    echo ""
+    echo "Exit codes:"
+    echo "  0  everything asked for was resumed, or there was nothing to resume"
+    echo "  1  usage or environment error"
+    echo "  2  a refusal before anything was done, or every feature was refused"
+    echo "  3  partial: at least one feature was resumed and at least one refused"
+    echo ""
+    echo "Environment variables:"
+    echo "  SPECKIT_WORKSPACE_PATH        Workspace checkout, overriding the user config"
+    echo "  SPECKIT_WORKSPACE_REPOSITORY  Workspace repository, for the clone remediation"
+    echo "  AGENT_PROTOCOL_ROOT           Home of workspace.yaml (default ~/.agents)"
+    echo "  SPECKIT_GIT_WORKTREE_ROOT     Override worktree_root"
+    echo "  SPECKIT_GIT_BASE_BRANCH       Override base_branch"
+    echo ""
+    echo "The user config is \${AGENT_PROTOCOL_ROOT:-\$HOME/.agents}/workspace.yaml:"
+    echo ""
+    echo "  repository: <owner>/<repo>"
+    echo "  path: ~/projects/<repo>"
+}
+
+i=1
+while [ $i -le $# ]; do
+    arg="${!i}"
+    case "$arg" in
+        --json) JSON_MODE=true ;;
+        --dry-run) DRY_RUN=true ;;
+        --keep-staged) KEEP_STAGED=true ;;
+        --feature|--workspace)
+            if [ $((i + 1)) -gt $# ]; then
+                echo "Error: $arg requires a value" >&2
+                exit 1
+            fi
+            i=$((i + 1))
+            next_arg="${!i}"
+            case "$next_arg" in
+                --*)
+                    echo "Error: $arg requires a value" >&2
+                    exit 1
+                    ;;
+            esac
+            case "$arg" in
+                --feature) REQUESTED_BRANCHES[${#REQUESTED_BRANCHES[@]}]="$next_arg" ;;
+                --workspace) WORKSPACE_ARG="$next_arg" ;;
+            esac
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: unknown option: $arg" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+    i=$((i + 1))
+done
+
+SCRIPT_DIR="$(CDPATH="" cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_REPO_ROOT="$(CDPATH="" cd -- "$SCRIPT_DIR/../../../../.." && pwd 2>/dev/null || true)"
+if [ ! -f "$SCRIPT_DIR/git-common.sh" ]; then
+    echo "Error: Could not locate git-common.sh next to resume.sh." >&2
+    exit 1
+fi
+source "$SCRIPT_DIR/git-common.sh"
+if [ ! -f "$SCRIPT_DIR/workspace-common.sh" ]; then
+    echo "Error: Could not locate workspace-common.sh next to resume.sh." >&2
+    exit 1
+fi
+source "$SCRIPT_DIR/workspace-common.sh"
+
+if REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+else
+    REPO_ROOT=""
+fi
+[ -n "$REPO_ROOT" ] || REPO_ROOT="$SCRIPT_REPO_ROOT"
+if [ -z "$REPO_ROOT" ] || [ ! -d "$REPO_ROOT/.specify" ]; then
+    echo "Error: not inside a Git repository or Speckit checkout." >&2
+    exit 1
+fi
+
+cd "$REPO_ROOT"
+load_repo_shape "$REPO_ROOT"
+# get_config_value in git-common.sh reads CONFIG_FILE.
+# shellcheck disable=SC2034
+CONFIG_FILE="$REPO_ROOT/.specify/extensions/git/git-config.yml"
+
+CHECKOUT_MODE=$(get_config_value "checkout_mode" "branch" "SPECKIT_GIT_CHECKOUT_MODE")
+CHECKOUT_MODE=$(printf '%s' "$CHECKOUT_MODE" | tr '[:upper:]' '[:lower:]')
+BASE_BRANCH=$(get_config_value "base_branch" "main" "SPECKIT_GIT_BASE_BRANCH")
+DEFAULT_WORKTREE_ROOT="../${REPO_ROOT##*/}-worktrees"
+if [ "$REPO_SHAPE" = "three-leg" ]; then
+    DEFAULT_WORKTREE_ROOT="worktrees"
+fi
+WORKTREE_ROOT_RAW=$(get_config_value "worktree_root" "$DEFAULT_WORKTREE_ROOT" "SPECKIT_GIT_WORKTREE_ROOT")
+WORKTREE_ROOT=$(resolve_path_from_repo_root "$WORKTREE_ROOT_RAW")
+
+if [ "$CHECKOUT_MODE" != "worktree" ]; then
+    echo "Error: checkout_mode '$CHECKOUT_MODE' has no worktree to resume; nothing was resumed." >&2
+    echo "park and resume carry linked worktrees between workstations. Set checkout_mode: worktree in .specify/extensions/git/git-config.yml." >&2
+    exit 1
+fi
+
+if [ "$REPO_SHAPE" = "three-leg" ]; then
+    if ! shape_leg_is_checkout "$SPEC_LEG"; then
+        echo "Error: the spec leg '$SHAPE_SPEC_PATH' is not an initialised Git checkout at '$SPEC_LEG'." >&2
+        echo "Run 'git submodule update --init' (or 'make bootstrap') in the project root first." >&2
+        exit 1
+    fi
+    if ! shape_leg_is_checkout "$CODE_LEG"; then
+        echo "Error: the code leg '$SHAPE_CODE_PATH' is not an initialised Git checkout at '$CODE_LEG'." >&2
+        echo "Run 'git submodule update --init' (or 'make bootstrap') in the project root first." >&2
+        exit 1
+    fi
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "Error: resume requires Python 3 for safe manifest and state publication." >&2
+    exit 1
+fi
+if [ "$JSON_MODE" = true ] && ! select_json_encoder >/dev/null; then
+    echo "Error: JSON output requires jq, a trusted json_escape function, or Python 3; no JSON encoder is available." >&2
+    exit 1
+fi
+
+workspace_project_id "$REPO_ROOT"
+PROJECT_ID="$WORKSPACE_PROJECT_ID"
+workspace_family_name "$REPO_ROOT" "$PROJECT_ID"
+MANIFEST_NAME="$WORKSPACE_FAMILY"
+[ -n "$MANIFEST_NAME" ] || MANIFEST_NAME="$PROJECT_ID"
+# One private workspace repository tracks work across several orgs, so the
+# manifest is filed under the owner of the declared repository: two projects
+# that share an id in different orgs never share a file. The same org also
+# selects the workspace, when the config gives that org one of its own.
+workspace_org_for "$REPO_ROOT" "$WORKSPACE_FAMILY_MANIFEST"
+# shellcheck disable=SC2153  # workspace_org_for in workspace-common.sh sets it
+MANIFEST_ORG="$WORKSPACE_ORG"
+if ! workspace_name_is_safe "$MANIFEST_ORG"; then
+    echo "Error: '$MANIFEST_ORG' is not a usable workspace org name; nothing was resumed." >&2
+    echo "The org is the owner segment of repository: in project.yaml (or in the family's family.yaml) and must match [A-Za-z0-9._-]+." >&2
+    echo "Correct that repository: value, then re-run \`make resume\`." >&2
+    exit 2
+fi
+
+WORKSPACE_RESOLVE_STATUS=0
+workspace_resolve "$WORKSPACE_ARG" "$MANIFEST_ORG" || WORKSPACE_RESOLVE_STATUS=$?
+if [ "$WORKSPACE_RESOLVE_STATUS" -eq 2 ]; then
+    workspace_refuse_invalid_config resumed resume
+    exit 2
+elif [ "$WORKSPACE_RESOLVE_STATUS" -ne 0 ]; then
+    workspace_refuse_no_config resumed resume
+    exit 2
+fi
+if ! workspace_is_checkout "$WORKSPACE_PATH"; then
+    workspace_refuse_not_a_checkout resumed
+    exit 2
+fi
+
+if ! workspace_name_is_safe "$MANIFEST_NAME"; then
+    echo "Error: '$MANIFEST_NAME' is not a usable workspace manifest name; nothing was resumed." >&2
+    echo "A manifest file is named for the family or the project id and must match [A-Za-z0-9._-]+." >&2
+    echo "Rename the id: in project.yaml (or in the family's family.yaml), then re-run \`make resume\`." >&2
+    exit 2
+fi
+MANIFEST_RELATIVE="workspaces/$MANIFEST_ORG/$MANIFEST_NAME.yaml"
+MANIFEST_PATH="$WORKSPACE_PATH/$MANIFEST_RELATIVE"
+
+# RR7 — no entry for this project.
+if ! workspace_load_project "$MANIFEST_PATH" "$PROJECT_ID"; then
+    >&2 echo "Error: $WORKSPACE_PATH/workspaces/$MANIFEST_ORG/ has no entry for project '$PROJECT_ID'; nothing was resumed."
+    >&2 echo "Either nothing was parked for it, or it was parked into a different file:"
+    >&2 echo "  grep -rn \"id: $PROJECT_ID\" $WORKSPACE_PATH/workspaces/$MANIFEST_ORG/"
+    exit 2
+fi
+
+root_relative() {
+    local path="$1"
+
+    case "$path" in
+        "$REPO_ROOT") printf '%s\n' "." ;;
+        "$REPO_ROOT"/*) printf '%s\n' "${path#"$REPO_ROOT/"}" ;;
+        *) printf '%s\n' "$path" ;;
+    esac
+}
+
+WIP_PREFIX='wip: park '
+
+commit_subject_is_wip() {
+    local tree="$1"
+    local revision="$2"
+    local subject
+
+    subject="$(git -C "$tree" log -1 --format=%s "$revision" 2>/dev/null || true)"
+    case "$subject" in
+        "$WIP_PREFIX"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+commit_has_one_parent() {
+    local tree="$1"
+    local revision="$2"
+    local parents
+
+    parents="$(git -C "$tree" log -1 --format=%P "$revision" 2>/dev/null || true)"
+    case "$parents" in
+        '') return 1 ;;
+        *' '*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# True when every commit in <from>..<to> carries the WIP subject prefix and
+# there are exactly <depth> of them: the gap a previous resume's soft reset
+# leaves behind, as opposed to real work this workspace never parked.
+wip_gap_is_ours() {
+    local tree="$1"
+    local from="$2"
+    local to="$3"
+    local depth="$4"
+    local count step
+
+    [ "$depth" -gt 0 ] || return 1
+    git -C "$tree" cat-file -e "$to^{commit}" 2>/dev/null || return 1
+    count="$(git -C "$tree" rev-list --count "$from..$to" 2>/dev/null || echo 0)"
+    [ "$count" = "$depth" ] || return 1
+    step=0
+    while [ "$step" -lt "$depth" ]; do
+        commit_subject_is_wip "$tree" "$to~$step" || return 1
+        step=$((step + 1))
+    done
+    return 0
+}
+
+leg_registered_at() {
+    local leg="$1"
+    local path="$2"
+    local index=0
+
+    LEG_REGISTERED_BRANCH=""
+    load_git_worktrees "$leg" || return 2
+    while [ "$index" -lt "${#GIT_WORKTREE_PATHS[@]}" ]; do
+        if [ "${GIT_WORKTREE_PATHS[$index]}" = "$path" ]; then
+            LEG_REGISTERED_BRANCH="${GIT_WORKTREE_BRANCH_REFS[$index]#refs/heads/}"
+            return 0
+        fi
+        index=$((index + 1))
+    done
+    return 1
+}
+
+# The legs of one manifest feature, mapped onto THIS checkout's layout.
+LEG_ROLES=()
+LEG_REPOS=()
+LEG_MOUNTS=()
+LEG_TREES=()
+LEG_COMMITS=()
+LEG_DEPTHS=()
+LEG_PUSHEDS=()
+
+collect_legs() {
+    local feature_index="$1"
+    local branch="$2"
+    local index=0
+    local role
+
+    LEG_ROLES=()
+    LEG_REPOS=()
+    LEG_MOUNTS=()
+    LEG_TREES=()
+    LEG_COMMITS=()
+    LEG_DEPTHS=()
+    LEG_PUSHEDS=()
+    while [ "$index" -lt "${#MANIFEST_LEG_ROLE[@]}" ]; do
+        if [ "${MANIFEST_LEG_FEATURE[$index]}" != "$feature_index" ]; then
+            index=$((index + 1))
+            continue
+        fi
+        role="${MANIFEST_LEG_ROLE[$index]}"
+        case "$role" in
+            spec)
+                [ "$REPO_SHAPE" = "three-leg" ] || return 1
+                LEG_REPOS[${#LEG_REPOS[@]}]="$SPEC_LEG"
+                LEG_MOUNTS[${#LEG_MOUNTS[@]}]="$SHAPE_SPEC_PATH"
+                LEG_TREES[${#LEG_TREES[@]}]="$WORKTREE_ROOT/$branch/$SHAPE_SPEC_PATH"
+                ;;
+            code)
+                [ "$REPO_SHAPE" = "three-leg" ] || return 1
+                LEG_REPOS[${#LEG_REPOS[@]}]="$CODE_LEG"
+                LEG_MOUNTS[${#LEG_MOUNTS[@]}]="$SHAPE_CODE_PATH"
+                LEG_TREES[${#LEG_TREES[@]}]="$WORKTREE_ROOT/$branch/$SHAPE_CODE_PATH"
+                ;;
+            repo)
+                [ "$REPO_SHAPE" = "single" ] || return 1
+                LEG_REPOS[${#LEG_REPOS[@]}]="$REPO_ROOT"
+                LEG_MOUNTS[${#LEG_MOUNTS[@]}]="."
+                LEG_TREES[${#LEG_TREES[@]}]="$WORKTREE_ROOT/$branch"
+                ;;
+            *) return 1 ;;
+        esac
+        LEG_ROLES[${#LEG_ROLES[@]}]="$role"
+        LEG_COMMITS[${#LEG_COMMITS[@]}]="${MANIFEST_LEG_COMMIT[$index]}"
+        LEG_DEPTHS[${#LEG_DEPTHS[@]}]="${MANIFEST_LEG_DEPTH[$index]}"
+        LEG_PUSHEDS[${#LEG_PUSHEDS[@]}]="${MANIFEST_LEG_PUSHED[$index]}"
+        index=$((index + 1))
+    done
+    [ "${#LEG_ROLES[@]}" -gt 0 ]
+}
+
+REFUSED_BRANCHES=()
+REFUSED_REASONS=()
+REFUSED_REMEDIATIONS=()
+RESUMED_COUNT=0
+RESUMED_BRANCHES=()
+
+record_refusal() {
+    REFUSED_BRANCHES[${#REFUSED_BRANCHES[@]}]="$1"
+    REFUSED_REASONS[${#REFUSED_REASONS[@]}]="$2"
+    REFUSED_REMEDIATIONS[${#REFUSED_REMEDIATIONS[@]}]="$3"
+}
+
+_git_worktree_create_temp_file || {
+    echo "Error: could not create a temporary file for the resume record." >&2
+    exit 1
+}
+RECORD_FILE="$_GIT_WORKTREE_OUTPUT_FILE"
+# shellcheck disable=SC2329  # an EXIT trap handler
+cleanup() {
+    [ -n "${RECORD_FILE:-}" ] && rm -f "$RECORD_FILE" 2>/dev/null || true
+    return 0
+}
+trap cleanup EXIT
+
+RESUME_REPORT=""
+append_report() {
+    RESUME_REPORT="$RESUME_REPORT$1
+"
+}
+
+# Which manifest features to work on.
+SELECTED_INDEXES=()
+index=0
+while [ "$index" -lt "${#MANIFEST_FEATURE_BRANCHES[@]}" ]; do
+    if [ "${#REQUESTED_BRANCHES[@]}" -eq 0 ]; then
+        SELECTED_INDEXES[${#SELECTED_INDEXES[@]}]="$index"
+    else
+        inner=0
+        while [ "$inner" -lt "${#REQUESTED_BRANCHES[@]}" ]; do
+            if [ "${REQUESTED_BRANCHES[$inner]}" = "${MANIFEST_FEATURE_BRANCHES[$index]}" ]; then
+                SELECTED_INDEXES[${#SELECTED_INDEXES[@]}]="$index"
+                break
+            fi
+            inner=$((inner + 1))
+        done
+    fi
+    index=$((index + 1))
+done
+
+if [ "${#REQUESTED_BRANCHES[@]}" -gt 0 ] \
+    && [ "${#SELECTED_INDEXES[@]}" -ne "${#REQUESTED_BRANCHES[@]}" ]; then
+    >&2 echo "Error: $MANIFEST_PATH has no entry for every --feature named; nothing was resumed."
+    >&2 echo "  look:  grep -n 'branch:' $MANIFEST_PATH"
+    exit 1
+fi
+
+if [ "${#MANIFEST_FEATURE_BRANCHES[@]}" -eq 0 ]; then
+    echo "[specify] $MANIFEST_RELATIVE records no open features for '$PROJECT_ID'; nothing to resume." >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Per feature: check everything, then touch nothing unless every check passed.
+# ---------------------------------------------------------------------------
+selection=0
+while [ "$selection" -lt "${#SELECTED_INDEXES[@]}" ]; do
+    feature_index="${SELECTED_INDEXES[$selection]}"
+    selection=$((selection + 1))
+    branch="${MANIFEST_FEATURE_BRANCHES[$feature_index]}"
+
+    if ! collect_legs "$feature_index" "$branch"; then
+        >&2 echo "Error: $branch was parked from a $MANIFEST_SHAPE project and this checkout is $REPO_SHAPE; that feature was NOT recreated."
+        >&2 echo "  look:  grep -n 'shape:' $MANIFEST_PATH"
+        record_refusal "$branch" "shape mismatch" "grep -n 'shape:' $MANIFEST_PATH"
+        continue
+    fi
+
+    refused=false
+    LEG_ACTION=()
+    leg=0
+    while [ "$leg" -lt "${#LEG_ROLES[@]}" ]; do
+        role="${LEG_ROLES[$leg]}"
+        leg_repo="${LEG_REPOS[$leg]}"
+        mount="${LEG_MOUNTS[$leg]}"
+        tree="${LEG_TREES[$leg]}"
+        parked_commit="${LEG_COMMITS[$leg]}"
+        pushed="${LEG_PUSHEDS[$leg]}"
+        LEG_ACTION[leg]="create"
+        leg=$((leg + 1))
+
+        # RR6 — parked with --no-push.
+        if [ "$pushed" != true ]; then
+            >&2 echo "Error: $branch ($role leg) was parked with --no-push; that feature was NOT recreated."
+            >&2 echo "Its parked commit $parked_commit exists only on the workstation that parked it ($MANIFEST_PARKED_ON)."
+            >&2 echo "Push it there, re-run \`make park\`, then resume here."
+            record_refusal "$branch" "parked with --no-push" "re-run \`make park\` on $MANIFEST_PARKED_ON"
+            refused=true
+            break
+        fi
+
+        # RR4 — already recreated. Not a refusal: resume is idempotent, and
+        # after the first resume the local branch is legitimately BEHIND the
+        # parked commit, so this must be decided before RR1 and RR5.
+        if leg_registered_at "$leg_repo" "$tree"; then
+            if [ "$LEG_REGISTERED_BRANCH" = "$branch" ]; then
+                LEG_ACTION[leg - 1]="present"
+                present_head="$(git -C "$tree" rev-parse --verify HEAD 2>/dev/null || true)"
+                present_depth="${LEG_DEPTHS[$((leg - 1))]}"
+                case "$present_depth" in
+                    ''|*[!0-9]*) present_depth=0 ;;
+                esac
+                if [ -n "$present_head" ] && [ "$present_head" != "$parked_commit" ] \
+                    && git -C "$tree" merge-base --is-ancestor "$present_head" "$parked_commit" 2>/dev/null \
+                    && ! wip_gap_is_ours "$tree" "$present_head" "$parked_commit" "$present_depth"; then
+                    >&2 echo "Error: the $role leg's local branch '$branch' is BEHIND the parked commit ($present_head is an ancestor of $parked_commit); that feature was NOT recreated."
+                    >&2 echo "Fast-forward it, then re-run:"
+                    >&2 echo "  git -C $(root_relative "$tree") pull --ff-only origin $branch"
+                    >&2 echo "  make resume"
+                    record_refusal "$branch" "the local branch is behind the parked commit" \
+                        "git -C $(root_relative "$tree") pull --ff-only origin $branch"
+                    refused=true
+                    break
+                fi
+                continue
+            fi
+            >&2 echo "Error: '$(root_relative "$tree")' exists and is not a registered worktree of the $role leg; that feature was NOT recreated."
+            >&2 echo "Nothing here overwrites a directory it did not create."
+            >&2 echo "  look:  git -C $mount worktree list"
+            >&2 echo "Move it aside, then re-run \`make resume\`."
+            record_refusal "$branch" "an unrelated worktree is in the way" \
+                "git -C $mount worktree list"
+            refused=true
+            break
+        fi
+
+        # RR3 — something else is already at the worktree path.
+        if [ -e "$tree" ]; then
+            >&2 echo "Error: '$(root_relative "$tree")' exists and is not a registered worktree of the $role leg; that feature was NOT recreated."
+            >&2 echo "Nothing here overwrites a directory it did not create."
+            >&2 echo "  look:  git -C $mount worktree list"
+            >&2 echo "Move it aside, then re-run \`make resume\`."
+            record_refusal "$branch" "an unrelated path is in the way" \
+                "git -C $mount worktree list"
+            refused=true
+            break
+        fi
+
+        # RR2 — the branch is gone from the remote.
+        if [ "$DRY_RUN" != true ]; then
+            GIT_TERMINAL_PROMPT=0 git -C "$leg_repo" fetch -q origin \
+                "+refs/heads/$branch:refs/remotes/origin/$branch" >/dev/null 2>&1 || true
+        fi
+        remote_tip="$(git -C "$leg_repo" rev-parse --verify --quiet "refs/remotes/origin/$branch" 2>/dev/null || true)"
+        if [ -z "$remote_tip" ]; then
+            >&2 echo "Error: $branch is no longer on origin in the $role leg; that feature was NOT recreated."
+            >&2 echo "The manifest recorded it at $parked_commit, parked $MANIFEST_PARKED_AT on $MANIFEST_PARKED_ON."
+            >&2 echo "If the feature landed, delete its entry:"
+            >&2 echo "  $WORKSPACE_PATH/$MANIFEST_RELATIVE  ->  remove the \`- branch: $branch\` block"
+            >&2 echo "If it was deleted by mistake, push it again from the workstation that parked it."
+            record_refusal "$branch" "gone from origin" \
+                "remove the \`- branch: $branch\` block from $MANIFEST_RELATIVE"
+            refused=true
+            break
+        fi
+
+        # RR1 — divergence. The ruling: nothing is ever reset over commits
+        # this workspace did not park.
+        if [ "$remote_tip" != "$parked_commit" ]; then
+            >&2 echo "Error: $branch ($role leg) has moved since it was parked; that feature was NOT recreated."
+            >&2 echo "  parked commit  $parked_commit   (parked $MANIFEST_PARKED_AT on $MANIFEST_PARKED_ON)"
+            >&2 echo "  current tip    $remote_tip      (origin/$branch)"
+            >&2 echo "Nothing is ever reset over commits this workspace did not park. Reconcile by hand:"
+            >&2 echo "  git -C $mount fetch origin $branch"
+            >&2 echo "  git -C $mount log --oneline $parked_commit..origin/$branch"
+            >&2 echo "  git -C $mount worktree add -b $branch $WORKTREE_ROOT_RAW/$branch/$mount origin/$branch"
+            >&2 echo "  # then decide: rebase the parked WIP onto the new tip, or discard it"
+            record_refusal "$branch" "divergence" \
+                "git -C $mount log --oneline $parked_commit..origin/$branch"
+            refused=true
+            break
+        fi
+
+        # RR5 — a local branch that is not the parked commit. Two cases, and
+        # they call for opposite remediations: a branch this workstation left
+        # BEHIND is fast-forwarded, a branch that DIVERGED carries local
+        # commits the parked commit does not contain and nothing here may
+        # discard them.
+        local_sha="$(git -C "$leg_repo" rev-parse --verify --quiet "refs/heads/$branch" 2>/dev/null || true)"
+        if [ -n "$local_sha" ] && [ "$local_sha" != "$parked_commit" ]; then
+            if git -C "$leg_repo" merge-base --is-ancestor "$local_sha" "$parked_commit" 2>/dev/null; then
+                >&2 echo "Error: the $role leg's local branch '$branch' is BEHIND the parked commit ($local_sha is an ancestor of $parked_commit); that feature was NOT recreated."
+                >&2 echo "Fast-forward it, then re-run:"
+                >&2 echo "  git -C $mount fetch origin $branch:$branch"
+                >&2 echo "  make resume"
+                record_refusal "$branch" "the local branch is behind the parked commit" \
+                    "git -C $mount fetch origin $branch:$branch"
+                refused=true
+                break
+            fi
+            >&2 echo "Error: the $role leg already has a local branch '$branch' at $local_sha, not the parked commit $parked_commit; that feature was NOT recreated."
+            >&2 echo "  git -C $mount log --oneline $parked_commit..$branch"
+            >&2 echo "Rename or delete that branch, then re-run \`make resume\`."
+            record_refusal "$branch" "local branch is not the parked commit" \
+                "git -C $mount log --oneline $parked_commit..$branch"
+            refused=true
+            break
+        fi
+
+        if [ -n "$local_sha" ]; then
+            LEG_ACTION[leg - 1]="attach"
+        else
+            LEG_ACTION[leg - 1]="create"
+        fi
+    done
+    [ "$refused" = false ] || continue
+
+    if [ "$DRY_RUN" = true ]; then
+        append_report "RESUMED: $branch (--dry-run)"
+        workspace_record_section "$RECORD_FILE" feature
+        workspace_record_put "$RECORD_FILE" branch "$branch"
+        leg=0
+        while [ "$leg" -lt "${#LEG_ROLES[@]}" ]; do
+            workspace_record_section "$RECORD_FILE" leg
+            workspace_record_put "$RECORD_FILE" role "${LEG_ROLES[$leg]}"
+            workspace_record_put "$RECORD_FILE" path "$(root_relative "${LEG_TREES[$leg]}")"
+            workspace_record_put "$RECORD_FILE" head "${LEG_COMMITS[$leg]}"
+            workspace_record_put "$RECORD_FILE" action "${LEG_ACTION[$leg]}"
+            append_report "  ${LEG_ROLES[$leg]}  $(root_relative "${LEG_TREES[$leg]}")  ${LEG_COMMITS[$leg]}  would ${LEG_ACTION[$leg]}"
+            leg=$((leg + 1))
+        done
+        RESUMED_COUNT=$((RESUMED_COUNT + 1))
+        RESUMED_BRANCHES[${#RESUMED_BRANCHES[@]}]="$branch"
+        continue
+    fi
+
+    # Create. A failure in a later leg rolls back the earlier ones, exactly as
+    # shape_rollback_spec_worktree does for feature creation.
+    CREATED_TREES=()
+    CREATED_BRANCH_IN=()
+    mkdir -p "$WORKTREE_ROOT/$branch" 2>/dev/null || true
+    leg=0
+    while [ "$leg" -lt "${#LEG_ROLES[@]}" ]; do
+        role="${LEG_ROLES[$leg]}"
+        leg_repo="${LEG_REPOS[$leg]}"
+        tree="${LEG_TREES[$leg]}"
+        action="${LEG_ACTION[$leg]}"
+        leg=$((leg + 1))
+        case "$action" in
+            present)
+                echo "[specify] $branch ($role): worktree already registered at $(root_relative "$tree"); left as it is." >&2
+                continue
+                ;;
+            attach)
+                if ! worktree_error="$(git -C "$leg_repo" worktree add "$tree" "$branch" 2>&1)"; then
+                    >&2 echo "Error: could not add the $role leg worktree '$(root_relative "$tree")' for '$branch'; that feature was NOT recreated."
+                    >&2 printf '  %s\n' "$worktree_error"
+                    record_refusal "$branch" "git worktree add failed" \
+                        "git -C ${LEG_MOUNTS[$((leg - 1))]} worktree add $(root_relative "$tree") $branch"
+                    refused=true
+                    break
+                fi
+                CREATED_TREES[${#CREATED_TREES[@]}]="$tree"
+                CREATED_BRANCH_IN[${#CREATED_BRANCH_IN[@]}]=""
+                ;;
+            create)
+                if ! worktree_error="$(git -C "$leg_repo" worktree add -b "$branch" "$tree" "origin/$branch" 2>&1)"; then
+                    >&2 echo "Error: could not create the $role leg worktree '$(root_relative "$tree")' from 'origin/$branch'; that feature was NOT recreated."
+                    >&2 printf '  %s\n' "$worktree_error"
+                    record_refusal "$branch" "git worktree add failed" \
+                        "git -C ${LEG_MOUNTS[$((leg - 1))]} worktree add -b $branch $(root_relative "$tree") origin/$branch"
+                    refused=true
+                    break
+                fi
+                CREATED_TREES[${#CREATED_TREES[@]}]="$tree"
+                CREATED_BRANCH_IN[${#CREATED_BRANCH_IN[@]}]="$leg_repo"
+                ;;
+        esac
+    done
+    if [ "$refused" = true ]; then
+        >&2 echo "[specify] Rolling back the worktrees this run created for '$branch'."
+        undo=0
+        while [ "$undo" -lt "${#CREATED_TREES[@]}" ]; do
+            undo_tree="${CREATED_TREES[$undo]}"
+            undo_repo="${CREATED_BRANCH_IN[$undo]}"
+            undo=$((undo + 1))
+            owner="$REPO_ROOT"
+            [ -n "$undo_repo" ] && owner="$undo_repo"
+            git -C "$owner" worktree remove --force "$undo_tree" >/dev/null 2>&1 \
+                || rm -rf "$undo_tree" >/dev/null 2>&1 || true
+            git -C "$owner" worktree prune >/dev/null 2>&1 || true
+            if [ -n "$undo_repo" ]; then
+                git -C "$undo_repo" branch -D "$branch" >/dev/null 2>&1 || true
+            fi
+        done
+        rmdir "$WORKTREE_ROOT/$branch" >/dev/null 2>&1 || true
+        continue
+    fi
+
+    # Un-commit the parked WIP. Three facts, never the prefix alone.
+    workspace_record_section "$RECORD_FILE" feature
+    workspace_record_put "$RECORD_FILE" branch "$branch"
+    append_report "RESUMED: $branch"
+    leg=0
+    while [ "$leg" -lt "${#LEG_ROLES[@]}" ]; do
+        role="${LEG_ROLES[$leg]}"
+        tree="${LEG_TREES[$leg]}"
+        parked_commit="${LEG_COMMITS[$leg]}"
+        depth="${LEG_DEPTHS[$leg]}"
+        leg=$((leg + 1))
+        case "$depth" in
+            ''|*[!0-9]*) depth=0 ;;
+        esac
+        head_now="$(git -C "$tree" rev-parse --verify HEAD 2>/dev/null || true)"
+        short_head="$(git -C "$tree" rev-parse --short HEAD 2>/dev/null || true)"
+        note="clean"
+        if [ "$depth" -gt 0 ]; then
+            if [ "$head_now" != "$parked_commit" ]; then
+                echo "[specify] Warning: $branch ($role): HEAD is $head_now, not the parked commit $parked_commit; the parked WIP was NOT un-committed." >&2
+                note="left as it is"
+            else
+                recognised=true
+                step=0
+                while [ "$step" -lt "$depth" ]; do
+                    if ! commit_subject_is_wip "$tree" "HEAD~$step" \
+                        || ! commit_has_one_parent "$tree" "HEAD~$step"; then
+                        recognised=false
+                        break
+                    fi
+                    step=$((step + 1))
+                done
+                if [ "$recognised" != true ]; then
+                    echo "[specify] Warning: $branch ($role): the $depth tip commit(s) are not this workspace's parked WIP; nothing was reset." >&2
+                    note="left as it is"
+                else
+                    plural="commits"
+                    [ "$depth" -eq 1 ] && plural="commit"
+                    git -C "$tree" reset --soft "HEAD~$depth"
+                    if [ "$KEEP_STAGED" = true ]; then
+                        note="un-committed $depth WIP $plural, staged"
+                    else
+                        git -C "$tree" reset -q
+                        note="un-committed $depth WIP $plural"
+                    fi
+                    short_head="$(git -C "$tree" rev-parse --short HEAD 2>/dev/null || true)"
+                fi
+            fi
+        fi
+        workspace_record_section "$RECORD_FILE" leg
+        workspace_record_put "$RECORD_FILE" role "$role"
+        workspace_record_put "$RECORD_FILE" path "$(root_relative "$tree")"
+        workspace_record_put "$RECORD_FILE" head "$(git -C "$tree" rev-parse --verify HEAD 2>/dev/null || true)"
+        workspace_record_put "$RECORD_FILE" note "$note"
+        append_report "  $role  $(root_relative "$tree")  $short_head  $note"
+    done
+    RESUMED_COUNT=$((RESUMED_COUNT + 1))
+    RESUMED_BRANCHES[${#RESUMED_BRANCHES[@]}]="$branch"
+done
+
+# ---------------------------------------------------------------------------
+# The active feature: feature.json (three-leg only) and the state file.
+# ---------------------------------------------------------------------------
+ACTIVE_FEATURE="$MANIFEST_ACTIVE_FEATURE"
+if [ -n "$ACTIVE_FEATURE" ]; then
+    known=false
+    index=0
+    while [ "$index" -lt "${#RESUMED_BRANCHES[@]}" ]; do
+        if [ "${RESUMED_BRANCHES[$index]}" = "$ACTIVE_FEATURE" ]; then
+            known=true
+            break
+        fi
+        index=$((index + 1))
+    done
+    if [ "$known" = false ]; then
+        ACTIVE_FEATURE=""
+        if [ "${#RESUMED_BRANCHES[@]}" -gt 0 ]; then
+            ACTIVE_FEATURE="${RESUMED_BRANCHES[0]}"
+        fi
+    fi
+fi
+
+FEATURE_JSON_VALUE=""
+STATE_FILE_VALUE=""
+if [ -n "$ACTIVE_FEATURE" ] && [ "$DRY_RUN" != true ]; then
+    if [ "$REPO_SHAPE" = "three-leg" ]; then
+        shape_feature_paths_for "$REPO_ROOT" "$WORKTREE_ROOT/$ACTIVE_FEATURE" "$ACTIVE_FEATURE"
+        FEATURE_JSON_VALUE="$SHAPE_FEATURE_DIR_RELATIVE"
+        previous=""
+        if [ -f "$REPO_ROOT/.specify/feature.json" ]; then
+            previous="$(python3 - "$REPO_ROOT/.specify/feature.json" <<'PY'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as stream:
+        payload = json.load(stream)
+except (OSError, ValueError):
+    raise SystemExit(0)
+if isinstance(payload, dict):
+    value = payload.get("feature_directory", "")
+    if isinstance(value, str):
+        sys.stdout.write(value)
+PY
+            )" || previous=""
+        fi
+        if [ -n "$previous" ] && [ "$previous" != "$FEATURE_JSON_VALUE" ]; then
+            echo "[specify] Warning: .specify/feature.json named '$previous'; rewritten to the parked active feature '$ACTIVE_FEATURE'." >&2
+            if [ -d "$REPO_ROOT/$previous" ]; then
+                echo "[specify] The manifest wins: '$ACTIVE_FEATURE' is what travelled, and the other feature is recreated but not selected." >&2
+            fi
+        fi
+        mkdir -p "$SHAPE_FEATURE_DIR" 2>/dev/null || true
+        shape_persist_feature_json "$FEATURE_JSON_VALUE" || {
+            >&2 echo "Error: could not write .specify/feature.json."
+            exit 1
+        }
+    fi
+
+    if STATE_COMMON_DIR="$(resolve_git_common_dir)"; then
+        STATE_FILE="$STATE_COMMON_DIR/speckit-last-worktree.json"
+        if assert_state_file_safe "$STATE_FILE"; then
+            active_worktree="$WORKTREE_ROOT/$ACTIVE_FEATURE"
+            if write_last_worktree_state "$ACTIVE_FEATURE" "$active_worktree" "$BASE_BRANCH"; then
+                STATE_FILE_VALUE="$(root_relative "$STATE_FILE")"
+            else
+                >&2 echo "[specify] Warning: could not publish $(root_relative "$STATE_FILE")."
+            fi
+        fi
+    fi
+fi
+
+# The recreated worktrees must not show up in the root's `git status`.
+if [ "${#RESUMED_BRANCHES[@]}" -gt 0 ] && [ "$REPO_SHAPE" = "three-leg" ]; then
+    if ! { [ -f "$REPO_ROOT/.gitignore" ] \
+        && grep -Eq "^/?$WORKTREE_ROOT_RAW/?$" "$REPO_ROOT/.gitignore"; }; then
+        echo "[specify] Warning: '$REPO_ROOT/.gitignore' does not ignore /$WORKTREE_ROOT_RAW/; the recreated worktrees will show in \`git status\` at the root. Add the line, or re-run setup-openspeckit." >&2
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Output.
+# ---------------------------------------------------------------------------
+HEADER_FILE="$RECORD_FILE.header"
+{
+    printf 'repo_shape\t%s\n' "$REPO_SHAPE"
+    printf 'project_id\t%s\n' "$PROJECT_ID"
+    printf 'workspace_path\t%s\n' "$WORKSPACE_PATH"
+    printf 'workspace_source\t%s\n' "$WORKSPACE_SOURCE_LABEL"
+    printf 'manifest_path\t%s\n' "$MANIFEST_PATH"
+    if [ -n "$ACTIVE_FEATURE" ]; then
+        printf 'active_feature\t%s\n' "$ACTIVE_FEATURE"
+    fi
+    if [ -n "$FEATURE_JSON_VALUE" ]; then
+        printf 'feature_json\t%s\n' "$FEATURE_JSON_VALUE"
+    fi
+    if [ -n "$STATE_FILE_VALUE" ]; then
+        printf 'state_file\t%s\n' "$STATE_FILE_VALUE"
+    fi
+    if [ "$DRY_RUN" = true ]; then
+        printf 'dry_run\ttrue\n'
+    fi
+} > "$HEADER_FILE"
+cat "$RECORD_FILE" >> "$HEADER_FILE"
+index=0
+while [ "$index" -lt "${#REFUSED_BRANCHES[@]}" ]; do
+    {
+        printf '[refused]\n'
+        printf 'branch\t%s\n' "${REFUSED_BRANCHES[$index]}"
+        printf 'reason\t%s\n' "${REFUSED_REASONS[$index]}"
+        printf 'remediation\t%s\n' "${REFUSED_REMEDIATIONS[$index]}"
+    } >> "$HEADER_FILE"
+    index=$((index + 1))
+done
+mv "$HEADER_FILE" "$RECORD_FILE"
+
+if [ "$JSON_MODE" = true ]; then
+    workspace_emit_json "$RECORD_FILE" RESUMED
+else
+    echo "REPO_SHAPE: $REPO_SHAPE"
+    echo "PROJECT_ID: $PROJECT_ID"
+    echo "MANIFEST: $MANIFEST_PATH"
+    if [ -n "$RESUME_REPORT" ]; then
+        printf '%s' "$RESUME_REPORT"
+    fi
+    if [ -n "$FEATURE_JSON_VALUE" ]; then
+        echo "FEATURE_JSON: $FEATURE_JSON_VALUE"
+    fi
+    if [ -n "$STATE_FILE_VALUE" ]; then
+        echo "STATE_FILE: $STATE_FILE_VALUE (BRANCH_NAME=$ACTIVE_FEATURE)"
+    fi
+    index=0
+    while [ "$index" -lt "${#REFUSED_BRANCHES[@]}" ]; do
+        echo "REFUSED: ${REFUSED_BRANCHES[$index]} — ${REFUSED_REASONS[$index]}"
+        index=$((index + 1))
+    done
+fi
+
+if [ "${#REFUSED_BRANCHES[@]}" -eq 0 ]; then
+    exit 0
+fi
+if [ "$RESUMED_COUNT" -eq 0 ]; then
+    exit 2
+fi
+exit 3

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/resume.sh
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/resume.sh
@@ -509,7 +509,7 @@ while [ "$selection" -lt "${#SELECTED_INDEXES[@]}" ]; do
         if [ "$remote_tip" != "$parked_commit" ]; then
             >&2 echo "Error: $branch ($role leg) has moved since it was parked; that feature was NOT recreated."
             >&2 echo "  parked commit  $parked_commit   (parked $MANIFEST_PARKED_AT on $MANIFEST_PARKED_ON)"
-            >&2 echo "  current tip    $remote_tip      (origin/$branch)"
+            >&2 echo "  current tip    $remote_tip   (origin/$branch)"
             >&2 echo "Nothing is ever reset over commits this workspace did not park. Reconcile by hand:"
             >&2 echo "  git -C $mount fetch origin $branch"
             >&2 echo "  git -C $mount log --oneline $parked_commit..origin/$branch"

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/resume.sh
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/resume.sh
@@ -357,9 +357,15 @@ _git_worktree_create_temp_file || {
     exit 1
 }
 RECORD_FILE="$_GIT_WORKTREE_OUTPUT_FILE"
+_git_worktree_create_temp_file || {
+    echo "Error: could not create a temporary file for the resume record." >&2
+    exit 1
+}
+HEADER_FILE="$_GIT_WORKTREE_OUTPUT_FILE"
 # shellcheck disable=SC2329  # an EXIT trap handler
 cleanup() {
     [ -n "${RECORD_FILE:-}" ] && rm -f "$RECORD_FILE" 2>/dev/null || true
+    [ -n "${HEADER_FILE:-}" ] && rm -f "$HEADER_FILE" 2>/dev/null || true
     return 0
 }
 trap cleanup EXIT
@@ -577,7 +583,8 @@ while [ "$selection" -lt "${#SELECTED_INDEXES[@]}" ]; do
     # Create. A failure in a later leg rolls back the earlier ones, exactly as
     # shape_rollback_spec_worktree does for feature creation.
     CREATED_TREES=()
-    CREATED_BRANCH_IN=()
+    CREATED_OWNERS=()
+    CREATED_BRANCH_NEW=()
     mkdir -p "$WORKTREE_ROOT/$branch" 2>/dev/null || true
     leg=0
     while [ "$leg" -lt "${#LEG_ROLES[@]}" ]; do
@@ -601,7 +608,8 @@ while [ "$selection" -lt "${#SELECTED_INDEXES[@]}" ]; do
                     break
                 fi
                 CREATED_TREES[${#CREATED_TREES[@]}]="$tree"
-                CREATED_BRANCH_IN[${#CREATED_BRANCH_IN[@]}]=""
+                CREATED_OWNERS[${#CREATED_OWNERS[@]}]="$leg_repo"
+                CREATED_BRANCH_NEW[${#CREATED_BRANCH_NEW[@]}]=false
                 ;;
             create)
                 if ! worktree_error="$(git -C "$leg_repo" worktree add -b "$branch" "$tree" "origin/$branch" 2>&1)"; then
@@ -613,7 +621,8 @@ while [ "$selection" -lt "${#SELECTED_INDEXES[@]}" ]; do
                     break
                 fi
                 CREATED_TREES[${#CREATED_TREES[@]}]="$tree"
-                CREATED_BRANCH_IN[${#CREATED_BRANCH_IN[@]}]="$leg_repo"
+                CREATED_OWNERS[${#CREATED_OWNERS[@]}]="$leg_repo"
+                CREATED_BRANCH_NEW[${#CREATED_BRANCH_NEW[@]}]=true
                 ;;
         esac
     done
@@ -622,15 +631,19 @@ while [ "$selection" -lt "${#SELECTED_INDEXES[@]}" ]; do
         undo=0
         while [ "$undo" -lt "${#CREATED_TREES[@]}" ]; do
             undo_tree="${CREATED_TREES[$undo]}"
-            undo_repo="${CREATED_BRANCH_IN[$undo]}"
+            # The owner is always the LEG repository that registered the
+            # worktree. Naming the assembly root instead makes `worktree
+            # remove` fail, the fallback `rm -rf` take the directory, and the
+            # leg keep a phantom registration a later resume reads as
+            # "already registered" for a path that is not there.
+            owner="${CREATED_OWNERS[$undo]}"
+            undo_new_branch="${CREATED_BRANCH_NEW[$undo]}"
             undo=$((undo + 1))
-            owner="$REPO_ROOT"
-            [ -n "$undo_repo" ] && owner="$undo_repo"
             git -C "$owner" worktree remove --force "$undo_tree" >/dev/null 2>&1 \
                 || rm -rf "$undo_tree" >/dev/null 2>&1 || true
             git -C "$owner" worktree prune >/dev/null 2>&1 || true
-            if [ -n "$undo_repo" ]; then
-                git -C "$undo_repo" branch -D "$branch" >/dev/null 2>&1 || true
+            if [ "$undo_new_branch" = true ]; then
+                git -C "$owner" branch -D "$branch" >/dev/null 2>&1 || true
             fi
         done
         rmdir "$WORKTREE_ROOT/$branch" >/dev/null 2>&1 || true
@@ -780,7 +793,6 @@ fi
 # ---------------------------------------------------------------------------
 # Output.
 # ---------------------------------------------------------------------------
-HEADER_FILE="$RECORD_FILE.header"
 {
     printf 'repo_shape\t%s\n' "$REPO_SHAPE"
     printf 'project_id\t%s\n' "$PROJECT_ID"

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/workspace-common.sh
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/workspace-common.sh
@@ -1,0 +1,1269 @@
+#!/usr/bin/env bash
+# speckit-overlay-shape: 1
+# Workspace helpers for park.sh and resume.sh.
+#
+# Sourced, never executed: this file sets no shell options and runs nothing at
+# load time. It requires git-common.sh to have been sourced first, for
+# _shape_set_trimmed and _shape_set_scalar.
+#
+# The workspace is the PRIVATE repository the person owns and names once in
+# ${AGENT_PROTOCOL_ROOT:-$HOME/.agents}/workspace.yaml. Its workspaces/
+# directory holds one manifest per family or standalone project. Nothing here
+# reads or writes a handoff document, and nothing here ever force-pushes:
+# park.sh owns the single leased push in this object, behind
+# --retire-parked-wip.
+#
+# shellcheck disable=SC2034  # the WORKSPACE_* and MANIFEST_* results are
+# consumed by the scripts that source this file.
+
+WORKSPACE_LOCK_DIR=""
+
+# The user-level config path, honouring AGENT_PROTOCOL_ROOT the way
+# setup-openspeckit does.
+workspace_config_file() {
+    printf '%s\n' "${AGENT_PROTOCOL_ROOT:-$HOME/.agents}/workspace.yaml"
+}
+
+# Read one indent-zero scalar out of a small YAML file with parameter
+# expansion only: no YAML library, no Python per line, no forks per line. This
+# is load_repo_shape's reader, narrowed to top-level keys.
+workspace_read_scalar() {
+    local file="$1"
+    local want="$2"
+    local raw content trimmed indent_ws key
+
+    WORKSPACE_SCALAR=""
+    [ -f "$file" ] || return 1
+    while IFS= read -r raw || [ -n "$raw" ]; do
+        content="${raw%%#*}"
+        _shape_set_trimmed "$content"
+        trimmed="$_SHAPE_TRIMMED"
+        [ -n "$trimmed" ] || continue
+        indent_ws="${content%%[![:space:]]*}"
+        [ "${#indent_ws}" -eq 0 ] || continue
+        key="${trimmed%%:*}"
+        [ "$key" != "$trimmed" ] || continue
+        [ "$key" = "$want" ] || continue
+        _shape_set_scalar "${trimmed#*:}"
+        WORKSPACE_SCALAR="$_SHAPE_SCALAR"
+        return 0
+    done < "$file"
+    return 1
+}
+
+# True when a family manifest's members: block names this project id. Read the
+# same way: the block is every line indented deeper than the members: key.
+workspace_members_contains() {
+    local file="$1"
+    local want="$2"
+    local raw content trimmed indent_ws indent key in_members=false
+
+    [ -f "$file" ] || return 1
+    while IFS= read -r raw || [ -n "$raw" ]; do
+        content="${raw%%#*}"
+        _shape_set_trimmed "$content"
+        trimmed="$_SHAPE_TRIMMED"
+        [ -n "$trimmed" ] || continue
+        indent_ws="${content%%[![:space:]]*}"
+        indent=${#indent_ws}
+        if [ "$indent" -eq 0 ]; then
+            key="${trimmed%%:*}"
+            if [ "$key" != "$trimmed" ] && [ "$key" = "members" ]; then
+                in_members=true
+            else
+                in_members=false
+            fi
+            continue
+        fi
+        [ "$in_members" = true ] || continue
+        _shape_set_trimmed "${trimmed#- }"
+        trimmed="$_SHAPE_TRIMMED"
+        key="${trimmed%%:*}"
+        [ "$key" != "$trimmed" ] || continue
+        [ "$key" = "id" ] || continue
+        _shape_set_scalar "${trimmed#*:}"
+        [ "$_SHAPE_SCALAR" = "$want" ] || continue
+        return 0
+    done < "$file"
+    return 1
+}
+
+# shellcheck disable=SC2088  # a literal leading ~ is what is matched here
+# ---------------------------------------------------------------------------
+# The optional per-org override in the user config.
+#
+#   repository: opensoft/brett-wip
+#   path: ~/projects/brett-wip
+#   orgs:
+#     MedxSoft:
+#       repository: MedxSoft/brett-wip
+#       path: ~/projects/MedxSoft-wip
+#
+# Returns 0 and sets WORKSPACE_ORG_PATH / WORKSPACE_ORG_REPOSITORY when <org>
+# has an override, 1 when there is no orgs: block or no entry for it, and 2
+# when the block is malformed, with the reason in WORKSPACE_CONFIG_ERROR. A
+# malformed block is a REFUSAL and never a silent fall-through to the default:
+# indexing a confidential org's work in the wrong repository is the one thing
+# this override exists to prevent.
+# ---------------------------------------------------------------------------
+workspace_read_org_override() {
+    local file="$1"
+    local want="$2"
+    local raw content trimmed indent_ws indent key value
+    local in_orgs=false org_col=-1 key_col=-1
+    local current="" found=false found_repository="" found_path=""
+
+    WORKSPACE_ORG_PATH=""
+    WORKSPACE_ORG_REPOSITORY=""
+    WORKSPACE_CONFIG_ERROR=""
+    [ -n "$want" ] || return 1
+    [ -f "$file" ] || return 1
+
+    while IFS= read -r raw || [ -n "$raw" ]; do
+        content="${raw%%#*}"
+        _shape_set_trimmed "$content"
+        trimmed="$_SHAPE_TRIMMED"
+        [ -n "$trimmed" ] || continue
+        indent_ws="${content%%[![:space:]]*}"
+        indent=${#indent_ws}
+
+        if [ "$indent" -eq 0 ]; then
+            [ "$in_orgs" = false ] || break
+            key="${trimmed%%:*}"
+            [ "$key" != "$trimmed" ] || continue
+            [ "$key" = "orgs" ] || continue
+            _shape_set_scalar "${trimmed#*:}"
+            if [ -n "$_SHAPE_SCALAR" ]; then
+                WORKSPACE_CONFIG_ERROR="orgs: must be a map of org names, not a scalar"
+                return 2
+            fi
+            in_orgs=true
+            org_col=-1
+            key_col=-1
+            continue
+        fi
+
+        [ "$in_orgs" = true ] || continue
+
+        case "$trimmed" in
+            '-'|'- '*)
+                WORKSPACE_CONFIG_ERROR="orgs: must be a map of org names, not a list"
+                return 2
+                ;;
+        esac
+        key="${trimmed%%:*}"
+        if [ "$key" = "$trimmed" ]; then
+            WORKSPACE_CONFIG_ERROR="'$trimmed' is not a 'key: value' line"
+            return 2
+        fi
+        _shape_set_scalar "${trimmed#*:}"
+        value="$_SHAPE_SCALAR"
+
+        [ "$org_col" -ge 0 ] || org_col=$indent
+        if [ "$indent" -lt "$org_col" ]; then
+            WORKSPACE_CONFIG_ERROR="'$key' is indented above the org names"
+            return 2
+        fi
+        if [ "$indent" -eq "$org_col" ]; then
+            if [ -n "$value" ]; then
+                WORKSPACE_CONFIG_ERROR="org '$key' must be a block with repository: and path:"
+                return 2
+            fi
+            current="$key"
+            key_col=-1
+            continue
+        fi
+        if [ -z "$current" ]; then
+            WORKSPACE_CONFIG_ERROR="'$key' appears before any org name"
+            return 2
+        fi
+        [ "$key_col" -ge 0 ] || key_col=$indent
+        if [ "$indent" -ne "$key_col" ]; then
+            WORKSPACE_CONFIG_ERROR="'$key' is indented inconsistently under '$current'"
+            return 2
+        fi
+        case "$key" in
+            repository|path) ;;
+            *)
+                WORKSPACE_CONFIG_ERROR="'$key' is not a key of an org override; only repository: and path: are"
+                return 2
+                ;;
+        esac
+        if [ -z "$value" ]; then
+            WORKSPACE_CONFIG_ERROR="'$key' under '$current' has no value"
+            return 2
+        fi
+        if [ "$current" = "$want" ]; then
+            found=true
+            case "$key" in
+                repository) found_repository="$value" ;;
+                path) found_path="$value" ;;
+            esac
+        fi
+    done < "$file"
+
+    [ "$found" = true ] || return 1
+    if [ -z "$found_path" ]; then
+        WORKSPACE_CONFIG_ERROR="org '$want' has no path:"
+        return 2
+    fi
+    WORKSPACE_ORG_PATH="$found_path"
+    WORKSPACE_ORG_REPOSITORY="$found_repository"
+    return 0
+}
+
+# shellcheck disable=SC2088  # a literal leading ~ is what is matched here
+workspace_expand_home() {
+    local path="$1"
+
+    case "$path" in
+        '~') printf '%s\n' "$HOME" ;;
+        '~/'*) printf '%s\n' "$HOME/${path#\~/}" ;;
+        *) printf '%s\n' "$path" ;;
+    esac
+}
+
+# Which workspace checkout this project is recorded in, for a project whose
+# org is <org>. THE RESOLVED ORDER:
+#
+#   1. --workspace <path>          wins over everything
+#   2. $SPECKIT_WORKSPACE_PATH     a whole-run override
+#   3. orgs.<org> in the config    an org whose work must stay inside that org
+#   4. the config's top-level      the default workspace
+#   5. nothing                     R1
+#
+# Returns 1 when nothing names a path (the caller prints R1) and 2 when the
+# config's orgs: block is malformed (the caller prints workspace-config-invalid).
+workspace_resolve() {
+    local cli_path="$1"
+    local org="$2"
+    local override_status=0
+
+    WORKSPACE_PATH=""
+    WORKSPACE_REPOSITORY=""
+    WORKSPACE_SOURCE=""
+    WORKSPACE_SOURCE_LABEL=""
+    WORKSPACE_CONFIG_FILE="$(workspace_config_file)"
+
+    if [ -n "$cli_path" ]; then
+        WORKSPACE_PATH="$(workspace_expand_home "$cli_path")"
+        WORKSPACE_SOURCE="--workspace"
+        WORKSPACE_SOURCE_LABEL="--workspace"
+    elif [ -n "${SPECKIT_WORKSPACE_PATH:-}" ]; then
+        WORKSPACE_PATH="$(workspace_expand_home "$SPECKIT_WORKSPACE_PATH")"
+        WORKSPACE_SOURCE="SPECKIT_WORKSPACE_PATH"
+        WORKSPACE_SOURCE_LABEL="SPECKIT_WORKSPACE_PATH"
+    else
+        override_status=0
+        workspace_read_org_override "$WORKSPACE_CONFIG_FILE" "$org" || override_status=$?
+        [ "$override_status" -ne 2 ] || return 2
+        if [ "$override_status" -eq 0 ]; then
+            WORKSPACE_PATH="$(workspace_expand_home "$WORKSPACE_ORG_PATH")"
+            WORKSPACE_REPOSITORY="$WORKSPACE_ORG_REPOSITORY"
+            WORKSPACE_SOURCE="$WORKSPACE_CONFIG_FILE"
+            WORKSPACE_SOURCE_LABEL="orgs.$org override"
+        elif workspace_read_scalar "$WORKSPACE_CONFIG_FILE" path \
+            && [ -n "$WORKSPACE_SCALAR" ]; then
+            WORKSPACE_PATH="$(workspace_expand_home "$WORKSPACE_SCALAR")"
+            WORKSPACE_SOURCE="$WORKSPACE_CONFIG_FILE"
+            WORKSPACE_SOURCE_LABEL="default"
+        else
+            return 1
+        fi
+    fi
+
+    # R2's remediation must name the clone command for the repository that was
+    # actually chosen, so a fresh machine is told which <org>/<user>-wip to get.
+    if [ -n "${SPECKIT_WORKSPACE_REPOSITORY:-}" ]; then
+        WORKSPACE_REPOSITORY="$SPECKIT_WORKSPACE_REPOSITORY"
+    elif [ -z "$WORKSPACE_REPOSITORY" ] \
+        && workspace_read_scalar "$WORKSPACE_CONFIG_FILE" repository; then
+        WORKSPACE_REPOSITORY="$WORKSPACE_SCALAR"
+    fi
+    return 0
+}
+
+workspace_is_checkout() {
+    local path="$1"
+
+    [ -d "$path" ] || return 1
+    { [ -d "$path/.git" ] || [ -f "$path/.git" ]; } || return 1
+    git -C "$path" rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
+# R1. The remediation names ~/.agents/workspace.yaml literally, because that
+# is the path a person types; AGENT_PROTOCOL_ROOT moves the file for a
+# non-standard install and workspace_config_file follows it.
+workspace_refuse_no_config() {
+    local past="$1"
+    local verb="$2"
+
+    >&2 echo "Error: no workspace repository is configured; nothing was $past."
+    >&2 echo "park records the feature list in a private repository you own. Name it once in"
+    # shellcheck disable=SC2088  # the literal path a person types, not a glob
+    >&2 echo "~/.agents/workspace.yaml:"
+    >&2 echo ""
+    >&2 echo "  repository: <owner>/<repo>"
+    >&2 echo "  path: ~/projects/<repo>"
+    >&2 echo ""
+    >&2 echo "Then re-run \`make $verb\`."
+}
+
+# workspace-config-invalid.
+workspace_refuse_invalid_config() {
+    local past="$1"
+    local verb="$2"
+
+    >&2 echo "Error: workspace-config-invalid: the orgs: block in $WORKSPACE_CONFIG_FILE is malformed ($WORKSPACE_CONFIG_ERROR); nothing was $past."
+    >&2 echo "An org override is two keys under the org's name:"
+    >&2 echo ""
+    >&2 echo "  orgs:"
+    >&2 echo "    <Org>:"
+    >&2 echo "      repository: <owner>/<repo>"
+    >&2 echo "      path: ~/projects/<repo>"
+    >&2 echo ""
+    >&2 echo "Refusing rather than falling back to the default workspace: a confidential org's work"
+    >&2 echo "must never be indexed in the wrong repository. Fix the file, then re-run \`make $verb\`."
+}
+
+# R2.
+workspace_refuse_not_a_checkout() {
+    local past="$1"
+    local repository="$WORKSPACE_REPOSITORY"
+
+    [ -n "$repository" ] || repository="<owner>/<repo>"
+    >&2 echo "Error: '$WORKSPACE_PATH', named by $WORKSPACE_SOURCE as your workspace checkout, is not a Git checkout; nothing was $past."
+    >&2 echo "Remediation: git clone git@github.com:$repository.git $WORKSPACE_PATH"
+}
+
+# The workstation name, in Rule 10's spelling. SPECKIT_WORKSTATION is the
+# override the tests use; nothing is ever guessed from a window name.
+workspace_workstation() {
+    local name=""
+
+    if [ -n "${SPECKIT_WORKSTATION:-}" ]; then
+        name="$SPECKIT_WORKSTATION"
+    elif [ -n "${WORKSTATION:-}" ]; then
+        name="$WORKSTATION"
+    else
+        name="$(hostname 2>/dev/null || true)"
+        [ -n "$name" ] || name="$(uname -n 2>/dev/null || true)"
+    fi
+    [ -n "$name" ] || name="unknown"
+    printf '%s\n' "${name%%.*}"
+}
+
+# The lane, in Rule 5's spelling, never guessed from a window name.
+workspace_lane() {
+    local lane="$1"
+
+    [ -n "$lane" ] || lane="${SPECKIT_LANE:-}"
+    [ -n "$lane" ] || lane="${LANE:-}"
+    [ -n "$lane" ] || lane="unknown"
+    printf '%s\n' "$lane"
+}
+
+# A manifest file name is refused rather than sanitised.
+workspace_name_is_safe() {
+    case "$1" in
+        '' | '.' | '..') return 1 ;;
+        *[!A-Za-z0-9._-]*) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# project.yaml's id:, falling back to the repository directory name.
+workspace_project_id() {
+    local root="$1"
+
+    WORKSPACE_PROJECT_ID=""
+    if [ -f "$root/project.yaml" ] \
+        && workspace_read_scalar "$root/project.yaml" id \
+        && [ -n "$WORKSPACE_SCALAR" ]; then
+        WORKSPACE_PROJECT_ID="$WORKSPACE_SCALAR"
+        return 0
+    fi
+    WORKSPACE_PROJECT_ID="${root##*/}"
+}
+
+# The project's repository slug, read out of project.yaml's legs: block: the
+# assembly leg's repository:. There is no top-level repository: key in the
+# openRepoShape project manifest, and the git remote URL is a host path here,
+# which the manifest may never record.
+workspace_project_repository() {
+    local root="$1"
+    local manifest="$root/project.yaml"
+    local raw content trimmed indent_ws indent key rest
+    local in_legs=false key_col=-1
+    local cur_role="" cur_repository=""
+
+    WORKSPACE_PROJECT_REPOSITORY=""
+    [ -f "$manifest" ] || return 0
+    while IFS= read -r raw || [ -n "$raw" ]; do
+        content="${raw%%#*}"
+        _shape_set_trimmed "$content"
+        trimmed="$_SHAPE_TRIMMED"
+        [ -n "$trimmed" ] || continue
+        indent_ws="${content%%[![:space:]]*}"
+        indent=${#indent_ws}
+
+        if [ "$in_legs" = true ]; then
+            if [ "$indent" -eq 0 ]; then
+                in_legs=false
+            elif [ "${trimmed:0:2}" = "- " ] || [ "$trimmed" = "-" ]; then
+                if [ "$cur_role" = "assembly" ] && [ -n "$cur_repository" ]; then
+                    WORKSPACE_PROJECT_REPOSITORY="$cur_repository"
+                    return 0
+                fi
+                cur_role=""
+                cur_repository=""
+                key_col=$((indent + 2))
+                _shape_set_trimmed "${trimmed#-}"
+                rest="$_SHAPE_TRIMMED"
+                key="${rest%%:*}"
+                if [ -n "$rest" ] && [ "$key" != "$rest" ]; then
+                    _shape_set_scalar "${rest#*:}"
+                    case "$key" in
+                        role) cur_role="$_SHAPE_SCALAR" ;;
+                        repository) cur_repository="$_SHAPE_SCALAR" ;;
+                    esac
+                fi
+                continue
+            elif [ "$indent" -eq "$key_col" ]; then
+                key="${trimmed%%:*}"
+                if [ "$key" != "$trimmed" ]; then
+                    _shape_set_scalar "${trimmed#*:}"
+                    case "$key" in
+                        role) cur_role="$_SHAPE_SCALAR" ;;
+                        repository) cur_repository="$_SHAPE_SCALAR" ;;
+                    esac
+                fi
+                continue
+            else
+                continue
+            fi
+        fi
+
+        if [ "$indent" -eq 0 ]; then
+            key="${trimmed%%:*}"
+            [ "$key" != "$trimmed" ] || continue
+            if [ "$key" = "legs" ]; then
+                in_legs=true
+                key_col=-1
+            fi
+        fi
+    done < "$manifest"
+    if [ "$cur_role" = "assembly" ] && [ -n "$cur_repository" ]; then
+        WORKSPACE_PROJECT_REPOSITORY="$cur_repository"
+    fi
+    return 0
+}
+
+# The family, when the root sits in the doubled <Family>/<Family> layout and
+# the holder's family.yaml names this project as a member. Sets
+# WORKSPACE_FAMILY (empty for a standalone project) and WORKSPACE_FAMILY_DIR.
+workspace_family_name() {
+    local root="$1"
+    local project_id="$2"
+    local parent family_dir manifest
+
+    WORKSPACE_FAMILY=""
+    WORKSPACE_FAMILY_DIR=""
+    WORKSPACE_FAMILY_MANIFEST=""
+    parent="${root%/*}"
+    [ -n "$parent" ] || return 0
+    [ "$parent" != "$root" ] || return 0
+    family_dir="${parent##*/}"
+    [ -n "$family_dir" ] || return 0
+    manifest="$parent/$family_dir/family.yaml"
+    [ -f "$manifest" ] || return 0
+    workspace_read_scalar "$manifest" kind || return 0
+    [ "$WORKSPACE_SCALAR" = "family-manifest" ] || return 0
+    workspace_members_contains "$manifest" "$project_id" || return 0
+    workspace_read_scalar "$manifest" id || return 0
+    [ -n "$WORKSPACE_SCALAR" ] || return 0
+    WORKSPACE_FAMILY="$WORKSPACE_SCALAR"
+    WORKSPACE_FAMILY_DIR="$family_dir"
+    WORKSPACE_FAMILY_MANIFEST="$manifest"
+}
+
+# The owner segment of a repository slug or URL: owner/repo,
+# git@host:owner/repo.git, ssh://git@host/owner/repo.git and
+# https://host/owner/repo all give "owner". A filesystem path has no owner and
+# is refused, so nothing invents one.
+workspace_org_from_url() {
+    local url="$1"
+    local rest owner
+
+    WORKSPACE_ORG=""
+    [ -n "$url" ] || return 1
+    case "$url" in
+        file://*) return 1 ;;
+        *://*)
+            rest="${url#*://}"
+            rest="${rest#*@}"
+            case "$rest" in
+                */*) rest="${rest#*/}" ;;
+                *) return 1 ;;
+            esac
+            ;;
+        /*) return 1 ;;
+        *:*) rest="${url#*:}" ;;
+        */*) rest="$url" ;;
+        *) return 1 ;;
+    esac
+    case "$rest" in
+        */*) owner="${rest%%/*}" ;;
+        *) return 1 ;;
+    esac
+    [ -n "$owner" ] || return 1
+    WORKSPACE_ORG="$owner"
+}
+
+# The org a manifest file is filed under. One private workspace repository can
+# track work across several orgs, and two projects in different orgs may share
+# an id, so the file is workspaces/<org>/<name>.yaml and never workspaces/
+# <name>.yaml. The org is the owner segment of the family holder's or the
+# project's declared repository, falling back to the root's origin remote and
+# then to "local" for a checkout that declares no owner at all.
+workspace_org_for() {
+    local root="$1"
+    local family_manifest="$2"
+    local url
+
+    WORKSPACE_ORG=""
+    if [ -n "$family_manifest" ] \
+        && workspace_read_scalar "$family_manifest" repository \
+        && workspace_org_from_url "$WORKSPACE_SCALAR"; then
+        return 0
+    fi
+    workspace_project_repository "$root"
+    if [ -n "$WORKSPACE_PROJECT_REPOSITORY" ] \
+        && workspace_org_from_url "$WORKSPACE_PROJECT_REPOSITORY"; then
+        return 0
+    fi
+    url="$(git -C "$root" remote get-url origin 2>/dev/null || true)"
+    if workspace_org_from_url "$url"; then
+        return 0
+    fi
+    WORKSPACE_ORG="local"
+}
+
+# The manifest's own `root:` value: POSIX, relative, never absolute. A member
+# of a family is recorded as <family folder>/<project folder>; a standalone
+# project as its own folder name.
+workspace_manifest_root_value() {
+    local root="$1"
+    local family_dir="$2"
+
+    if [ -n "$family_dir" ]; then
+        printf '%s/%s\n' "$family_dir" "${root##*/}"
+    else
+        printf '%s\n' "${root##*/}"
+    fi
+}
+
+# One JSON field out of the last-worktree state file. Python 3 is a hard
+# requirement of park.sh and resume.sh, so there is one implementation.
+workspace_read_state_field() {
+    local state_file="$1"
+    local field="$2"
+
+    WORKSPACE_STATE_VALUE=""
+    [ -n "$state_file" ] || return 1
+    [ -L "$state_file" ] && return 1
+    [ -f "$state_file" ] || return 1
+    WORKSPACE_STATE_VALUE="$(python3 - "$state_file" "$field" <<'PY'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as stream:
+        payload = json.load(stream)
+except (OSError, ValueError):
+    raise SystemExit(1)
+if not isinstance(payload, dict):
+    raise SystemExit(1)
+value = payload.get(sys.argv[2], "")
+if not isinstance(value, str):
+    raise SystemExit(1)
+sys.stdout.write(value)
+PY
+    )" || return 1
+    [ -n "$WORKSPACE_STATE_VALUE" ]
+}
+
+# ---------------------------------------------------------------------------
+# The manifest reader.
+#
+# workspace_load_project <manifest file> <project id> fills, for resume.sh:
+#   MANIFEST_PROJECT_FOUND        true | false
+#   MANIFEST_FAMILY               the family name, or empty
+#   MANIFEST_SHAPE                three-leg | single
+#   MANIFEST_ROOT                 relative POSIX path
+#   MANIFEST_TRACKING_BRANCH
+#   MANIFEST_WORKTREE_ROOT        provenance only; resume uses the LOCAL config
+#   MANIFEST_PARKED_AT / _ON / _BY_LANE
+#   MANIFEST_ACTIVE_FEATURE / _SOURCE
+#   MANIFEST_FEATURE_BRANCHES[]   MANIFEST_FEATURE_DIRECTORIES[]
+#   MANIFEST_LEG_FEATURE[]        the feature index each leg row belongs to
+#   MANIFEST_LEG_ROLE[] _REMOTE[] _COMMIT[] _WIP[] _DEPTH[] _PUSHED[]
+#
+# Bash 3.2 has no nested arrays, so the leg rows are a flat table keyed by
+# feature index. The file is written by this extension with a fixed layout, so
+# the reader keys on indent width and on the leading "- " of a list item.
+# ---------------------------------------------------------------------------
+workspace_load_project() {
+    local file="$1"
+    local want="$2"
+    local raw content trimmed indent_ws indent key value rest
+    local in_projects=false matching=false in_features=false in_legs=false
+    local feature_index=-1
+
+    MANIFEST_PROJECT_FOUND=false
+    MANIFEST_FAMILY=""
+    MANIFEST_SHAPE=""
+    MANIFEST_ROOT=""
+    MANIFEST_TRACKING_BRANCH=""
+    MANIFEST_WORKTREE_ROOT=""
+    MANIFEST_PARKED_AT=""
+    MANIFEST_PARKED_ON=""
+    MANIFEST_PARKED_BY_LANE=""
+    MANIFEST_ACTIVE_FEATURE=""
+    MANIFEST_ACTIVE_FEATURE_SOURCE=""
+    MANIFEST_FEATURE_BRANCHES=()
+    MANIFEST_FEATURE_DIRECTORIES=()
+    MANIFEST_LEG_FEATURE=()
+    MANIFEST_LEG_ROLE=()
+    MANIFEST_LEG_REMOTE=()
+    MANIFEST_LEG_COMMIT=()
+    MANIFEST_LEG_WIP=()
+    MANIFEST_LEG_DEPTH=()
+    MANIFEST_LEG_PUSHED=()
+
+    [ -f "$file" ] || return 1
+    while IFS= read -r raw || [ -n "$raw" ]; do
+        content="${raw%%#*}"
+        _shape_set_trimmed "$content"
+        trimmed="$_SHAPE_TRIMMED"
+        [ -n "$trimmed" ] || continue
+        indent_ws="${content%%[![:space:]]*}"
+        indent=${#indent_ws}
+
+        if [ "$indent" -eq 0 ]; then
+            in_projects=false
+            matching=false
+            in_features=false
+            in_legs=false
+            key="${trimmed%%:*}"
+            [ "$key" != "$trimmed" ] || continue
+            _shape_set_scalar "${trimmed#*:}"
+            value="$_SHAPE_SCALAR"
+            case "$key" in
+                family) MANIFEST_FAMILY="$value" ;;
+                projects) in_projects=true ;;
+            esac
+            continue
+        fi
+
+        [ "$in_projects" = true ] || continue
+
+        if [ "$indent" -eq 2 ]; then
+            matching=false
+            in_features=false
+            in_legs=false
+            case "$trimmed" in
+                '- '*) ;;
+                *) continue ;;
+            esac
+            _shape_set_trimmed "${trimmed#- }"
+            rest="$_SHAPE_TRIMMED"
+            key="${rest%%:*}"
+            [ "$key" != "$rest" ] || continue
+            _shape_set_scalar "${rest#*:}"
+            if [ "$key" = "id" ] && [ "$_SHAPE_SCALAR" = "$want" ]; then
+                matching=true
+                MANIFEST_PROJECT_FOUND=true
+            fi
+            continue
+        fi
+
+        [ "$matching" = true ] || continue
+
+        if [ "$indent" -eq 4 ]; then
+            in_features=false
+            in_legs=false
+            key="${trimmed%%:*}"
+            [ "$key" != "$trimmed" ] || continue
+            _shape_set_scalar "${trimmed#*:}"
+            value="$_SHAPE_SCALAR"
+            case "$key" in
+                shape) MANIFEST_SHAPE="$value" ;;
+                root) MANIFEST_ROOT="$value" ;;
+                tracking_branch) MANIFEST_TRACKING_BRANCH="$value" ;;
+                worktree_root) MANIFEST_WORKTREE_ROOT="$value" ;;
+                parked_at) MANIFEST_PARKED_AT="$value" ;;
+                parked_on) MANIFEST_PARKED_ON="$value" ;;
+                parked_by_lane) MANIFEST_PARKED_BY_LANE="$value" ;;
+                active_feature) MANIFEST_ACTIVE_FEATURE="$value" ;;
+                active_feature_source) MANIFEST_ACTIVE_FEATURE_SOURCE="$value" ;;
+                features) in_features=true ;;
+            esac
+            continue
+        fi
+
+        [ "$in_features" = true ] || continue
+
+        if [ "$indent" -eq 6 ]; then
+            in_legs=false
+            case "$trimmed" in
+                '- '*) ;;
+                *) continue ;;
+            esac
+            _shape_set_trimmed "${trimmed#- }"
+            rest="$_SHAPE_TRIMMED"
+            key="${rest%%:*}"
+            [ "$key" != "$rest" ] || continue
+            _shape_set_scalar "${rest#*:}"
+            [ "$key" = "branch" ] || continue
+            MANIFEST_FEATURE_BRANCHES[${#MANIFEST_FEATURE_BRANCHES[@]}]="$_SHAPE_SCALAR"
+            MANIFEST_FEATURE_DIRECTORIES[${#MANIFEST_FEATURE_DIRECTORIES[@]}]=""
+            feature_index=$((${#MANIFEST_FEATURE_BRANCHES[@]} - 1))
+            continue
+        fi
+
+        [ "$feature_index" -ge 0 ] || continue
+
+        if [ "$indent" -eq 8 ]; then
+            in_legs=false
+            key="${trimmed%%:*}"
+            [ "$key" != "$trimmed" ] || continue
+            _shape_set_scalar "${trimmed#*:}"
+            case "$key" in
+                feature_directory)
+                    MANIFEST_FEATURE_DIRECTORIES[feature_index]="$_SHAPE_SCALAR"
+                    ;;
+                legs) in_legs=true ;;
+            esac
+            continue
+        fi
+
+        [ "$in_legs" = true ] || continue
+
+        if [ "$indent" -eq 10 ]; then
+            case "$trimmed" in
+                '- '*) ;;
+                *) continue ;;
+            esac
+            _shape_set_trimmed "${trimmed#- }"
+            rest="$_SHAPE_TRIMMED"
+            key="${rest%%:*}"
+            [ "$key" != "$rest" ] || continue
+            _shape_set_scalar "${rest#*:}"
+            [ "$key" = "role" ] || continue
+            MANIFEST_LEG_FEATURE[${#MANIFEST_LEG_FEATURE[@]}]="$feature_index"
+            MANIFEST_LEG_ROLE[${#MANIFEST_LEG_ROLE[@]}]="$_SHAPE_SCALAR"
+            MANIFEST_LEG_REMOTE[${#MANIFEST_LEG_REMOTE[@]}]=""
+            MANIFEST_LEG_COMMIT[${#MANIFEST_LEG_COMMIT[@]}]=""
+            MANIFEST_LEG_WIP[${#MANIFEST_LEG_WIP[@]}]="false"
+            MANIFEST_LEG_DEPTH[${#MANIFEST_LEG_DEPTH[@]}]="0"
+            MANIFEST_LEG_PUSHED[${#MANIFEST_LEG_PUSHED[@]}]="false"
+            continue
+        fi
+
+        if [ "$indent" -eq 12 ] && [ "${#MANIFEST_LEG_ROLE[@]}" -gt 0 ]; then
+            local leg_index=$((${#MANIFEST_LEG_ROLE[@]} - 1))
+            key="${trimmed%%:*}"
+            [ "$key" != "$trimmed" ] || continue
+            _shape_set_scalar "${trimmed#*:}"
+            case "$key" in
+                remote) MANIFEST_LEG_REMOTE[leg_index]="$_SHAPE_SCALAR" ;;
+                parked_commit) MANIFEST_LEG_COMMIT[leg_index]="$_SHAPE_SCALAR" ;;
+                wip) MANIFEST_LEG_WIP[leg_index]="$_SHAPE_SCALAR" ;;
+                wip_depth) MANIFEST_LEG_DEPTH[leg_index]="$_SHAPE_SCALAR" ;;
+                pushed) MANIFEST_LEG_PUSHED[leg_index]="$_SHAPE_SCALAR" ;;
+            esac
+        fi
+    done < "$file"
+
+    [ "$MANIFEST_PROJECT_FOUND" = true ]
+}
+
+# ---------------------------------------------------------------------------
+# The mutex, and the writes in the workspace repository.
+#
+# This is ~/projects/xFactory/.lanes/lanes-edit.sh's shape, and for its
+# reasons: a peer's in-flight edit is committed as its own commit before ours,
+# every commit carries an explicit pathspec, and a rebase conflict ABORTS
+# rather than leaving a mid-rebase checkout behind.
+# ---------------------------------------------------------------------------
+workspace_lock() {
+    local workspace="$1"
+    local lock="$workspace/.workspaces.lock"
+    local attempt=0
+
+    while [ "$attempt" -lt 60 ]; do
+        if mkdir "$lock" 2>/dev/null; then
+            WORKSPACE_LOCK_DIR="$lock"
+            return 0
+        fi
+        attempt=$((attempt + 1))
+        sleep 1
+    done
+    return 1
+}
+
+workspace_unlock() {
+    [ -n "$WORKSPACE_LOCK_DIR" ] || return 0
+    rmdir "$WORKSPACE_LOCK_DIR" 2>/dev/null || true
+    WORKSPACE_LOCK_DIR=""
+}
+
+# Any pre-existing uncommitted change under workspaces/ becomes its own commit
+# first, so a peer's in-flight edit is never swept into ours.
+workspace_commit_pre_existing() {
+    local workspace="$1"
+    local workstation="$2"
+    local dirty count
+
+    dirty="$(git -C "$workspace" status --porcelain --untracked-files=all -- workspaces 2>/dev/null || true)"
+    [ -n "$dirty" ] || return 0
+    count="$(printf '%s\n' "$dirty" | grep -c '^' || true)"
+    git -C "$workspace" add -- workspaces >/dev/null 2>&1 || return 1
+    git -C "$workspace" commit -q \
+        -m "park(pre-existing@$workstation): $count file(s)" -- workspaces || return 1
+    echo "[specify] Committed $count pre-existing change(s) under workspaces/ as their own commit." >&2
+}
+
+# Refuse if the write touched anything under workspaces/ other than our file.
+workspace_only_our_file_changed() {
+    local workspace="$1"
+    local relative="$2"
+    local line path
+
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        path="${line:3}"
+        case "$path" in
+            "$relative") ;;
+            *) return 1 ;;
+        esac
+    done <<EOF
+$(git -C "$workspace" status --porcelain --untracked-files=all -- workspaces 2>/dev/null || true)
+EOF
+    return 0
+}
+
+# Bring the workspace checkout up to date before the manifest is rewritten, so
+# the write lands on what origin already holds instead of colliding with it.
+# On a rebase conflict the rebase is ABORTED and the caller refuses.
+workspace_sync() {
+    local workspace="$1"
+    local branch conflict
+
+    git -C "$workspace" remote get-url origin >/dev/null 2>&1 || return 0
+    branch="$(git -C "$workspace" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+    [ -n "$branch" ] && [ "$branch" != "HEAD" ] || return 0
+    git -C "$workspace" fetch -q origin "$branch" >/dev/null 2>&1 || return 0
+    git -C "$workspace" merge-base --is-ancestor "refs/remotes/origin/$branch" HEAD 2>/dev/null && return 0
+    if git -C "$workspace" pull --rebase -q origin "$branch" >/dev/null 2>&1; then
+        return 0
+    fi
+    conflict="$(git -C "$workspace" diff --name-only --diff-filter=U 2>/dev/null || true)"
+    git -C "$workspace" rebase --abort >/dev/null 2>&1 || true
+    >&2 echo "Error: rebasing the workspace repository '$workspace' onto origin/$branch conflicted; nothing was recorded."
+    if [ -n "$conflict" ]; then
+        >&2 printf '  %s\n' "$conflict"
+    fi
+    >&2 echo "The rebase was aborted, so the checkout is clean and not mid-rebase. Reconcile by hand:"
+    >&2 echo "  git -C $workspace pull --rebase origin $branch"
+    return 1
+}
+
+workspace_commit_manifest() {
+    local workspace="$1"
+    local relative="$2"
+    local subject="$3"
+
+    git -C "$workspace" add -- "$relative" >/dev/null 2>&1 || return 1
+    git -C "$workspace" commit -q -m "$subject" -- "$relative" || return 1
+}
+
+# git pull --rebase then push, with a race retry. On a rebase conflict the
+# rebase is ABORTED and the caller refuses: the checkout is left clean and not
+# mid-rebase. Never a force-push here.
+WORKSPACE_PUSH_RESULT=""
+workspace_push_manifest() {
+    local workspace="$1"
+    local attempt=0
+    local branch conflict
+
+    WORKSPACE_PUSH_RESULT="not-pushed"
+    if ! git -C "$workspace" remote get-url origin >/dev/null 2>&1; then
+        echo "[specify] Warning: the workspace checkout '$workspace' has no 'origin' remote; the manifest commit was not pushed." >&2
+        return 0
+    fi
+    branch="$(git -C "$workspace" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+    if [ -z "$branch" ] || [ "$branch" = "HEAD" ]; then
+        echo "[specify] Warning: the workspace checkout '$workspace' is not on a branch; the manifest commit was not pushed." >&2
+        return 0
+    fi
+
+    while [ "$attempt" -lt 6 ]; do
+        if git -C "$workspace" push -q origin "HEAD:refs/heads/$branch" 2>/dev/null; then
+            WORKSPACE_PUSH_RESULT="pushed"
+            return 0
+        fi
+        if ! git -C "$workspace" pull --rebase -q origin "$branch" 2>/dev/null; then
+            conflict="$(git -C "$workspace" diff --name-only --diff-filter=U 2>/dev/null || true)"
+            git -C "$workspace" rebase --abort >/dev/null 2>&1 || true
+            >&2 echo "Error: rebasing the workspace repository '$workspace' onto origin/$branch conflicted; the manifest commit was NOT pushed."
+            if [ -n "$conflict" ]; then
+                >&2 printf '  %s\n' "$conflict"
+            fi
+            >&2 echo "The rebase was aborted, so the checkout is clean and not mid-rebase. Reconcile by hand:"
+            >&2 echo "  git -C $workspace pull --rebase origin $branch"
+            >&2 echo "  git -C $workspace push origin $branch"
+            WORKSPACE_PUSH_RESULT="conflict"
+            return 1
+        fi
+        attempt=$((attempt + 1))
+    done
+    echo "[specify] Warning: could not push the manifest commit to origin/$branch after 6 attempts; it is committed locally." >&2
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# The record file, and the two Python 3 writers.
+#
+# park.sh and resume.sh describe their result once, as a small tab-delimited
+# record file, and hand it to the writers below. That keeps one description of
+# the facts instead of one per output format:
+#
+#   <key>\t<value>        a top-level fact; a key starting with "_" is
+#                         manifest-only and never appears in --json output
+#   [feature]             starts a feature; its own <key>\t<value> lines follow
+#   [leg]                 starts a leg of the current feature
+#   [refused]             starts a refusal record (never reaches the manifest)
+#
+# Python 3 is a hard requirement of both scripts — the manifest and the
+# last-worktree state file are both published through it — so there is one
+# implementation of each writer rather than three.
+# ---------------------------------------------------------------------------
+
+workspace_record_reset() {
+    : > "$1"
+}
+
+workspace_record_put() {
+    local file="$1"
+    local key="$2"
+    local value="$3"
+
+    value="${value//	/ }"
+    value="${value//$'\n'/ }"
+    printf '%s\t%s\n' "$key" "$value" >> "$file"
+}
+
+workspace_record_section() {
+    printf '[%s]\n' "$2" >> "$1"
+}
+
+# Merge this project's block into <manifest>, in a fixed key order, rewriting
+# no other project's block. Prints "changed" or "unchanged"; a byte-identical
+# rewrite is not a write, so park makes no empty commit.
+workspace_write_manifest() {
+    local manifest="$1"
+    local record="$2"
+
+    python3 - "$manifest" "$record" <<'PY'
+import os
+import re
+import sys
+
+manifest_path, record_path = sys.argv[1], sys.argv[2]
+SAFE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/@:+-]*$")
+INTEGER = re.compile(r"^(?:0|[1-9][0-9]*)$")
+
+
+def scalar(value):
+    if value in ("true", "false") or INTEGER.match(value):
+        return value
+    if SAFE.match(value):
+        return value
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return '"%s"' % escaped
+
+
+def relative(value, where):
+    if value.startswith("/") or value.startswith("~"):
+        sys.stderr.write(
+            "Error: refusing to record an absolute path in the workspace "
+            "manifest: %s = %s\n" % (where, value)
+        )
+        raise SystemExit(1)
+    return value
+
+
+top = {}
+features = []
+section = None
+with open(record_path, "r", encoding="utf-8") as stream:
+    for raw in stream:
+        line = raw.rstrip("\n")
+        if not line:
+            continue
+        if line == "[feature]":
+            features.append({"legs": []})
+            section = "feature"
+            continue
+        if line == "[leg]":
+            features[-1]["legs"].append({})
+            section = "leg"
+            continue
+        if line == "[refused]":
+            section = "refused"
+            continue
+        key, _, value = line.partition("\t")
+        if section == "feature":
+            features[-1][key] = value
+        elif section == "leg":
+            features[-1]["legs"][-1][key] = value
+        elif section == "refused":
+            continue
+        else:
+            top[key] = value
+
+project_id = top.get("project_id", "")
+if not project_id:
+    sys.stderr.write("Error: the workspace record names no project id.\n")
+    raise SystemExit(1)
+
+PROJECT_KEYS = (
+    ("repository", "_repository"),
+    ("shape", "_shape"),
+    ("root", "_root"),
+    ("tracking_branch", "_tracking_branch"),
+    ("worktree_root", "_worktree_root"),
+    ("parked_at", "_parked_at"),
+    ("parked_on", "_parked_on"),
+    ("parked_by_lane", "_parked_by_lane"),
+    ("active_feature", "active_feature"),
+    ("active_feature_source", "active_feature_source"),
+)
+LEG_KEYS = (
+    ("role", "role"),
+    ("remote", "_remote"),
+    ("parked_commit", "parked_commit"),
+    ("wip", "wip"),
+    ("wip_depth", "wip_depth"),
+    ("pushed", "pushed"),
+)
+
+block = ["  - id: %s" % scalar(project_id)]
+for out_key, record_key in PROJECT_KEYS:
+    value = top.get(record_key, "")
+    if value == "":
+        continue
+    if out_key in ("root", "worktree_root"):
+        value = relative(value, out_key)
+    block.append("    %s: %s" % (out_key, scalar(value)))
+if not features:
+    block.append("    features: []")
+else:
+    block.append("    features:")
+    for feature in features:
+        block.append("      - branch: %s" % scalar(feature.get("branch", "")))
+        directory = feature.get("_feature_directory", "")
+        if directory:
+            block.append(
+                "        feature_directory: %s"
+                % scalar(relative(directory, "feature_directory"))
+            )
+        legs = feature.get("legs", [])
+        if not legs:
+            block.append("        legs: []")
+            continue
+        block.append("        legs:")
+        for leg in legs:
+            first = True
+            for out_key, record_key in LEG_KEYS:
+                value = leg.get(record_key, "")
+                if value == "" and out_key != "role":
+                    continue
+                prefix = "          - " if first else "            "
+                block.append("%s%s: %s" % (prefix, out_key, scalar(value)))
+                first = False
+
+try:
+    with open(manifest_path, "r", encoding="utf-8") as stream:
+        existing = stream.read()
+except OSError:
+    existing = ""
+
+blocks = []
+lines = existing.splitlines()
+index = 0
+while index < len(lines) and not lines[index].startswith("projects:"):
+    index += 1
+index += 1
+current = None
+while index < len(lines):
+    line = lines[index]
+    index += 1
+    if not line.strip():
+        continue
+    if not line.startswith(" "):
+        break
+    if line.startswith("  - "):
+        current = [line]
+        blocks.append(current)
+    elif current is not None:
+        current.append(line)
+
+
+def block_id(candidate):
+    match = re.match(r"^  - id:\s*(.*)$", candidate[0])
+    if match is None:
+        return None
+    value = match.group(1).strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        value = value[1:-1]
+    return value
+
+
+def without_parked_at(candidate):
+    return [line for line in candidate if not line.startswith("    parked_at:")]
+
+
+# parked_at is the only volatile field. When the rest of the block is
+# unchanged, keep the recorded instant: a re-park of unchanged state must
+# produce a byte-identical file and therefore no commit at all.
+for candidate in blocks:
+    if block_id(candidate) != project_id:
+        continue
+    if without_parked_at(candidate) == without_parked_at(block):
+        previous = [line for line in candidate if line.startswith("    parked_at:")]
+        if previous:
+            block = [
+                previous[0] if line.startswith("    parked_at:") else line
+                for line in block
+            ]
+    break
+
+merged = []
+placed = False
+for candidate in blocks:
+    if block_id(candidate) == project_id:
+        if not placed:
+            merged.append(block)
+            placed = True
+        continue
+    merged.append(candidate)
+if not placed:
+    merged.append(block)
+
+header = ["schema_version: 1", "kind: workspace-manifest"]
+family = top.get("_family", "")
+if family:
+    header.append("family: %s" % scalar(family))
+header.append("written_by: speckit park")
+header.append("projects:")
+rendered = "\n".join(header + [line for candidate in merged for line in candidate]) + "\n"
+
+if rendered == existing:
+    sys.stdout.write("unchanged\n")
+    raise SystemExit(0)
+
+directory = os.path.dirname(manifest_path) or "."
+os.makedirs(directory, exist_ok=True)
+temporary = os.path.join(directory, ".%s.tmp" % os.path.basename(manifest_path))
+with open(temporary, "w", encoding="utf-8") as stream:
+    stream.write(rendered)
+os.replace(temporary, manifest_path)
+sys.stdout.write("changed\n")
+PY
+}
+
+# Render the record file as the extension's uppercase-keyed JSON. The list key
+# is PARKED for park.sh and RESUMED for resume.sh.
+workspace_emit_json() {
+    local record="$1"
+    local list_key="$2"
+
+    python3 - "$record" "$list_key" <<'PY'
+import json
+import re
+import sys
+
+record_path, list_key = sys.argv[1], sys.argv[2]
+INTEGER = re.compile(r"^(?:0|[1-9][0-9]*)$")
+
+
+def coerce(value):
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    if INTEGER.match(value):
+        return int(value)
+    return value
+
+
+top = {}
+features = []
+refused = []
+section = None
+with open(record_path, "r", encoding="utf-8") as stream:
+    for raw in stream:
+        line = raw.rstrip("\n")
+        if not line:
+            continue
+        if line == "[feature]":
+            features.append({"LEGS": []})
+            section = "feature"
+            continue
+        if line == "[leg]":
+            features[-1]["LEGS"].append({})
+            section = "leg"
+            continue
+        if line == "[refused]":
+            refused.append({})
+            section = "refused"
+            continue
+        key, _, value = line.partition("\t")
+        if key.startswith("_"):
+            continue
+        if section == "feature":
+            features[-1][key.upper()] = coerce(value)
+        elif section == "leg":
+            features[-1]["LEGS"][-1][key.upper()] = coerce(value)
+        elif section == "refused":
+            refused[-1][key.upper()] = coerce(value)
+        else:
+            top[key.upper()] = coerce(value)
+
+payload = {}
+for key in (
+    "REPO_SHAPE",
+    "PROJECT_ID",
+    "WORKSPACE_PATH",
+    "WORKSPACE_SOURCE",
+    "MANIFEST_PATH",
+):
+    if key in top:
+        payload[key] = top[key]
+payload[list_key] = features
+payload["REFUSED"] = refused
+for key in ("ACTIVE_FEATURE", "ACTIVE_FEATURE_SOURCE", "FEATURE_JSON", "STATE_FILE"):
+    if key in top:
+        payload[key] = top[key]
+for key in sorted(top):
+    if key not in payload and key != "DRY_RUN":
+        payload[key] = top[key]
+if top.get("DRY_RUN") is True:
+    payload["DRY_RUN"] = True
+json.dump(payload, sys.stdout, ensure_ascii=False, separators=(",", ":"))
+sys.stdout.write("\n")
+PY
+}

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/workspace-common.sh
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/workspace-common.sh
@@ -111,8 +111,14 @@ workspace_read_org_override() {
     local want="$2"
     local raw content trimmed indent_ws indent key value
     local in_orgs=false org_col=-1 key_col=-1
-    local current="" found=false found_repository="" found_path=""
+    local current="" current_folded="" found=false
+    local found_repository="" found_path="" want_folded
 
+    # GitHub org names are case-insensitive, so `orgs: medxsoft:` must match a
+    # `repository: MedxSoft/...`. Routing a confidential org's manifest to the
+    # DEFAULT workspace over a capital letter is the one failure this override
+    # exists to prevent.
+    want_folded="$(printf '%s' "$want" | tr '[:upper:]' '[:lower:]')"
     WORKSPACE_ORG_PATH=""
     WORKSPACE_ORG_REPOSITORY=""
     WORKSPACE_CONFIG_ERROR=""
@@ -170,6 +176,7 @@ workspace_read_org_override() {
                 return 2
             fi
             current="$key"
+            current_folded="$(printf '%s' "$key" | tr '[:upper:]' '[:lower:]')"
             key_col=-1
             continue
         fi
@@ -193,7 +200,7 @@ workspace_read_org_override() {
             WORKSPACE_CONFIG_ERROR="'$key' under '$current' has no value"
             return 2
         fi
-        if [ "$current" = "$want" ]; then
+        if [ "$current_folded" = "$want_folded" ]; then
             found=true
             case "$key" in
                 repository) found_repository="$value" ;;
@@ -854,9 +861,50 @@ EOF
     return 0
 }
 
+# Tracked changes outside workspaces/ that would stop a rebase. Untracked
+# files do not stop one, so they are not counted: a half-written handoff that
+# has never been added is nobody's problem. workspace_commit_pre_existing has
+# already dealt with everything under workspaces/.
+workspace_dirty_outside_manifests() {
+    local workspace="$1"
+    local line path
+
+    WORKSPACE_DIRTY_PATHS=""
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        case "$line" in
+            '??'*) continue ;;
+        esac
+        path="${line:3}"
+        case "$path" in
+            workspaces/*) continue ;;
+        esac
+        WORKSPACE_DIRTY_PATHS="$WORKSPACE_DIRTY_PATHS$path
+"
+    done <<EOF
+$(git -C "$workspace" status --porcelain 2>/dev/null || true)
+EOF
+    [ -n "$WORKSPACE_DIRTY_PATHS" ]
+}
+
+# workspace-dirty.
+workspace_refuse_dirty() {
+    local workspace="$1"
+    local past="$2"
+
+    >&2 echo "Error: workspace-dirty: '$workspace' has uncommitted changes outside workspaces/, so it cannot be brought up to date; nothing was $past."
+    >&2 printf '  %s
+' "$WORKSPACE_DIRTY_PATHS" | sed '/^  $/d'
+    >&2 echo "park and resume never touch a file outside workspaces/ — a handoff is yours to commit."
+    >&2 echo "  commit or stash those paths, then re-run:"
+    >&2 echo "  git -C $workspace status"
+}
+
 # Bring the workspace checkout up to date before the manifest is rewritten, so
 # the write lands on what origin already holds instead of colliding with it.
-# On a rebase conflict the rebase is ABORTED and the caller refuses.
+# On a rebase conflict the rebase is ABORTED and the caller refuses. Returns 2
+# when the checkout is dirty outside workspaces/ and a rebase is needed, so
+# the caller can refuse by name instead of misreporting a conflict.
 workspace_sync() {
     local workspace="$1"
     local branch conflict
@@ -866,6 +914,10 @@ workspace_sync() {
     [ -n "$branch" ] && [ "$branch" != "HEAD" ] || return 0
     git -C "$workspace" fetch -q origin "$branch" >/dev/null 2>&1 || return 0
     git -C "$workspace" merge-base --is-ancestor "refs/remotes/origin/$branch" HEAD 2>/dev/null && return 0
+    # A rebase is actually needed, so the working tree has to be clean for it.
+    if workspace_dirty_outside_manifests "$workspace"; then
+        return 2
+    fi
     if git -C "$workspace" pull --rebase -q origin "$branch" >/dev/null 2>&1; then
         return 0
     fi
@@ -913,6 +965,10 @@ workspace_push_manifest() {
         if git -C "$workspace" push -q origin "HEAD:refs/heads/$branch" 2>/dev/null; then
             WORKSPACE_PUSH_RESULT="pushed"
             return 0
+        fi
+        if workspace_dirty_outside_manifests "$workspace"; then
+            WORKSPACE_PUSH_RESULT="dirty"
+            return 1
         fi
         if ! git -C "$workspace" pull --rebase -q origin "$branch" 2>/dev/null; then
             conflict="$(git -C "$workspace" diff --name-only --diff-filter=U 2>/dev/null || true)"

--- a/devBenches/devcontainer.test/test-openspeckit-bootstrap.sh
+++ b/devBenches/devcontainer.test/test-openspeckit-bootstrap.sh
@@ -3464,11 +3464,11 @@ make_fake_overlay_template() {
         "$root/specify/extensions/git/scripts/powershell" \
         "$root/specify/shell"
     printf '%s\n' 'name: git' > "$root/specify/extensions/git/extension.yml"
-    for overlay_command in commit feature initialize remote validate; do
+    for overlay_command in commit feature initialize park remote resume validate; do
         printf '%s\n' "# speckit.git.$overlay_command fixture" \
             > "$root/specify/extensions/git/commands/speckit.git.$overlay_command.md"
     done
-    for overlay_script in auto-commit create-new-feature get-last-worktree git-common initialize-repo; do
+    for overlay_script in auto-commit create-new-feature get-last-worktree git-common initialize-repo park resume workspace-common; do
         {
             printf '%s\n' '#!/usr/bin/env bash'
             printf '%s\n' 'set -euo pipefail'

--- a/devBenches/devcontainer.test/test-speckit-git-feature.sh
+++ b/devBenches/devcontainer.test/test-speckit-git-feature.sh
@@ -2687,7 +2687,7 @@ test_resume_refuses_on_divergence() {
     assert_contains_block "$stderr_file" \
 "Error: 001-routing-core (spec leg) has moved since it was parked; that feature was NOT recreated.
   parked commit  $RESUME_PARKED_SPEC   (parked $parked_at on Fixture)
-  current tip    $foreign_tip      (origin/001-routing-core)
+  current tip    $foreign_tip   (origin/001-routing-core)
 Nothing is ever reset over commits this workspace did not park. Reconcile by hand:
   git -C spec fetch origin 001-routing-core
   git -C spec log --oneline $RESUME_PARKED_SPEC..origin/001-routing-core

--- a/devBenches/devcontainer.test/test-speckit-git-feature.sh
+++ b/devBenches/devcontainer.test/test-speckit-git-feature.sh
@@ -13,13 +13,16 @@ FEATURE_SCRIPT="$TEMPLATE_ROOT/specify/extensions/git/scripts/bash/create-new-fe
 GET_LAST_WORKTREE_SCRIPT="$TEMPLATE_ROOT/specify/extensions/git/scripts/bash/get-last-worktree.sh"
 GIT_COMMON_SCRIPT="$TEMPLATE_ROOT/specify/extensions/git/scripts/bash/git-common.sh"
 AUTO_COMMIT_SCRIPT="$TEMPLATE_ROOT/specify/extensions/git/scripts/bash/auto-commit.sh"
+WORKSPACE_COMMON_SCRIPT="$TEMPLATE_ROOT/specify/extensions/git/scripts/bash/workspace-common.sh"
+PARK_SCRIPT="$TEMPLATE_ROOT/specify/extensions/git/scripts/bash/park.sh"
+RESUME_SCRIPT="$TEMPLATE_ROOT/specify/extensions/git/scripts/bash/resume.sh"
 SELECT_WORKTREE_SCRIPT="$TEMPLATE_ROOT/specify/shell/select-worktree.sh"
 REAL_GIT="$(command -v git)"
 
 FIXTURE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/speckit-git-feature.XXXXXX")"
 trap 'rm -rf "$FIXTURE_ROOT"' EXIT
 
-for required_script in "$FEATURE_SCRIPT" "$GET_LAST_WORKTREE_SCRIPT" "$GIT_COMMON_SCRIPT" "$AUTO_COMMIT_SCRIPT" "$SELECT_WORKTREE_SCRIPT"; do
+for required_script in "$FEATURE_SCRIPT" "$GET_LAST_WORKTREE_SCRIPT" "$GIT_COMMON_SCRIPT" "$AUTO_COMMIT_SCRIPT" "$WORKSPACE_COMMON_SCRIPT" "$PARK_SCRIPT" "$RESUME_SCRIPT" "$SELECT_WORKTREE_SCRIPT"; do
     if [ ! -x "$required_script" ]; then
         printf 'Checked-in Speckit script is missing or not executable: %s\n' "$required_script" >&2
         exit 1
@@ -1959,6 +1962,1254 @@ test_three_leg_auto_commit_commits_both_legs_only() {
     assert_equal "$root_head_before" "$(git -C "$root" rev-parse HEAD)" 'no-feature auto-commit left the root alone'
 }
 
+# ---------------------------------------------------------------------------
+# park / resume fixtures and scenarios (openRepoShape#77 S1, workBenches#30).
+#
+# The leg origins are BARE here, unlike initialize_three_leg_fixture's: park
+# pushes the feature branch, and pushing the checked-out branch of a non-bare
+# origin works only by accident (receive.denyCurrentBranch). The divergence
+# scenario also has to push a foreign commit INTO an origin.
+# ---------------------------------------------------------------------------
+
+PARKED_ROOT=''
+PARKED_SPEC_ORIGIN=''
+PARKED_CODE_ORIGIN=''
+PARKED_BASE=''
+WORKSPACE_DIR=''
+WORKSPACE_ORIGIN=''
+
+init_bare_repo() {
+    local bare="$1"
+
+    if git init -q --bare -b main "$bare" 2>/dev/null; then
+        return 0
+    fi
+    git init -q --bare "$bare" || return 1
+    git -C "$bare" symbolic-ref HEAD refs/heads/main
+}
+
+# A bare origin seeded with one commit on main, through a throwaway checkout.
+init_seeded_bare_origin() {
+    local bare="$1"
+    local seed="$2"
+
+    mkdir -p "$seed" || return 1
+    git init -q -b main "$seed" || return 1
+    git -C "$seed" config user.name 'Spec Kit test' || return 1
+    git -C "$seed" config user.email 'spec-kit-test@example.invalid' || return 1
+    printf 'fixture\n' > "$seed/README.md" || return 1
+    mkdir -p "$seed/specs" || return 1
+    printf 'fixture\n' > "$seed/specs/.keep" || return 1
+    git -C "$seed" add -A || return 1
+    git -C "$seed" commit -qm 'fixture commit' || return 1
+    init_bare_repo "$bare" || return 1
+    git -C "$seed" remote add origin "$bare" || return 1
+    git -C "$seed" push -q origin main || return 1
+}
+
+install_park_scripts() {
+    local root="$1"
+    local script_dir="$root/.specify/extensions/git/scripts/bash"
+
+    mkdir -p "$script_dir" "$root/.specify/shell" || return 1
+    cp "$GIT_COMMON_SCRIPT" "$script_dir/git-common.sh" || return 1
+    cp "$WORKSPACE_COMMON_SCRIPT" "$script_dir/workspace-common.sh" || return 1
+    cp "$PARK_SCRIPT" "$script_dir/park.sh" || return 1
+    cp "$RESUME_SCRIPT" "$script_dir/resume.sh" || return 1
+    cp "$GET_LAST_WORKTREE_SCRIPT" "$script_dir/get-last-worktree.sh" || return 1
+    cp "$SELECT_WORKTREE_SCRIPT" "$root/.specify/shell/select-worktree.sh" || return 1
+    chmod +x \
+        "$script_dir/park.sh" \
+        "$script_dir/resume.sh" \
+        "$script_dir/get-last-worktree.sh" \
+        "$root/.specify/shell/select-worktree.sh"
+}
+
+initialize_three_leg_parked_fixture() {
+    local name="$1"
+    local config="$2"
+    local base="$FIXTURE_ROOT/$name"
+    local leg
+
+    PARKED_BASE="$base"
+    PARKED_ROOT="$base/root"
+    PARKED_SPEC_ORIGIN="$base/spec-origin.git"
+    PARKED_CODE_ORIGIN="$base/code-origin.git"
+
+    mkdir -p "$base" || return 1
+    init_seeded_bare_origin "$PARKED_SPEC_ORIGIN" "$base/spec-seed" || return 1
+    init_seeded_bare_origin "$PARKED_CODE_ORIGIN" "$base/code-seed" || return 1
+    init_plain_repo "$PARKED_ROOT" || return 1
+    add_local_submodule "$PARKED_ROOT" "$PARKED_SPEC_ORIGIN" spec || return 1
+    add_local_submodule "$PARKED_ROOT" "$PARKED_CODE_ORIGIN" code || return 1
+    for leg in spec code; do
+        git -C "$PARKED_ROOT/$leg" config user.name 'Spec Kit test' || return 1
+        git -C "$PARKED_ROOT/$leg" config user.email 'spec-kit-test@example.invalid' || return 1
+    done
+    write_three_leg_manifest "$PARKED_ROOT/project.yaml" || return 1
+    mkdir -p "$PARKED_ROOT/.specify/extensions/git" || return 1
+    printf '%s\n' "$config" > "$PARKED_ROOT/.specify/extensions/git/git-config.yml" || return 1
+    printf '/worktrees/\n' > "$PARKED_ROOT/.gitignore" || return 1
+    install_park_scripts "$PARKED_ROOT" || return 1
+    git -C "$PARKED_ROOT" add -A || return 1
+    git -C "$PARKED_ROOT" commit -qm 'three-leg parked fixture' || return 1
+}
+
+initialize_workspace_fixture() {
+    local name="$1"
+    local base="$FIXTURE_ROOT/$name"
+
+    WORKSPACE_ORIGIN="$base/workspace-origin.git"
+    WORKSPACE_DIR="$base/workspace"
+    mkdir -p "$base" || return 1
+    init_bare_repo "$WORKSPACE_ORIGIN" || return 1
+    git init -q -b main "$WORKSPACE_DIR" || return 1
+    git -C "$WORKSPACE_DIR" config user.name 'Spec Kit test' || return 1
+    git -C "$WORKSPACE_DIR" config user.email 'spec-kit-test@example.invalid' || return 1
+    mkdir -p "$WORKSPACE_DIR/workspaces" || return 1
+    printf 'workspace manifests\n' > "$WORKSPACE_DIR/workspaces/README.md" || return 1
+    git -C "$WORKSPACE_DIR" add -A || return 1
+    git -C "$WORKSPACE_DIR" commit -qm 'workspace fixture' || return 1
+    git -C "$WORKSPACE_DIR" remote add origin "$WORKSPACE_ORIGIN" || return 1
+    git -C "$WORKSPACE_DIR" push -q -u origin main || return 1
+}
+
+clone_workspace_fixture() {
+    local destination="$1"
+
+    git clone -q "$WORKSPACE_ORIGIN" "$destination" || return 1
+    git -C "$destination" config user.name 'Spec Kit test' || return 1
+    git -C "$destination" config user.email 'spec-kit-test@example.invalid'
+}
+
+# A second checkout of a three-leg root, the way a person reaches one on
+# another workstation: clone the assembly root, then initialise the legs.
+clone_three_leg_root() {
+    local source="$1"
+    local destination="$2"
+    local leg
+
+    git -c protocol.file.allow=always clone -q "$source" "$destination" || return 1
+    git -C "$destination" config user.name 'Spec Kit test' || return 1
+    git -C "$destination" config user.email 'spec-kit-test@example.invalid' || return 1
+    git -C "$destination" -c protocol.file.allow=always submodule update -q --init || return 1
+    for leg in spec code; do
+        git -C "$destination/$leg" config user.name 'Spec Kit test' || return 1
+        git -C "$destination/$leg" config user.email 'spec-kit-test@example.invalid' || return 1
+    done
+    rm -f "$destination/.specify/feature.json"
+}
+
+PARK_OUTPUT=''
+PARK_STATUS=0
+invoke_park() {
+    local root="$1"
+    local stderr_file="$2"
+    shift 2
+
+    PARK_OUTPUT=''
+    PARK_STATUS=0
+    PARK_OUTPUT="$(cd "$root" && env \
+        SPECKIT_WORKSTATION=Fixture SPECKIT_LANE=fixture-lane \
+        bash .specify/extensions/git/scripts/bash/park.sh \
+        --workspace "$WORKSPACE_DIR" "$@" 2>"$stderr_file")" || PARK_STATUS=$?
+    return 0
+}
+
+RESUME_OUTPUT=''
+RESUME_STATUS=0
+invoke_resume() {
+    local root="$1"
+    local stderr_file="$2"
+    shift 2
+
+    RESUME_OUTPUT=''
+    RESUME_STATUS=0
+    RESUME_OUTPUT="$(cd "$root" && env \
+        SPECKIT_WORKSTATION=Fixture SPECKIT_LANE=fixture-lane \
+        bash .specify/extensions/git/scripts/bash/resume.sh \
+        --workspace "$WORKSPACE_DIR" "$@" 2>"$stderr_file")" || RESUME_STATUS=$?
+    return 0
+}
+
+create_parked_feature() {
+    local root="$1"
+    local description="$2"
+    local stderr_file="$3"
+    shift 3
+
+    FEATURE_OUTPUT=''
+    FEATURE_OUTPUT="$(cd "$root" && bash "$FEATURE_SCRIPT" --json "$@" "$description" 2>"$stderr_file")" || return 1
+}
+
+assert_contains_block() {
+    local file="$1"
+    local expected="$2"
+    local label="$3"
+    local content
+
+    content="$(cat "$file")"
+    case "$content" in
+        *"$expected"*) return 0 ;;
+    esac
+    printf 'assertion failed: %s\n--- expected block ---\n%s\n--- actual ---\n%s\n' \
+        "$label" "$expected" "$content" >&2
+    return 1
+}
+
+assert_file_absent() {
+    local path="$1"
+    local label="$2"
+
+    if [ -e "$path" ]; then
+        printf 'assertion failed: %s exists: %s\n' "$label" "$path" >&2
+        return 1
+    fi
+}
+
+commit_count() {
+    git -C "$1" rev-list --count HEAD 2>/dev/null || echo 0
+}
+
+manifest_line_count() {
+    grep -c "$2" "$1" 2>/dev/null || true
+}
+
+# Mask the values that move between runs so a whole-file comparison can assert
+# every field AND the fixed key order at once. Python 3 rather than sed -E,
+# because BusyBox sed is what the Bash 3.2 CI image has.
+mask_manifest() {
+    python3 - "$1" <<'PY'
+import re
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as stream:
+    for line in stream:
+        line = line.rstrip("\n")
+        line = re.sub(r"^( *parked_commit:) [0-9a-f]{40}$", r"\1 <SHA>", line)
+        line = re.sub(
+            r"^( *parked_at:) [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
+            r"\1 <TS>",
+            line,
+        )
+        print(line)
+PY
+}
+
+PARKED_CONFIG=$'checkout_mode: worktree\nbase_branch: main\nworktree_root: worktrees'
+
+# Point the fixture project's assembly leg at another org, so its manifest is
+# filed — and its workspace chosen — under that org instead.
+set_assembly_repository() {
+    local root="$1"
+    local slug="$2"
+
+    python3 - "$root/project.yaml" "$slug" <<'PY'
+import sys
+
+path, slug = sys.argv[1], sys.argv[2]
+with open(path, "r", encoding="utf-8") as stream:
+    text = stream.read()
+old = "    repository: dummy/fixture-project\n"
+if text.count(old) != 1:
+    raise SystemExit("the assembly leg's repository line is not unique")
+with open(path, "w", encoding="utf-8") as stream:
+    stream.write(text.replace(old, "    repository: %s\n" % slug))
+PY
+    git -C "$root" add project.yaml || return 1
+    git -C "$root" commit -qm 'point the assembly leg at another org'
+}
+
+test_park_commits_and_pushes_both_legs() {
+    local stderr_file="$FIXTURE_ROOT/park-both-legs.stderr"
+    local root spec_tree code_tree spec_before code_before
+    local root_head_before root_index_before subject
+
+    # Given: a parked-shape fixture with uncommitted work in both legs.
+    initialize_three_leg_parked_fixture 'park-both-legs' "$PARKED_CONFIG" || return 1
+    initialize_workspace_fixture 'park-both-legs-ws' || return 1
+    root="$PARKED_ROOT"
+    if ! create_parked_feature "$root" 'Add routing core' "$stderr_file"; then
+        printf 'feature creation failed: %s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    spec_tree="$root/worktrees/001-routing-core/spec"
+    code_tree="$root/worktrees/001-routing-core/code"
+    printf 'draft\n' > "$spec_tree/specs/001-routing-core/spec.md" || return 1
+    printf 'impl\n' > "$code_tree/implementation.txt" || return 1
+    spec_before="$(commit_count "$spec_tree")"
+    code_before="$(commit_count "$code_tree")"
+    root_head_before="$(git -C "$root" rev-parse HEAD)"
+    root_index_before="$(git -C "$root" diff --cached --name-only | sort | tr '\n' ' ')"
+
+    # When: park runs from the assembly root.
+    invoke_park "$root" "$stderr_file"
+    if [ "$PARK_STATUS" -ne 0 ]; then
+        printf 'park failed (%s): %s\n' "$PARK_STATUS" "$(<"$stderr_file")" >&2
+        return 1
+    fi
+
+    # Then: exactly one WIP commit per leg, with the fixed subject.
+    assert_equal "$((spec_before + 1))" "$(commit_count "$spec_tree")" 'spec leg WIP commit' || return 1
+    assert_equal "$((code_before + 1))" "$(commit_count "$code_tree")" 'code leg WIP commit' || return 1
+    subject="$(git -C "$spec_tree" log -1 --format=%s)"
+    if ! printf '%s\n' "$subject" | grep -Eq '^wip: park [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z — lane fixture-lane$'; then
+        printf 'assertion failed: WIP subject does not match: %s\n' "$subject" >&2
+        return 1
+    fi
+
+    # Then: the origins carry the branch at the parked commit.
+    assert_equal "$(git -C "$spec_tree" rev-parse HEAD)" \
+        "$(git -C "$PARKED_SPEC_ORIGIN" rev-parse refs/heads/001-routing-core)" \
+        'spec origin has the parked commit' || return 1
+    assert_equal "$(git -C "$code_tree" rev-parse HEAD)" \
+        "$(git -C "$PARKED_CODE_ORIGIN" rev-parse refs/heads/001-routing-core)" \
+        'code origin has the parked commit' || return 1
+
+    # Then: the manifest records the WIP.
+    assert_equal '2' "$(manifest_line_count "$WORKSPACE_DIR/workspaces/dummy/fixture-project.yaml" '^            wip: true$')" \
+        'manifest wip: true per leg' || return 1
+    assert_equal '2' "$(manifest_line_count "$WORKSPACE_DIR/workspaces/dummy/fixture-project.yaml" '^            wip_depth: 1$')" \
+        'manifest wip_depth: 1 per leg' || return 1
+
+    # Then: the assembly root is untouched — no branch, no worktree, no index.
+    assert_equal 'main ' "$(leg_branches "$root")" 'park left the root branches alone' || return 1
+    assert_equal '1' "$(worktree_record_count "$root")" 'park left the root worktree records alone' || return 1
+    assert_equal "$root_head_before" "$(git -C "$root" rev-parse HEAD)" 'park left the root HEAD alone' || return 1
+    assert_equal "$root_index_before" "$(git -C "$root" diff --cached --name-only | sort | tr '\n' ' ')" \
+        'park left the root index alone'
+}
+
+test_park_clean_feature_makes_no_commit() {
+    local stderr_file="$FIXTURE_ROOT/park-clean.stderr"
+    local root spec_tree spec_before spec_tip
+
+    # Given: a created feature with nothing uncommitted.
+    initialize_three_leg_parked_fixture 'park-clean' "$PARKED_CONFIG" || return 1
+    initialize_workspace_fixture 'park-clean-ws' || return 1
+    root="$PARKED_ROOT"
+    create_parked_feature "$root" 'Add routing core' "$stderr_file" || return 1
+    spec_tree="$root/worktrees/001-routing-core/spec"
+    spec_before="$(commit_count "$spec_tree")"
+    spec_tip="$(git -C "$spec_tree" rev-parse HEAD)"
+
+    # When: park runs.
+    invoke_park "$root" "$stderr_file"
+    assert_equal '0' "$PARK_STATUS" 'clean park exit code' || return 1
+
+    # Then: no commit was created anywhere and the tip is what was recorded.
+    assert_equal "$spec_before" "$(commit_count "$spec_tree")" 'clean park created no commit' || return 1
+    assert_equal '2' "$(manifest_line_count "$WORKSPACE_DIR/workspaces/dummy/fixture-project.yaml" '^            wip: false$')" \
+        'clean park records wip: false' || return 1
+    assert_equal '2' "$(manifest_line_count "$WORKSPACE_DIR/workspaces/dummy/fixture-project.yaml" '^            wip_depth: 0$')" \
+        'clean park records wip_depth: 0' || return 1
+    if ! grep -Fq "            parked_commit: $spec_tip" "$WORKSPACE_DIR/workspaces/dummy/fixture-project.yaml"; then
+        printf 'assertion failed: the spec tip was not recorded as the parked commit\n%s\n' \
+            "$(<"$WORKSPACE_DIR/workspaces/dummy/fixture-project.yaml")" >&2
+        return 1
+    fi
+}
+
+test_park_enumerates_from_git_not_feature_json() {
+    local stderr_file="$FIXTURE_ROOT/park-stale-json.stderr"
+    local root
+
+    # Given: a created feature and a feature.json naming a directory that is
+    # not an open feature.
+    initialize_three_leg_parked_fixture 'park-stale-json' "$PARKED_CONFIG" || return 1
+    initialize_workspace_fixture 'park-stale-json-ws' || return 1
+    root="$PARKED_ROOT"
+    create_parked_feature "$root" 'Add routing core' "$stderr_file" || return 1
+    printf '%s\n' '{"feature_directory":"worktrees/009-removed/spec/specs/009-removed"}' \
+        > "$root/.specify/feature.json" || return 1
+
+    # When: park runs.
+    invoke_park "$root" "$stderr_file"
+    assert_equal '0' "$PARK_STATUS" 'stale feature.json park exit code' || return 1
+
+    # Then: the open feature is parked, and the disagreement is a warning.
+    if ! grep -Fq "[specify] Warning: .specify/feature.json names 'worktrees/009-removed/spec/specs/009-removed', which is not an open feature under 'worktrees'." "$stderr_file"; then
+        printf 'assertion failed: missing W1 first line\n%s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    if ! grep -Fq "[specify] Recorded active_feature_source: stale-feature-json; resume will select '001-routing-core' instead." "$stderr_file"; then
+        printf 'assertion failed: missing W1 second line\n%s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    if ! grep -Fq '    active_feature_source: stale-feature-json' "$WORKSPACE_DIR/workspaces/dummy/fixture-project.yaml"; then
+        printf 'assertion failed: active_feature_source was not recorded as stale-feature-json\n' >&2
+        return 1
+    fi
+    grep -Fq '      - branch: 001-routing-core' "$WORKSPACE_DIR/workspaces/dummy/fixture-project.yaml"
+}
+
+test_park_refuses_a_leg_without_origin() {
+    local stderr_file="$FIXTURE_ROOT/park-no-origin.stderr"
+    local root
+
+    # Given: a created feature whose code leg has no origin. A remote is a
+    # property of the leg REPOSITORY, so this refusal reaches every feature of
+    # that leg — here there is one, so nothing is parked at all.
+    initialize_three_leg_parked_fixture 'park-no-origin' "$PARKED_CONFIG" || return 1
+    initialize_workspace_fixture 'park-no-origin-ws' || return 1
+    root="$PARKED_ROOT"
+    create_parked_feature "$root" 'Add routing core' "$stderr_file" || return 1
+    git -C "$root/code" remote remove origin || return 1
+
+    # When: park runs.
+    invoke_park "$root" "$stderr_file"
+
+    # Then: R5, exactly, and nothing was recorded for the feature.
+    assert_equal '2' "$PARK_STATUS" 'no-origin park exit code' || return 1
+    assert_contains_block "$stderr_file" \
+"Error: 001-routing-core (code leg) has no 'origin' remote; that feature was NOT parked.
+resume rebuilds worktrees from pushed branches, so a leg with no remote cannot travel.
+  git -C code remote add origin <url>" 'R5 wording' || return 1
+    if grep -Fq '      - branch: 001-routing-core' "$WORKSPACE_DIR/workspaces/dummy/fixture-project.yaml" 2>/dev/null; then
+        printf 'assertion failed: a refused feature was recorded\n' >&2
+        return 1
+    fi
+    assert_equal '0' "$(commit_count "$root/worktrees/001-routing-core/spec")" \
+        'no-origin park made no spec commit' 2>/dev/null || true
+    if [ "$(git -C "$root/worktrees/001-routing-core/spec" log -1 --format=%s)" != 'fixture commit' ]; then
+        printf 'assertion failed: the spec leg was committed before the blockers were checked\n' >&2
+        return 1
+    fi
+}
+
+test_park_refuses_a_rebase_in_progress() {
+    local stderr_file="$FIXTURE_ROOT/park-rebase.stderr"
+    local root spec_tree spec_before
+
+    # Given: two features, one of which has a real conflicted rebase in its
+    # spec leg worktree.
+    initialize_three_leg_parked_fixture 'park-rebase' "$PARKED_CONFIG" || return 1
+    initialize_workspace_fixture 'park-rebase-ws' || return 1
+    root="$PARKED_ROOT"
+    create_parked_feature "$root" 'Add routing core' "$stderr_file" || return 1
+    create_parked_feature "$root" 'Add label render' "$stderr_file" || return 1
+    spec_tree="$root/worktrees/001-routing-core/spec"
+    printf 'feature side\n' > "$spec_tree/README.md" || return 1
+    git -C "$spec_tree" commit -q -am 'feature edit' || return 1
+    printf 'main side\n' > "$root/spec/README.md" || return 1
+    git -C "$root/spec" commit -q -am 'main edit' || return 1
+    git -C "$spec_tree" rebase main >/dev/null 2>&1 || true
+    if [ ! -e "$(git -C "$spec_tree" rev-parse --absolute-git-dir)/rebase-merge" ] \
+        && [ ! -e "$(git -C "$spec_tree" rev-parse --absolute-git-dir)/rebase-apply" ]; then
+        printf 'fixture failed: no rebase is in progress\n' >&2
+        return 1
+    fi
+    spec_before="$(commit_count "$spec_tree")"
+
+    # When: park runs.
+    invoke_park "$root" "$stderr_file"
+
+    # Then: R4, exit 3, no commit in that leg, and the other feature parked.
+    assert_equal '3' "$PARK_STATUS" 'rebase-in-progress park exit code' || return 1
+    assert_contains_block "$stderr_file" \
+"Error: 001-routing-core (spec leg) has a rebase in progress; that feature was NOT parked.
+A WIP commit over an unresolved index would park a conflicted tree as if it were work.
+  finish it:  git -C worktrees/001-routing-core/spec rebase --continue
+  or drop it: git -C worktrees/001-routing-core/spec rebase --abort
+Then re-run \`make park\`." 'R4 wording' || return 1
+    assert_equal "$spec_before" "$(commit_count "$spec_tree")" 'R4 made no commit' || return 1
+    grep -Fq '      - branch: 002-label-render' "$WORKSPACE_DIR/workspaces/dummy/fixture-project.yaml" || {
+        printf 'assertion failed: the other feature was not parked\n%s\n' \
+            "$(<"$WORKSPACE_DIR/workspaces/dummy/fixture-project.yaml")" >&2
+        return 1
+    }
+}
+
+test_park_refuses_a_rejected_push_and_keeps_the_wip_commit() {
+    local stderr_file="$FIXTURE_ROOT/park-push-refused.stderr"
+    local root spec_tree wip_sha
+
+    # Given: two features and a spec origin that rejects only 002-*.
+    initialize_three_leg_parked_fixture 'park-push-refused' "$PARKED_CONFIG" || return 1
+    initialize_workspace_fixture 'park-push-refused-ws' || return 1
+    root="$PARKED_ROOT"
+    create_parked_feature "$root" 'Add routing core' "$stderr_file" || return 1
+    create_parked_feature "$root" 'Add label render' "$stderr_file" || return 1
+    mkdir -p "$PARKED_SPEC_ORIGIN/hooks" || return 1
+    cat > "$PARKED_SPEC_ORIGIN/hooks/pre-receive" <<'HOOK'
+#!/usr/bin/env bash
+while read -r _old _new ref; do
+    case "$ref" in
+        */002-*) printf 'the fixture refuses %s\n' "$ref" >&2; exit 1 ;;
+    esac
+done
+exit 0
+HOOK
+    chmod +x "$PARKED_SPEC_ORIGIN/hooks/pre-receive" || return 1
+    spec_tree="$root/worktrees/002-label-render/spec"
+    printf 'draft\n' > "$spec_tree/specs/002-label-render/spec.md" || return 1
+
+    # When: park runs.
+    invoke_park "$root" "$stderr_file"
+
+    # Then: R6, exit 3, the WIP commit is still there, nothing recorded for it.
+    assert_equal '3' "$PARK_STATUS" 'rejected-push park exit code' || return 1
+    wip_sha="$(git -C "$spec_tree" rev-parse HEAD)"
+    if ! grep -Fq 'Error: pushing 002-label-render to origin refused in the spec leg; that feature was NOT parked.' "$stderr_file"; then
+        printf 'assertion failed: missing R6 first line\n%s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    if ! grep -Fq "Your work is NOT lost: it is committed locally at $wip_sha. park never force-pushes." "$stderr_file"; then
+        printf 'assertion failed: missing R6 reassurance\n%s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    if ! grep -Fq "  look:  git -C worktrees/002-label-render/spec fetch origin && git -C worktrees/002-label-render/spec log --oneline $wip_sha..origin/002-label-render" "$stderr_file"; then
+        printf 'assertion failed: missing R6 remediation\n%s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    if ! grep -Fq 'Then reconcile by hand and re-run `make park`.' "$stderr_file"; then
+        printf 'assertion failed: missing R6 closing line\n%s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    if ! git -C "$spec_tree" log -1 --format=%s | grep -q '^wip: park '; then
+        printf 'assertion failed: the WIP commit was not kept\n' >&2
+        return 1
+    fi
+    if grep -Fq '      - branch: 002-label-render' "$WORKSPACE_DIR/workspaces/dummy/fixture-project.yaml"; then
+        printf 'assertion failed: a feature whose push was refused was recorded\n' >&2
+        return 1
+    fi
+    grep -Fq '      - branch: 001-routing-core' "$WORKSPACE_DIR/workspaces/dummy/fixture-project.yaml"
+}
+
+test_park_stacks_a_second_wip_without_a_force_push() {
+    local stderr_file="$FIXTURE_ROOT/park-stacked.stderr"
+    local root spec_tree base_count
+
+    # Given: a feature already parked with one WIP commit, then dirty again.
+    initialize_three_leg_parked_fixture 'park-stacked' "$PARKED_CONFIG" || return 1
+    initialize_workspace_fixture 'park-stacked-ws' || return 1
+    root="$PARKED_ROOT"
+    create_parked_feature "$root" 'Add routing core' "$stderr_file" || return 1
+    spec_tree="$root/worktrees/001-routing-core/spec"
+    base_count="$(commit_count "$spec_tree")"
+    printf 'draft\n' > "$spec_tree/specs/001-routing-core/spec.md" || return 1
+    invoke_park "$root" "$stderr_file"
+    assert_equal '0' "$PARK_STATUS" 'first park of a stack' || return 1
+    printf 'draft again\n' >> "$spec_tree/specs/001-routing-core/spec.md" || return 1
+
+    # When: park runs a second time.
+    invoke_park "$root" "$stderr_file"
+
+    # Then: a second WIP commit, depth 2, and a fast-forward push.
+    assert_equal '0' "$PARK_STATUS" 'second park of a stack' || return 1
+    assert_equal "$((base_count + 2))" "$(commit_count "$spec_tree")" 'two stacked WIP commits' || return 1
+    if ! grep -Fq '            wip_depth: 2' "$WORKSPACE_DIR/workspaces/dummy/fixture-project.yaml"; then
+        printf 'assertion failed: wip_depth 2 was not recorded\n%s\n' \
+            "$(<"$WORKSPACE_DIR/workspaces/dummy/fixture-project.yaml")" >&2
+        return 1
+    fi
+    assert_equal "$(git -C "$spec_tree" rev-parse HEAD)" \
+        "$(git -C "$PARKED_SPEC_ORIGIN" rev-parse refs/heads/001-routing-core)" \
+        'the stacked push reached the origin' || return 1
+    if grep -Fq 'force' "$stderr_file"; then
+        printf 'assertion failed: a force-push was mentioned\n%s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+}
+
+test_park_dry_run_writes_nothing() {
+    local stderr_file="$FIXTURE_ROOT/park-dry-run.stderr"
+    local root spec_tree spec_before
+
+    # Given: a created feature with uncommitted work.
+    initialize_three_leg_parked_fixture 'park-dry-run' "$PARKED_CONFIG" || return 1
+    initialize_workspace_fixture 'park-dry-run-ws' || return 1
+    root="$PARKED_ROOT"
+    create_parked_feature "$root" 'Add routing core' "$stderr_file" || return 1
+    spec_tree="$root/worktrees/001-routing-core/spec"
+    printf 'draft\n' > "$spec_tree/specs/001-routing-core/spec.md" || return 1
+    spec_before="$(commit_count "$spec_tree")"
+
+    # When: park runs with --dry-run.
+    invoke_park "$root" "$stderr_file" --dry-run
+    assert_equal '0' "$PARK_STATUS" 'dry-run park exit code' || return 1
+
+    # Then: no commit, no push, no manifest, no lock left behind.
+    assert_equal "$spec_before" "$(commit_count "$spec_tree")" 'dry-run park made no commit' || return 1
+    if git -C "$PARKED_SPEC_ORIGIN" rev-parse --verify --quiet refs/heads/001-routing-core >/dev/null; then
+        printf 'assertion failed: dry-run park pushed a branch\n' >&2
+        return 1
+    fi
+    assert_file_absent "$WORKSPACE_DIR/workspaces/dummy/fixture-project.yaml" 'dry-run park manifest' || return 1
+    assert_file_absent "$WORKSPACE_DIR/.workspaces.lock" 'dry-run park lock directory' || return 1
+    assert_equal '1' "$(commit_count "$WORKSPACE_DIR")" 'dry-run park made no workspace commit' || return 1
+    if ! printf '%s\n' "$PARK_OUTPUT" | grep -Fq 'COMMITTED: nothing (--dry-run)'; then
+        printf 'assertion failed: dry-run park did not say it wrote nothing\n%s\n' "$PARK_OUTPUT" >&2
+        return 1
+    fi
+}
+
+# A parked three-leg fixture with one feature carrying WIP in both legs, and a
+# second checkout of the root ready to resume it. Sets PARKED_ROOT,
+# WORKSPACE_DIR, RESUME_ROOT and RESUME_PARKED_SPEC / RESUME_PARKED_CODE.
+RESUME_ROOT=''
+RESUME_PARKED_SPEC=''
+RESUME_PARKED_CODE=''
+park_then_clone() {
+    local name="$1"
+    local stderr_file="$2"
+    local root
+
+    initialize_three_leg_parked_fixture "$name" "$PARKED_CONFIG" || return 1
+    initialize_workspace_fixture "$name-ws" || return 1
+    root="$PARKED_ROOT"
+    create_parked_feature "$root" 'Add routing core' "$stderr_file" || return 1
+    printf 'draft\n' > "$root/worktrees/001-routing-core/spec/specs/001-routing-core/spec.md" || return 1
+    printf 'impl\n' > "$root/worktrees/001-routing-core/code/implementation.txt" || return 1
+    invoke_park "$root" "$stderr_file"
+    if [ "$PARK_STATUS" -ne 0 ]; then
+        printf 'park failed (%s): %s\n' "$PARK_STATUS" "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    RESUME_PARKED_SPEC="$(git -C "$root/worktrees/001-routing-core/spec" rev-parse HEAD)"
+    RESUME_PARKED_CODE="$(git -C "$root/worktrees/001-routing-core/code" rev-parse HEAD)"
+    RESUME_ROOT="$PARKED_BASE/second"
+    clone_three_leg_root "$root" "$RESUME_ROOT"
+}
+
+test_resume_recreates_worktrees_feature_json_and_state() {
+    local stderr_file="$FIXTURE_ROOT/resume-fresh.stderr"
+    local clone output
+
+    # Given: a parked feature and a fresh clone of the assembly root.
+    park_then_clone 'resume-fresh' "$stderr_file" || return 1
+    clone="$RESUME_ROOT"
+
+    # When: resume runs there.
+    invoke_resume "$clone" "$stderr_file"
+    if [ "$RESUME_STATUS" -ne 0 ]; then
+        printf 'resume failed (%s): %s\n' "$RESUME_STATUS" "$(<"$stderr_file")" >&2
+        return 1
+    fi
+
+    # Then: both legs are registered on the branch at the parked commit.
+    assert_worktree '001-routing-core' "$clone/worktrees/001-routing-core/spec" || return 1
+    assert_worktree '001-routing-core' "$clone/worktrees/001-routing-core/code" || return 1
+    assert_equal "$RESUME_PARKED_SPEC" \
+        "$(git -C "$clone/spec" rev-parse refs/remotes/origin/001-routing-core)" \
+        'resume fetched the parked spec commit' || return 1
+
+    # Then: feature.json and the state file are restored, and discovery agrees.
+    assert_equal 'worktrees/001-routing-core/spec/specs/001-routing-core' \
+        "$(json_field "$(<"$clone/.specify/feature.json")" feature_directory)" 'resume feature.json' || return 1
+    assert_equal '001-routing-core' \
+        "$(json_field "$(<"$clone/.git/speckit-last-worktree.json")" BRANCH_NAME)" 'resume state file' || return 1
+    output="$(cd "$clone" && bash .specify/extensions/git/scripts/bash/get-last-worktree.sh --json)" || return 1
+    assert_equal 'state_file' "$(json_field "$output" SOURCE)" 'resume discovery source' || return 1
+    assert_equal '001-routing-core' "$(json_field "$output" BRANCH_NAME)" 'resume discovery branch'
+}
+
+test_resume_uncommits_exactly_the_parked_wip() {
+    local stderr_file="$FIXTURE_ROOT/resume-uncommit.stderr"
+    local clone staged_clone spec_tree
+
+    # Given: a parked feature and a fresh clone.
+    park_then_clone 'resume-uncommit' "$stderr_file" || return 1
+    clone="$RESUME_ROOT"
+
+    # When: resume runs.
+    invoke_resume "$clone" "$stderr_file"
+    assert_equal '0' "$RESUME_STATUS" 'un-commit resume exit code' || return 1
+
+    # Then: the work is back, nothing is staged, and files absent from HEAD are
+    # untracked again.
+    spec_tree="$clone/worktrees/001-routing-core/spec"
+    assert_equal 'draft' "$(cat "$spec_tree/specs/001-routing-core/spec.md")" 'the parked content is back' || return 1
+    assert_equal '' "$(git -C "$spec_tree" diff --cached --name-only)" 'nothing is left staged' || return 1
+    if ! git -C "$spec_tree" status --porcelain | grep -q '^?? specs/001-routing-core/'; then
+        printf 'assertion failed: the restored file is not untracked\n%s\n' \
+            "$(git -C "$spec_tree" status --porcelain)" >&2
+        return 1
+    fi
+    assert_equal '1' "$(git -C "$spec_tree" rev-list --count HEAD..origin/001-routing-core)" \
+        'the local branch is exactly one WIP commit behind' || return 1
+
+    # When: another clone resumes with --keep-staged.
+    staged_clone="$PARKED_BASE/staged"
+    clone_three_leg_root "$PARKED_ROOT" "$staged_clone" || return 1
+    invoke_resume "$staged_clone" "$stderr_file" --keep-staged
+    assert_equal '0' "$RESUME_STATUS" '--keep-staged resume exit code' || return 1
+
+    # Then: the work is staged instead.
+    if ! git -C "$staged_clone/worktrees/001-routing-core/spec" diff --cached --name-only \
+        | grep -q '^specs/001-routing-core/spec.md$'; then
+        printf 'assertion failed: --keep-staged did not leave the work staged\n%s\n' \
+            "$(git -C "$staged_clone/worktrees/001-routing-core/spec" diff --cached --name-only)" >&2
+        return 1
+    fi
+}
+
+test_resume_refuses_on_divergence() {
+    local stderr_file="$FIXTURE_ROOT/resume-divergence.stderr"
+    local root clone foreign parked_at foreign_tip
+
+    # Given: two parked features, then a foreign commit pushed to the spec
+    # origin on the first one's branch.
+    initialize_three_leg_parked_fixture 'resume-divergence' "$PARKED_CONFIG" || return 1
+    initialize_workspace_fixture 'resume-divergence-ws' || return 1
+    root="$PARKED_ROOT"
+    create_parked_feature "$root" 'Add routing core' "$stderr_file" || return 1
+    create_parked_feature "$root" 'Add label render' "$stderr_file" || return 1
+    printf 'draft\n' > "$root/worktrees/001-routing-core/spec/specs/001-routing-core/spec.md" || return 1
+    invoke_park "$root" "$stderr_file"
+    if [ "$PARK_STATUS" -ne 0 ]; then
+        printf 'park failed (%s): %s\n' "$PARK_STATUS" "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    parked_at="$(grep -E '^    parked_at:' "$WORKSPACE_DIR/workspaces/dummy/fixture-project.yaml")"
+    parked_at="${parked_at#    parked_at: }"
+    RESUME_PARKED_SPEC="$(git -C "$root/worktrees/001-routing-core/spec" rev-parse HEAD)"
+
+    foreign="$PARKED_BASE/foreign"
+    git clone -q --branch 001-routing-core "$PARKED_SPEC_ORIGIN" "$foreign" || return 1
+    git -C "$foreign" config user.name 'Someone else' || return 1
+    git -C "$foreign" config user.email 'someone-else@example.invalid' || return 1
+    printf 'a foreign commit\n' > "$foreign/foreign.txt" || return 1
+    git -C "$foreign" add foreign.txt || return 1
+    git -C "$foreign" commit -qm 'foreign work' || return 1
+    git -C "$foreign" push -q origin 001-routing-core || return 1
+    foreign_tip="$(git -C "$foreign" rev-parse HEAD)"
+
+    clone="$PARKED_BASE/second"
+    clone_three_leg_root "$root" "$clone" || return 1
+
+    # When: resume runs in the fresh clone.
+    invoke_resume "$clone" "$stderr_file"
+
+    # Then: RR1, byte-for-byte, and nothing was recreated for that feature.
+    assert_equal '3' "$RESUME_STATUS" 'divergence resume exit code' || return 1
+    assert_contains_block "$stderr_file" \
+"Error: 001-routing-core (spec leg) has moved since it was parked; that feature was NOT recreated.
+  parked commit  $RESUME_PARKED_SPEC   (parked $parked_at on Fixture)
+  current tip    $foreign_tip      (origin/001-routing-core)
+Nothing is ever reset over commits this workspace did not park. Reconcile by hand:
+  git -C spec fetch origin 001-routing-core
+  git -C spec log --oneline $RESUME_PARKED_SPEC..origin/001-routing-core
+  git -C spec worktree add -b 001-routing-core worktrees/001-routing-core/spec origin/001-routing-core
+  # then decide: rebase the parked WIP onto the new tip, or discard it" 'RR1 wording' || return 1
+    assert_file_absent "$clone/worktrees/001-routing-core" 'the diverged feature directory' || return 1
+    assert_worktree '002-label-render' "$clone/worktrees/002-label-render/spec" || return 1
+    assert_worktree '002-label-render' "$clone/worktrees/002-label-render/code"
+}
+
+test_resume_is_idempotent() {
+    local stderr_file="$FIXTURE_ROOT/resume-idempotent.stderr"
+    local clone spec_tree head_before dirty_before
+
+    # Given: a clone that has already been resumed, with new local work.
+    park_then_clone 'resume-idempotent' "$stderr_file" || return 1
+    clone="$RESUME_ROOT"
+    invoke_resume "$clone" "$stderr_file"
+    assert_equal '0' "$RESUME_STATUS" 'first resume exit code' || return 1
+    spec_tree="$clone/worktrees/001-routing-core/spec"
+    printf 'later work\n' > "$spec_tree/later.txt" || return 1
+    head_before="$(git -C "$spec_tree" rev-parse HEAD)"
+    dirty_before="$(git -C "$spec_tree" status --porcelain)"
+
+    # When: resume runs again.
+    invoke_resume "$clone" "$stderr_file"
+
+    # Then: it says so, creates nothing, and never double-resets.
+    assert_equal '0' "$RESUME_STATUS" 'second resume exit code' || return 1
+    if ! grep -Fq "[specify] 001-routing-core (spec): worktree already registered at worktrees/001-routing-core/spec; left as it is." "$stderr_file"; then
+        printf 'assertion failed: missing RR4 line\n%s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    assert_equal "$head_before" "$(git -C "$spec_tree" rev-parse HEAD)" 'the second resume did not reset' || return 1
+    assert_equal "$dirty_before" "$(git -C "$spec_tree" status --porcelain)" 'the second resume left the dirty state alone' || return 1
+    assert_equal '2' "$(worktree_record_count "$clone/spec")" 'the second resume created no worktree'
+}
+
+test_resume_refuses_a_foreign_directory() {
+    local stderr_file="$FIXTURE_ROOT/resume-foreign-dir.stderr"
+    local clone intruder
+
+    # Given: a clone with an unrelated directory at the spec leg's target path.
+    park_then_clone 'resume-foreign-dir' "$stderr_file" || return 1
+    clone="$RESUME_ROOT"
+    intruder="$clone/worktrees/001-routing-core/spec"
+    mkdir -p "$intruder" || return 1
+    printf 'not a worktree\n' > "$intruder/keep.txt" || return 1
+
+    # When: resume runs.
+    invoke_resume "$clone" "$stderr_file"
+
+    # Then: RR3, and the intruder's bytes are unchanged.
+    assert_equal '2' "$RESUME_STATUS" 'foreign-directory resume exit code' || return 1
+    assert_contains_block "$stderr_file" \
+"Error: 'worktrees/001-routing-core/spec' exists and is not a registered worktree of the spec leg; that feature was NOT recreated.
+Nothing here overwrites a directory it did not create.
+  look:  git -C spec worktree list
+Move it aside, then re-run \`make resume\`." 'RR3 wording' || return 1
+    assert_equal 'not a worktree' "$(cat "$intruder/keep.txt")" 'the foreign directory is unchanged' || return 1
+    assert_equal '1' "$(worktree_record_count "$clone/spec")" 'RR3 created no worktree'
+}
+
+test_resume_refuses_a_local_branch_that_is_not_the_parked_commit() {
+    local stderr_file="$FIXTURE_ROOT/resume-local-branch.stderr"
+    local clone local_sha
+
+    # Given: a clone whose spec leg carries the branch with a local commit the
+    # parked commit does not contain — DIVERGED, not merely behind.
+    park_then_clone 'resume-local-branch' "$stderr_file" || return 1
+    clone="$RESUME_ROOT"
+    git -C "$clone/spec" checkout -q -b 001-routing-core main || return 1
+    printf 'local work\n' > "$clone/spec/local.txt" || return 1
+    git -C "$clone/spec" add local.txt || return 1
+    git -C "$clone/spec" commit -qm 'local work' || return 1
+    git -C "$clone/spec" checkout -q main || return 1
+    local_sha="$(git -C "$clone/spec" rev-parse refs/heads/001-routing-core)"
+
+    # When: resume runs.
+    invoke_resume "$clone" "$stderr_file"
+
+    # Then: RR5.
+    assert_equal '2' "$RESUME_STATUS" 'local-branch resume exit code' || return 1
+    assert_contains_block "$stderr_file" \
+"Error: the spec leg already has a local branch '001-routing-core' at $local_sha, not the parked commit $RESUME_PARKED_SPEC; that feature was NOT recreated.
+  git -C spec log --oneline $RESUME_PARKED_SPEC..001-routing-core
+Rename or delete that branch, then re-run \`make resume\`." 'RR5 wording' || return 1
+    assert_file_absent "$clone/worktrees/001-routing-core" 'RR5 feature directory'
+}
+
+test_resume_refuses_a_local_branch_behind_the_parked_commit() {
+    local stderr_file="$FIXTURE_ROOT/resume-behind.stderr"
+    local clone local_sha spec_tree
+
+    # Given: a clone whose spec leg carries the branch at an ancestor of the
+    # parked commit — this workstation had the feature before the other one
+    # parked newer work on it.
+    park_then_clone 'resume-behind' "$stderr_file" || return 1
+    clone="$RESUME_ROOT"
+    git -C "$clone/spec" branch 001-routing-core main || return 1
+    local_sha="$(git -C "$clone/spec" rev-parse refs/heads/001-routing-core)"
+
+    # When: resume runs.
+    invoke_resume "$clone" "$stderr_file"
+
+    # Then: the remediation is the fast-forward, not a deletion, and nothing
+    # was created or reset.
+    assert_equal '2' "$RESUME_STATUS" 'behind-branch resume exit code' || return 1
+    assert_contains_block "$stderr_file" \
+"Error: the spec leg's local branch '001-routing-core' is BEHIND the parked commit ($local_sha is an ancestor of $RESUME_PARKED_SPEC); that feature was NOT recreated.
+Fast-forward it, then re-run:
+  git -C spec fetch origin 001-routing-core:001-routing-core
+  make resume" 'RR5 behind wording' || return 1
+    assert_file_absent "$clone/worktrees/001-routing-core" 'behind-branch feature directory' || return 1
+    assert_equal "$local_sha" "$(git -C "$clone/spec" rev-parse refs/heads/001-routing-core)" \
+        'behind-branch resume moved nothing' || return 1
+
+    # When: the printed command runs, and resume runs again.
+    git -C "$clone/spec" fetch -q origin 001-routing-core:001-routing-core || return 1
+    invoke_resume "$clone" "$stderr_file"
+
+    # Then: the feature comes back and the parked WIP is un-committed.
+    if [ "$RESUME_STATUS" -ne 0 ]; then
+        printf 'the replayed resume failed (%s): %s\n' "$RESUME_STATUS" "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    spec_tree="$clone/worktrees/001-routing-core/spec"
+    assert_worktree '001-routing-core' "$spec_tree" || return 1
+    assert_worktree '001-routing-core' "$clone/worktrees/001-routing-core/code" || return 1
+    assert_equal 'draft' "$(cat "$spec_tree/specs/001-routing-core/spec.md")" 'the parked content is back' || return 1
+    assert_equal '1' "$(git -C "$spec_tree" rev-list --count HEAD..origin/001-routing-core)" \
+        'the replayed resume un-committed the parked WIP'
+}
+
+test_manifest_round_trip() {
+    local stderr_file="$FIXTURE_ROOT/manifest-round-trip.stderr"
+    local root manifest first_bytes second_bytes commits_before
+    local expected_manifest actual_manifest
+
+    # Given: a parked feature with WIP in both legs.
+    initialize_three_leg_parked_fixture 'manifest-round-trip' "$PARKED_CONFIG" || return 1
+    initialize_workspace_fixture 'manifest-round-trip-ws' || return 1
+    root="$PARKED_ROOT"
+    create_parked_feature "$root" 'Add routing core' "$stderr_file" || return 1
+    printf 'draft\n' > "$root/worktrees/001-routing-core/spec/specs/001-routing-core/spec.md" || return 1
+    printf 'impl\n' > "$root/worktrees/001-routing-core/code/implementation.txt" || return 1
+    invoke_park "$root" "$stderr_file"
+    assert_equal '0' "$PARK_STATUS" 'round-trip park exit code' || return 1
+
+    # Then: the file is filed under the org of the project's own repository,
+    # so two projects sharing an id in different orgs never share a file.
+    manifest="$WORKSPACE_DIR/workspaces/dummy/fixture-project.yaml"
+    if [ ! -f "$manifest" ]; then
+        printf 'assertion failed: no manifest at the org-namespaced path %s\n' "$manifest" >&2
+        find "$WORKSPACE_DIR/workspaces" -type f >&2
+        return 1
+    fi
+    assert_file_absent "$WORKSPACE_DIR/workspaces/fixture-project.yaml" \
+        'an un-namespaced manifest' || return 1
+
+    # Then: every field, in a fixed key order.
+    expected_manifest="$(cat <<'YAML'
+schema_version: 1
+kind: workspace-manifest
+written_by: speckit park
+projects:
+  - id: fixture-project
+    repository: dummy/fixture-project
+    shape: three-leg
+    root: root
+    tracking_branch: main
+    worktree_root: worktrees
+    parked_at: <TS>
+    parked_on: Fixture
+    parked_by_lane: fixture-lane
+    active_feature: 001-routing-core
+    active_feature_source: state_file
+    features:
+      - branch: 001-routing-core
+        feature_directory: worktrees/001-routing-core/spec/specs/001-routing-core
+        legs:
+          - role: spec
+            remote: origin
+            parked_commit: <SHA>
+            wip: true
+            wip_depth: 1
+            pushed: true
+          - role: code
+            remote: origin
+            parked_commit: <SHA>
+            wip: true
+            wip_depth: 1
+            pushed: true
+YAML
+    )"
+    actual_manifest="$(mask_manifest "$manifest")"
+    if [ "$expected_manifest" != "$actual_manifest" ]; then
+        printf 'assertion failed: the manifest is not the expected shape\n--- expected ---\n%s\n--- actual ---\n%s\n' \
+            "$expected_manifest" "$actual_manifest" >&2
+        return 1
+    fi
+
+    # Then: no value is a host-absolute path.
+    if grep -nE ':[[:space:]]+["'"'"']?[~/]' "$manifest"; then
+        printf 'assertion failed: the manifest names an absolute path\n' >&2
+        return 1
+    fi
+
+    # When: park runs again with nothing changed.
+    first_bytes="$(cat "$manifest")"
+    commits_before="$(commit_count "$WORKSPACE_DIR")"
+    invoke_park "$root" "$stderr_file"
+    assert_equal '0' "$PARK_STATUS" 'second round-trip park exit code' || return 1
+
+    # Then: the file is byte-identical and no commit was made.
+    second_bytes="$(cat "$manifest")"
+    if [ "$first_bytes" != "$second_bytes" ]; then
+        printf 'assertion failed: an unchanged re-park rewrote the manifest\n--- first ---\n%s\n--- second ---\n%s\n' \
+            "$first_bytes" "$second_bytes" >&2
+        return 1
+    fi
+    assert_equal "$commits_before" "$(commit_count "$WORKSPACE_DIR")" 'an unchanged re-park made no commit'
+}
+
+test_missing_workspace_config_refuses() {
+    local stderr_file="$FIXTURE_ROOT/no-workspace-config.stderr"
+    local root empty_home status
+
+    # Given: a created feature and a HOME with no workspace config.
+    initialize_three_leg_parked_fixture 'no-workspace-config' "$PARKED_CONFIG" || return 1
+    root="$PARKED_ROOT"
+    create_parked_feature "$root" 'Add routing core' "$stderr_file" || return 1
+    empty_home="$FIXTURE_ROOT/no-workspace-config/empty-home"
+    mkdir -p "$empty_home" || return 1
+
+    # When: park runs with nothing to point it at a workspace.
+    status=0
+    (cd "$root" && env -u SPECKIT_WORKSPACE_PATH -u AGENT_PROTOCOL_ROOT -u SPECKIT_WORKSPACE_REPOSITORY \
+        HOME="$empty_home" bash .specify/extensions/git/scripts/bash/park.sh \
+        >/dev/null 2>"$stderr_file") || status=$?
+
+    # Then: R1, exit 2, and nothing was created.
+    assert_equal '2' "$status" 'no-workspace-config park exit code' || return 1
+    assert_contains_block "$stderr_file" \
+'Error: no workspace repository is configured; nothing was parked.
+park records the feature list in a private repository you own. Name it once in
+~/.agents/workspace.yaml:
+
+  repository: <owner>/<repo>
+  path: ~/projects/<repo>
+
+Then re-run `make park`.' 'R1 wording for park' || return 1
+
+    # When: resume runs the same way.
+    status=0
+    (cd "$root" && env -u SPECKIT_WORKSPACE_PATH -u AGENT_PROTOCOL_ROOT -u SPECKIT_WORKSPACE_REPOSITORY \
+        HOME="$empty_home" bash .specify/extensions/git/scripts/bash/resume.sh \
+        >/dev/null 2>"$stderr_file") || status=$?
+
+    # Then: R1 with resume's verb, exit 2.
+    assert_equal '2' "$status" 'no-workspace-config resume exit code' || return 1
+    assert_contains_block "$stderr_file" \
+'Error: no workspace repository is configured; nothing was resumed.
+park records the feature list in a private repository you own. Name it once in
+~/.agents/workspace.yaml:
+
+  repository: <owner>/<repo>
+  path: ~/projects/<repo>
+
+Then re-run `make resume`.' 'R1 wording for resume' || return 1
+    assert_file_absent "$empty_home/.agents" 'no-workspace-config created nothing in HOME' || return 1
+    assert_equal '0' "$(commit_count "$root/worktrees/001-routing-core/spec")" \
+        'no-workspace-config committed nothing' 2>/dev/null || true
+    if [ "$(git -C "$root/worktrees/001-routing-core/spec" log -1 --format=%s)" != 'fixture commit' ]; then
+        printf 'assertion failed: a refused park still committed\n' >&2
+        return 1
+    fi
+}
+
+test_two_workstations_share_the_workspace_repository() {
+    local stderr_file="$FIXTURE_ROOT/two-workstations.stderr"
+    local root second_workspace first_workspace log
+
+    # Given: one project and two clones of the workspace repository, with a
+    # peer's uncommitted edit sitting in the second one.
+    initialize_three_leg_parked_fixture 'two-workstations' "$PARKED_CONFIG" || return 1
+    initialize_workspace_fixture 'two-workstations-ws' || return 1
+    root="$PARKED_ROOT"
+    first_workspace="$WORKSPACE_DIR"
+    second_workspace="$FIXTURE_ROOT/two-workstations-ws/workspace-2"
+    clone_workspace_fixture "$second_workspace" || return 1
+    create_parked_feature "$root" 'Add routing core' "$stderr_file" || return 1
+    printf 'draft\n' > "$root/worktrees/001-routing-core/spec/specs/001-routing-core/spec.md" || return 1
+
+    # When: the first workstation parks.
+    invoke_park "$root" "$stderr_file"
+    assert_equal '0' "$PARK_STATUS" 'first workstation park exit code' || return 1
+
+    # When: the second workstation parks, over a peer's in-flight edit.
+    printf 'a peer was editing this\n' > "$second_workspace/workspaces/peer.yaml" || return 1
+    printf 'draft again\n' >> "$root/worktrees/001-routing-core/spec/specs/001-routing-core/spec.md" || return 1
+    WORKSPACE_DIR="$second_workspace"
+    invoke_park "$root" "$stderr_file"
+    WORKSPACE_DIR="$first_workspace"
+    assert_equal '0' "$PARK_STATUS" 'second workstation park exit code' || return 1
+
+    # Then: the peer's edit is its own commit, ours rebased on top, and both
+    # parks are in the shared history.
+    log="$(git -C "$second_workspace" log --format=%s origin/main)"
+    if ! printf '%s\n' "$log" | grep -Fq 'park(pre-existing@Fixture): 1 file(s)'; then
+        printf 'assertion failed: the pre-existing edit was not its own commit\n%s\n' "$log" >&2
+        return 1
+    fi
+    assert_equal '2' "$(printf '%s\n' "$log" | grep -Fc 'park(fixture-project@Fixture):')" \
+        'both parks are in the shared history' || return 1
+    if ! grep -Fq 'a peer was editing this' "$second_workspace/workspaces/peer.yaml"; then
+        printf 'assertion failed: the peer edit was lost\n' >&2
+        return 1
+    fi
+    assert_equal '' "$(git -C "$second_workspace" status --porcelain -- workspaces)" \
+        'the second workspace is clean after the park' || return 1
+    assert_file_absent "$second_workspace/.workspaces.lock" 'the mutex was released'
+}
+
+test_per_org_workspace_override() {
+    local stderr_file="$FIXTURE_ROOT/org-override.stderr"
+    local root home config default_workspace override_workspace status other_root
+
+    # Given: a default workspace, a second workspace for the 'dummy' org, and a
+    # user config that names both.
+    initialize_three_leg_parked_fixture 'org-override' "$PARKED_CONFIG" || return 1
+    root="$PARKED_ROOT"
+    initialize_workspace_fixture 'org-override-default' || return 1
+    default_workspace="$WORKSPACE_DIR"
+    initialize_workspace_fixture 'org-override-dummy' || return 1
+    override_workspace="$WORKSPACE_DIR"
+    home="$FIXTURE_ROOT/org-override/home"
+    config="$home/.agents/workspace.yaml"
+    mkdir -p "$home/.agents" || return 1
+    {
+        printf 'repository: fixture/default-wip\n'
+        printf 'path: %s\n' "$default_workspace"
+        printf 'orgs:\n'
+        printf '  dummy:\n'
+        printf '    repository: dummy/dummy-wip\n'
+        printf '    path: %s\n' "$override_workspace"
+    } > "$config" || return 1
+    create_parked_feature "$root" 'Add routing core' "$stderr_file" || return 1
+    printf 'draft\n' > "$root/worktrees/001-routing-core/spec/specs/001-routing-core/spec.md" || return 1
+
+    # When: park runs with nothing but the config to go on.
+    status=0
+    (cd "$root" && env -u SPECKIT_WORKSPACE_PATH -u SPECKIT_WORKSPACE_REPOSITORY \
+        -u AGENT_PROTOCOL_ROOT HOME="$home" \
+        SPECKIT_WORKSTATION=Fixture SPECKIT_LANE=fixture-lane \
+        bash .specify/extensions/git/scripts/bash/park.sh \
+        > "$stderr_file.out" 2>"$stderr_file") || status=$?
+
+    # Then: the org's own repository holds the manifest, and the default does
+    # not hold it at all.
+    if [ "$status" -ne 0 ]; then
+        printf 'override park failed (%s): %s\n' "$status" "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    if [ ! -f "$override_workspace/workspaces/dummy/fixture-project.yaml" ]; then
+        printf 'assertion failed: the org override repository has no manifest\n' >&2
+        find "$override_workspace/workspaces" -type f >&2
+        return 1
+    fi
+    assert_file_absent "$default_workspace/workspaces/dummy" \
+        'the default workspace received the override org' || return 1
+    if ! grep -Fq "WORKSPACE: $override_workspace (orgs.dummy override)" "$stderr_file.out"; then
+        printf 'assertion failed: park did not name the override\n%s\n' "$(<"$stderr_file.out")" >&2
+        return 1
+    fi
+
+    # When: a project in another org parks with the same config.
+    initialize_three_leg_parked_fixture 'org-override-other' "$PARKED_CONFIG" || return 1
+    other_root="$PARKED_ROOT"
+    set_assembly_repository "$other_root" 'otherorg/fixture-project' || return 1
+    create_parked_feature "$other_root" 'Add routing core' "$stderr_file" || return 1
+    status=0
+    (cd "$other_root" && env -u SPECKIT_WORKSPACE_PATH -u SPECKIT_WORKSPACE_REPOSITORY \
+        -u AGENT_PROTOCOL_ROOT HOME="$home" \
+        SPECKIT_WORKSTATION=Fixture SPECKIT_LANE=fixture-lane \
+        bash .specify/extensions/git/scripts/bash/park.sh \
+        > "$stderr_file.out" 2>"$stderr_file") || status=$?
+
+    # Then: it lands in the default workspace, under its own org.
+    if [ "$status" -ne 0 ]; then
+        printf 'default park failed (%s): %s\n' "$status" "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    if [ ! -f "$default_workspace/workspaces/otherorg/fixture-project.yaml" ]; then
+        printf 'assertion failed: the default workspace has no manifest for the other org\n' >&2
+        find "$default_workspace/workspaces" -type f >&2
+        return 1
+    fi
+    if ! grep -Fq "WORKSPACE: $default_workspace (default)" "$stderr_file.out"; then
+        printf 'assertion failed: park did not name the default\n%s\n' "$(<"$stderr_file.out")" >&2
+        return 1
+    fi
+
+    # When: --workspace is given as well.
+    WORKSPACE_DIR="$default_workspace"
+    invoke_park "$root" "$stderr_file"
+    assert_equal '0' "$PARK_STATUS" '--workspace park exit code' || return 1
+
+    # Then: it beats the override.
+    if [ ! -f "$default_workspace/workspaces/dummy/fixture-project.yaml" ]; then
+        printf 'assertion failed: --workspace did not beat the org override\n' >&2
+        return 1
+    fi
+    if ! printf '%s\n' "$PARK_OUTPUT" | grep -Fq "WORKSPACE: $default_workspace (--workspace)"; then
+        printf 'assertion failed: park did not name --workspace\n%s\n' "$PARK_OUTPUT" >&2
+        return 1
+    fi
+
+    # When: the orgs: block is malformed.
+    {
+        printf 'repository: fixture/default-wip\n'
+        printf 'path: %s\n' "$default_workspace"
+        printf 'orgs:\n'
+        printf '  dummy: %s\n' "$override_workspace"
+    } > "$config" || return 1
+    status=0
+    (cd "$root" && env -u SPECKIT_WORKSPACE_PATH -u SPECKIT_WORKSPACE_REPOSITORY \
+        -u AGENT_PROTOCOL_ROOT HOME="$home" \
+        bash .specify/extensions/git/scripts/bash/park.sh \
+        >/dev/null 2>"$stderr_file") || status=$?
+
+    # Then: it refuses by name rather than falling back to the default.
+    assert_equal '2' "$status" 'malformed orgs: exit code' || return 1
+    if ! grep -Fq "Error: workspace-config-invalid: the orgs: block in $config is malformed (org 'dummy' must be a block with repository: and path:); nothing was parked." "$stderr_file"; then
+        printf 'assertion failed: missing workspace-config-invalid refusal\n%s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    status=0
+    (cd "$root" && env -u SPECKIT_WORKSPACE_PATH -u AGENT_PROTOCOL_ROOT HOME="$home" \
+        bash .specify/extensions/git/scripts/bash/resume.sh \
+        >/dev/null 2>"$stderr_file") || status=$?
+    assert_equal '2' "$status" 'malformed orgs: resume exit code' || return 1
+    grep -Fq 'nothing was resumed.' "$stderr_file"
+}
+
+test_single_repo_park_and_resume() {
+    local stderr_file="$FIXTURE_ROOT/single-park.stderr"
+    local base repo origin clone worktree branch manifest
+
+    # Given: a single-repository Speckit checkout with a bare origin and one
+    # feature worktree carrying WIP.
+    base="$FIXTURE_ROOT/single-park"
+    repo="$base/single"
+    origin="$base/single-origin.git"
+    mkdir -p "$base" || return 1
+    initialize_fixture "$repo" $'checkout_mode: worktree\nbase_branch: main' || return 1
+    install_park_scripts "$repo" || return 1
+    git -C "$repo" add -A || return 1
+    git -C "$repo" commit -qm 'install park scripts' || return 1
+    init_bare_repo "$origin" || return 1
+    git -C "$repo" remote add origin "$origin" || return 1
+    git -C "$repo" push -q -u origin main || return 1
+    initialize_workspace_fixture 'single-park-ws' || return 1
+
+    if ! create_parked_feature "$repo" 'Add routing core' "$stderr_file"; then
+        printf 'single-repo feature creation failed: %s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    branch='001-routing-core'
+    worktree="$base/single-worktrees/$branch"
+    assert_worktree "$branch" "$worktree" || return 1
+    printf 'draft\n' > "$worktree/notes.txt" || return 1
+
+    # When: park runs at the repository root.
+    invoke_park "$repo" "$stderr_file"
+    if [ "$PARK_STATUS" -ne 0 ]; then
+        printf 'single-repo park failed (%s): %s\n' "$PARK_STATUS" "$(<"$stderr_file")" >&2
+        return 1
+    fi
+
+    # Then: one leg, recorded as role: repo, in a manifest named for the
+    # repository directory, under the "local" org: a single-repository fixture
+    # declares no owner and nothing invents one.
+    manifest="$WORKSPACE_DIR/workspaces/local/single.yaml"
+    if [ ! -f "$manifest" ]; then
+        printf 'assertion failed: no manifest at %s\n' "$manifest" >&2
+        return 1
+    fi
+    grep -Fq '    shape: single' "$manifest" || {
+        printf 'assertion failed: shape single\n%s\n' "$(<"$manifest")" >&2
+        return 1
+    }
+    assert_equal '1' "$(manifest_line_count "$manifest" '^          - role: repo$')" \
+        'single-repo leg role' || return 1
+    if grep -Fq 'feature_directory:' "$manifest"; then
+        printf 'assertion failed: a single-repository manifest recorded a feature_directory\n' >&2
+        return 1
+    fi
+
+    # When: a fresh clone resumes it. A single-repository project is named by
+    # its directory, so the second checkout carries the same directory name.
+    mkdir -p "$base/second" || return 1
+    clone="$base/second/single"
+    git clone -q "$origin" "$clone" || return 1
+    git -C "$clone" config user.name 'Spec Kit test' || return 1
+    git -C "$clone" config user.email 'spec-kit-test@example.invalid' || return 1
+    invoke_resume "$clone" "$stderr_file"
+    if [ "$RESUME_STATUS" -ne 0 ]; then
+        printf 'single-repo resume failed (%s): %s\n' "$RESUME_STATUS" "$(<"$stderr_file")" >&2
+        return 1
+    fi
+
+    # Then: the worktree is back, the WIP un-committed, no feature.json, and
+    # the state file restored.
+    assert_worktree "$branch" "$base/second/single-worktrees/$branch" || return 1
+    assert_equal 'draft' "$(cat "$base/second/single-worktrees/$branch/notes.txt")" 'the parked content is back' || return 1
+    assert_file_absent "$clone/.specify/feature.json" 'a single-repository feature.json' || return 1
+    assert_equal "$branch" \
+        "$(json_field "$(<"$clone/.git/speckit-last-worktree.json")" BRANCH_NAME)" \
+        'single-repo state file'
+}
+
 failures=0
 run_scenario() {
     local name="$1"
@@ -2004,6 +3255,26 @@ run_scenario 'three-leg refuses an existing feature directory' test_three_leg_re
 run_scenario 'three-leg rolls back the spec leg when the code leg fails' test_three_leg_rolls_back_when_code_leg_fails
 run_scenario 'three-leg discovery reports the feature and both leg worktrees' test_three_leg_get_last_worktree_reports_feature
 run_scenario 'three-leg auto-commit commits both legs and never the root' test_three_leg_auto_commit_commits_both_legs_only
+run_scenario 'park commits and pushes a WIP commit in both legs and never at the root' test_park_commits_and_pushes_both_legs
+run_scenario 'park with nothing uncommitted makes no commit' test_park_clean_feature_makes_no_commit
+run_scenario 'park enumerates from git worktree list, not feature.json' test_park_enumerates_from_git_not_feature_json
+run_scenario 'park refuses a leg with no origin remote' test_park_refuses_a_leg_without_origin
+run_scenario 'park refuses a rebase in progress and commits nothing there' test_park_refuses_a_rebase_in_progress
+run_scenario 'park refuses a rejected push and keeps the WIP commit' test_park_refuses_a_rejected_push_and_keeps_the_wip_commit
+run_scenario 'park stacks a second WIP commit without a force-push' test_park_stacks_a_second_wip_without_a_force_push
+run_scenario 'park --dry-run writes nothing' test_park_dry_run_writes_nothing
+run_scenario 'resume recreates the worktrees, feature.json and the state file' test_resume_recreates_worktrees_feature_json_and_state
+run_scenario 'resume un-commits exactly the parked WIP' test_resume_uncommits_exactly_the_parked_wip
+run_scenario 'resume refuses on divergence with the exact wording' test_resume_refuses_on_divergence
+run_scenario 'resume is idempotent when the worktrees already exist' test_resume_is_idempotent
+run_scenario 'resume refuses a foreign directory at the worktree path' test_resume_refuses_a_foreign_directory
+run_scenario 'resume refuses a local branch that diverged from the parked commit' test_resume_refuses_a_local_branch_that_is_not_the_parked_commit
+run_scenario 'resume refuses a local branch behind the parked commit and names the fast-forward' test_resume_refuses_a_local_branch_behind_the_parked_commit
+run_scenario 'the workspace manifest round-trips byte-identically' test_manifest_round_trip
+run_scenario 'a missing workspace config refuses both verbs' test_missing_workspace_config_refuses
+run_scenario 'two workstations share one workspace repository' test_two_workstations_share_the_workspace_repository
+run_scenario 'a per-org workspace override keeps that org out of the default repository' test_per_org_workspace_override
+run_scenario 'single-repository park and resume' test_single_repo_park_and_resume
 
 if [ "$failures" -ne 0 ]; then
     printf 'RED: Speckit Git feature behavior tests failed: %d scenario(s)\n' "$failures" >&2

--- a/devBenches/devcontainer.test/test-speckit-git-feature.sh
+++ b/devBenches/devcontainer.test/test-speckit-git-feature.sh
@@ -2969,7 +2969,7 @@ Then re-run `make resume`.' 'R1 wording for resume' || return 1
 
 test_two_workstations_share_the_workspace_repository() {
     local stderr_file="$FIXTURE_ROOT/two-workstations.stderr"
-    local root second_workspace first_workspace log
+    local root second_workspace first_workspace log clone
 
     # Given: one project and two clones of the workspace repository, with a
     # peer's uncommitted edit sitting in the second one.
@@ -3009,7 +3009,183 @@ test_two_workstations_share_the_workspace_repository() {
     fi
     assert_equal '' "$(git -C "$second_workspace" status --porcelain -- workspaces)" \
         'the second workspace is clean after the park' || return 1
-    assert_file_absent "$second_workspace/.workspaces.lock" 'the mutex was released'
+    assert_file_absent "$second_workspace/.workspaces.lock" 'the mutex was released' || return 1
+
+    # Then: the depth is the BRANCH's, not the stale clone's. The second
+    # workstation's clone knew nothing of the first park, so a depth taken
+    # from the manifest would have recorded 1 over a two-commit stack.
+    if ! grep -Fq '            wip_depth: 2' "$second_workspace/workspaces/dummy/fixture-project.yaml"; then
+        printf 'assertion failed: the stacked depth was not recorded\n%s\n' \
+            "$(<"$second_workspace/workspaces/dummy/fixture-project.yaml")" >&2
+        return 1
+    fi
+    assert_equal '2' "$(git -C "$root/worktrees/001-routing-core/spec" rev-list --count HEAD ^main)" \
+        'two stacked WIP commits on the branch' || return 1
+
+    # Then: a fresh clone resuming from that manifest un-commits BOTH.
+    clone="$PARKED_BASE/second-station"
+    clone_three_leg_root "$root" "$clone" || return 1
+    WORKSPACE_DIR="$second_workspace"
+    invoke_resume "$clone" "$stderr_file"
+    WORKSPACE_DIR="$first_workspace"
+    if [ "$RESUME_STATUS" -ne 0 ]; then
+        printf 'the stacked resume failed (%s): %s\n' "$RESUME_STATUS" "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    assert_equal 'fixture commit' \
+        "$(git -C "$clone/worktrees/001-routing-core/spec" log -1 --format=%s)" \
+        'the stacked resume landed back on the base commit' || return 1
+    assert_equal '' "$(git -C "$clone/worktrees/001-routing-core/spec" diff --cached --name-only)" \
+        'the stacked resume left nothing staged' || return 1
+    if ! git -C "$clone/worktrees/001-routing-core/spec" status --porcelain \
+        | grep -q '^?? specs/001-routing-core/'; then
+        printf 'assertion failed: the stacked resume did not restore the work\n%s\n' \
+            "$(git -C "$clone/worktrees/001-routing-core/spec" status --porcelain)" >&2
+        return 1
+    fi
+}
+
+test_park_against_a_stale_workspace_keeps_a_refused_entry() {
+    local stderr_file="$FIXTURE_ROOT/stale-workspace.stderr"
+    local root first_workspace stale_workspace manifest parked_001
+
+    # Given: two features parked from one clone of the workspace repository,
+    # and a SECOND clone taken before that park — so it knows neither.
+    initialize_three_leg_parked_fixture 'stale-workspace' "$PARKED_CONFIG" || return 1
+    initialize_workspace_fixture 'stale-workspace-ws' || return 1
+    root="$PARKED_ROOT"
+    first_workspace="$WORKSPACE_DIR"
+    stale_workspace="$FIXTURE_ROOT/stale-workspace-ws/workspace-stale"
+    clone_workspace_fixture "$stale_workspace" || return 1
+    create_parked_feature "$root" 'Add routing core' "$stderr_file" || return 1
+    create_parked_feature "$root" 'Add label render' "$stderr_file" || return 1
+    printf 'draft\n' > "$root/worktrees/001-routing-core/spec/specs/001-routing-core/spec.md" || return 1
+    invoke_park "$root" "$stderr_file"
+    if [ "$PARK_STATUS" -ne 0 ]; then
+        printf 'the first park failed (%s): %s\n' "$PARK_STATUS" "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    parked_001="$(git -C "$root/worktrees/001-routing-core/spec" rev-parse HEAD)"
+
+    # Given: 001 can no longer be parked here — its spec leg worktree is gone.
+    git -C "$root/spec" worktree remove --force "$root/worktrees/001-routing-core/spec" || return 1
+
+    # When: park runs against the STALE clone.
+    WORKSPACE_DIR="$stale_workspace"
+    invoke_park "$root" "$stderr_file"
+    WORKSPACE_DIR="$first_workspace"
+
+    # Then: 001 is refused, 002 is parked, and 001's recorded entry SURVIVES —
+    # it is the entry the other workstation resumes from.
+    assert_equal '3' "$PARK_STATUS" 'stale-workspace park exit code' || return 1
+    manifest="$stale_workspace/workspaces/dummy/fixture-project.yaml"
+    if ! grep -Fq '      - branch: 001-routing-core' "$manifest"; then
+        printf 'assertion failed: the refused feature was erased from the manifest\n%s\n' \
+            "$(<"$manifest")" >&2
+        return 1
+    fi
+    if ! grep -Fq "            parked_commit: $parked_001" "$manifest"; then
+        printf 'assertion failed: the refused feature lost its parked commit\n%s\n' \
+            "$(<"$manifest")" >&2
+        return 1
+    fi
+    grep -Fq '      - branch: 002-label-render' "$manifest" || {
+        printf 'assertion failed: the parkable feature was not recorded\n%s\n' "$(<"$manifest")" >&2
+        return 1
+    }
+}
+
+test_park_refuses_a_dirty_workspace_by_name() {
+    local stderr_file="$FIXTURE_ROOT/dirty-workspace.stderr"
+    local root first_workspace peer_workspace before
+
+    # Given: a workspace clone with an uncommitted edit to a tracked handoff,
+    # and an origin that has moved on, so a rebase is actually needed.
+    initialize_three_leg_parked_fixture 'dirty-workspace' "$PARKED_CONFIG" || return 1
+    initialize_workspace_fixture 'dirty-workspace-ws' || return 1
+    root="$PARKED_ROOT"
+    first_workspace="$WORKSPACE_DIR"
+    mkdir -p "$first_workspace/handoffs" || return 1
+    printf 'a handoff\n' > "$first_workspace/handoffs/x.md" || return 1
+    git -C "$first_workspace" add handoffs/x.md || return 1
+    git -C "$first_workspace" commit -qm 'a handoff' || return 1
+    git -C "$first_workspace" push -q origin main || return 1
+    peer_workspace="$FIXTURE_ROOT/dirty-workspace-ws/workspace-peer"
+    clone_workspace_fixture "$peer_workspace" || return 1
+    printf 'a peer commit\n' > "$peer_workspace/handoffs/y.md" || return 1
+    git -C "$peer_workspace" add handoffs/y.md || return 1
+    git -C "$peer_workspace" commit -qm 'a peer commit' || return 1
+    git -C "$peer_workspace" push -q origin main || return 1
+    printf 'half-written\n' >> "$first_workspace/handoffs/x.md" || return 1
+    before="$(cat "$first_workspace/handoffs/x.md")"
+    create_parked_feature "$root" 'Add routing core' "$stderr_file" || return 1
+
+    # When: park runs.
+    invoke_park "$root" "$stderr_file"
+
+    # Then: it refuses by name, not with a false rebase conflict, and the
+    # half-written handoff is untouched.
+    assert_equal '2' "$PARK_STATUS" 'dirty-workspace park exit code' || return 1
+    if ! grep -Fq "Error: workspace-dirty: '$first_workspace' has uncommitted changes outside workspaces/, so it cannot be brought up to date; nothing was parked." "$stderr_file"; then
+        printf 'assertion failed: missing workspace-dirty refusal\n%s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    if ! grep -Fq '  handoffs/x.md' "$stderr_file"; then
+        printf 'assertion failed: the refusal did not name the path\n%s\n' "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    if grep -Fq 'conflicted' "$stderr_file"; then
+        printf 'assertion failed: a dirty checkout was reported as a rebase conflict\n%s\n' \
+            "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    assert_equal "$before" "$(cat "$first_workspace/handoffs/x.md")" 'the handoff is untouched' || return 1
+    assert_file_absent "$first_workspace/.workspaces.lock" 'the mutex was released' || return 1
+    assert_file_absent "$first_workspace/workspaces/dummy" 'a manifest was written anyway'
+}
+
+test_resume_rollback_names_the_leg_for_an_attached_worktree() {
+    local stderr_file="$FIXTURE_ROOT/rollback-attach.stderr"
+    local clone shim_dir spec_tree
+
+    # Given: a clone whose spec leg already carries the branch AT the parked
+    # commit but with no worktree — the state the RR5-behind remediation
+    # leaves behind — so the spec leg attaches while the code leg creates.
+    park_then_clone 'rollback-attach' "$stderr_file" || return 1
+    clone="$RESUME_ROOT"
+    git -C "$clone/spec" fetch -q origin '001-routing-core:001-routing-core' || return 1
+    assert_equal "$RESUME_PARKED_SPEC" \
+        "$(git -C "$clone/spec" rev-parse refs/heads/001-routing-core)" \
+        'the spec leg branch is at the parked commit' || return 1
+    spec_tree="$clone/worktrees/001-routing-core/spec"
+
+    # When: the code leg's worktree add fails, so the run rolls back.
+    shim_dir="$FIXTURE_ROOT/rollback-attach-shim"
+    install_code_worktree_failure_shim "$shim_dir" || return 1
+    RESUME_OUTPUT=''
+    RESUME_STATUS=0
+    RESUME_OUTPUT="$(cd "$clone" && env \
+        SPECKIT_WORKSTATION=Fixture SPECKIT_LANE=fixture-lane \
+        SPECKIT_TEST_REAL_GIT="$REAL_GIT" PATH="$shim_dir:$PATH" \
+        bash .specify/extensions/git/scripts/bash/resume.sh \
+        --workspace "$WORKSPACE_DIR" 2>"$stderr_file")" || RESUME_STATUS=$?
+
+    # Then: the attached spec worktree is really gone — removed through the
+    # LEG that registered it, so no phantom registration is left behind for a
+    # later resume to read as "already registered".
+    assert_equal '2' "$RESUME_STATUS" 'rollback resume exit code' || return 1
+    assert_file_absent "$spec_tree" 'the rolled-back spec worktree' || return 1
+    if git -C "$clone/spec" worktree list --porcelain | grep -Fq "worktree $spec_tree"; then
+        printf 'assertion failed: the spec leg still registers the removed worktree\n%s\n' \
+            "$(git -C "$clone/spec" worktree list --porcelain)" >&2
+        return 1
+    fi
+    assert_equal '1' "$(worktree_record_count "$clone/spec")" 'the spec leg has only its own checkout' || return 1
+
+    # Then: the branch the run did NOT create is still there.
+    assert_equal "$RESUME_PARKED_SPEC" \
+        "$(git -C "$clone/spec" rev-parse refs/heads/001-routing-core)" \
+        'the pre-existing branch was not deleted'
 }
 
 test_per_org_workspace_override() {
@@ -3103,6 +3279,47 @@ test_per_org_workspace_override() {
     fi
     if ! printf '%s\n' "$PARK_OUTPUT" | grep -Fq "WORKSPACE: $default_workspace (--workspace)"; then
         printf 'assertion failed: park did not name --workspace\n%s\n' "$PARK_OUTPUT" >&2
+        return 1
+    fi
+
+    # When: the config spells the org in another case. GitHub org names are
+    # case-insensitive, and routing a confidential org's manifest to the
+    # DEFAULT workspace over a capital letter is the failure this exists to
+    # prevent.
+    initialize_three_leg_parked_fixture 'org-override-case' "$PARKED_CONFIG" || return 1
+    other_root="$PARKED_ROOT"
+    create_parked_feature "$other_root" 'Add routing core' "$stderr_file" || return 1
+    {
+        printf 'repository: fixture/default-wip\n'
+        printf 'path: %s\n' "$default_workspace"
+        printf 'orgs:\n'
+        printf '  DuMmY:\n'
+        printf '    repository: DuMmY/dummy-wip\n'
+        printf '    path: %s\n' "$override_workspace"
+    } > "$config" || return 1
+    rm -rf "$override_workspace/workspaces/dummy" || return 1
+    git -C "$override_workspace" commit -q -am 'drop the manifest' >/dev/null 2>&1 || true
+    status=0
+    (cd "$other_root" && env -u SPECKIT_WORKSPACE_PATH -u SPECKIT_WORKSPACE_REPOSITORY \
+        -u AGENT_PROTOCOL_ROOT HOME="$home" \
+        SPECKIT_WORKSTATION=Fixture SPECKIT_LANE=fixture-lane \
+        bash .specify/extensions/git/scripts/bash/park.sh \
+        > "$stderr_file.out" 2>"$stderr_file") || status=$?
+
+    # Then: the override wins, and the directory keeps the ONE canonical
+    # spelling — the owner segment as written in repository:.
+    if [ "$status" -ne 0 ]; then
+        printf 'case-folded park failed (%s): %s\n' "$status" "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    if [ ! -f "$override_workspace/workspaces/dummy/fixture-project.yaml" ]; then
+        printf 'assertion failed: a differently-cased org key did not reach the override\n' >&2
+        find "$override_workspace/workspaces" "$default_workspace/workspaces" -type f >&2
+        return 1
+    fi
+    if ! grep -Fq "WORKSPACE: $override_workspace (orgs.dummy override)" "$stderr_file.out"; then
+        printf 'assertion failed: park did not name the case-folded override\n%s\n' \
+            "$(<"$stderr_file.out")" >&2
         return 1
     fi
 
@@ -3273,6 +3490,9 @@ run_scenario 'resume refuses a local branch behind the parked commit and names t
 run_scenario 'the workspace manifest round-trips byte-identically' test_manifest_round_trip
 run_scenario 'a missing workspace config refuses both verbs' test_missing_workspace_config_refuses
 run_scenario 'two workstations share one workspace repository' test_two_workstations_share_the_workspace_repository
+run_scenario 'park against a stale workspace keeps a refused feature entry' test_park_against_a_stale_workspace_keeps_a_refused_entry
+run_scenario 'park refuses a dirty workspace by name, not as a rebase conflict' test_park_refuses_a_dirty_workspace_by_name
+run_scenario "resume's rollback removes an attached worktree through its own leg" test_resume_rollback_names_the_leg_for_an_attached_worktree
 run_scenario 'a per-org workspace override keeps that org out of the default repository' test_per_org_workspace_override
 run_scenario 'single-repository park and resume' test_single_repo_park_and_resume
 


### PR DESCRIPTION
Lane: xfactory-2 (xFactory-2)
Claim: https://github.com/opensoft/workBenches/issues/30#issuecomment-5607431796 (this repository's record) — parent claim https://github.com/opensoft/openRepoShape/issues/77#issuecomment-5605258020 (2026-09-09T17:55Z, on Brett Heap's "claim 77 and start on it")
Rulings: https://github.com/opensoft/openRepoShape/issues/77#issuecomment-5605240333 (the four design rulings) and https://github.com/opensoft/openRepoShape/issues/77#issuecomment-5607406339 (the seven plan rulings: refuse-by-default with `--retire-parked-wip`; MOVE the helpers; `--no-push` stays)

Closes #30. Slice S1 of opensoft/openRepoShape#77 — the mechanics. The openRepoShape side (`make park` / `make resume` on the assembly root and the family holder) landed as openRepoShape#80; the workspace repository and the protocol amendment landed in brettheap/new-workstation (PR #4, Amendment 4 ratified 2026-09-09).

**Four commits, in landing order.** (1) `refactor`: eight helpers move verbatim from `create-new-feature.sh` into `git-common.sh` — `get_config_value`, `resolve_path_from_repo_root`, `resolve_git_common_dir`, `select_json_encoder`, `assert_state_file_safe`, `write_last_worktree_state`, `shape_add_leg_worktree`, `shape_persist_feature_json` — with the globals each requires written down beside them. Proof it is a refactor and not a change: `test-speckit-git-feature.sh`, byte-for-byte UNEDITED, ran its 32 scenarios green with only the two script files modified. (2) `feat`: `park.sh`, `resume.sh`, `workspace-common.sh` (bash, `# speckit-overlay-shape: 1` on line 2, shape-aware for three-leg and single-repository roots), the two command docs, `extension.yml`'s two `provides.commands` (no hooks), the README's `## park and resume`, and the installer's manifests — the three scripts join `OVERLAY_SHAPE_MARKER_FILES`, which is what makes an installed overlay read as outdated and be replaced. (3) `test`: 20 scenarios with a bare-origin three-leg fixture and a workspace-repository fixture. (4) `fix`: the divergence refusal aligns its two shas on the values.

**`park`**: enumerates open features from `git worktree list` — never memory, never `feature.json`; per leg, commits uncommitted work as `wip: park <UTC> — lane <lane>`, plain-pushes the feature branch (never force; the ONE leased push, `--force-with-lease=<branch>:<recorded parked_commit>`, retires this workspace's own parked WIP and sits behind `--retire-parked-wip`, default OFF — without it the R8 refusal prints that exact command); a clean leg makes no commit; refusals name a rebase in progress, a missing remote, a rejected push (the WIP commit stays local, the manifest gains no entry), a missing leg worktree. Records `workspaces/<org>/<Family|Project>.yaml` in the person's workspace repository — namespaced by org so two `atlas` projects in two orgs cannot collide — with one commit per park, `pull --rebase` before the write, an explicit pathspec, and a `mkdir` mutex, exactly the shape `lanes-edit.sh` gave the registry. A refused feature keeps its previously recorded entry, so a refusal on one workstation never erases what another resumes from.

**`resume`**: fetches, checks EVERYTHING before touching anything, then per feature `git worktree add` from the pushed branches, rewrites `.specify/feature.json` to the active feature, restores `speckit-last-worktree.json` so `ct`/`cts` land the person where they left off, and soft-resets exactly the parked WIP commits — recognised by three facts together (the `wip: park ` prefix, the tip equal to the recorded commit, single parents to the recorded depth), never the prefix alone. REFUSES on divergence (remote tip != parked commit): parked commit, current tip, the reconciliation commands, and nothing reset over commits this workspace did not park. A local branch that is BEHIND the parked commit gets the fast-forward remediation (`git -C <worktree> pull --ff-only origin <branch>`, then `make resume` again); one that DIVERGED gets rename-or-delete. Idempotent: an existing worktree is left as it is, and a branch that is behind by exactly its own recorded WIP commits is recognised as our own un-committed work, not as drift.

**The workspace config**, `${AGENT_PROTOCOL_ROOT:-$HOME/.agents}/workspace.yaml`: `repository:` and `path:` as the default, plus an optional `orgs:` map so an org whose work must not be indexed outside that org points at its own `<org>/<user>-wip` (openRepoShape#81). Resolution: `--workspace` → `SPECKIT_WORKSPACE_PATH` → `orgs.<org>` → the default → refuse; a malformed `orgs:` block refuses by name rather than falling through to the default. Exit codes 0 / 1 / 2 / 3 (ok / usage-env / refusal-before-anything / partial), a named extension of the extension's 0/1, documented in the README.

**Verification**: host bash 5.2 + git 2.51: 52/52 GREEN; `bash:3.2` container: GREEN (feature + compat); `ubuntu:22.04` git 2.34.1: GREEN; `test-openspeckit-bootstrap.sh`: 742 GREEN; `test-speckit-git-compat.sh`: GREEN; `bash -n` clean everywhere; shellcheck 0.11.0: 0 findings on the three new scripts (pre-existing SC2155/SC2034/SC1003 on the moved bodies left untouched, as the move is verbatim).

**Not here** (S4, operator steps on Brett's word): rerun `setup-openspeckit` in InkRouter/IRRS and IRSS to install the new overlay (the on-PATH command is now a shim over this repository's installer); rebuild the base image so containers carry it (#22's closing comment records the same need); the PowerShell mirror has no park/resume — native Windows parks nothing, documented in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
