### PR TITLE
Vendor the openRepoShape estate commands and pin them: a multi-source upstream-pin.yaml, an update-upstream.py check|apply, openRepoShape/park/resume in /usr/local/bin, and the three-leg fixture derived from the pinned manifest template (#32)

### DIFF
--- a/.github/workflows/speckit-git-bash.yml
+++ b/.github/workflows/speckit-git-bash.yml
@@ -13,6 +13,10 @@ on:
       - devBenches/base-image/files/claude/commands/opsx/**
       - base-image/files/claude/skills/speckit-clarify/SKILL.md
       - devBenches/base-image/files/ct/ct-functions.zsh
+      - devBenches/base-image/upstream-pin.yaml
+      - devBenches/base-image/update-upstream.py
+      - devBenches/base-image/files/openreposhape/**
+      - devBenches/base-image/files/openrepotools/**
   pull_request:
     paths:
       - .github/workflows/speckit-git-bash.yml
@@ -25,6 +29,10 @@ on:
       - devBenches/base-image/files/claude/commands/opsx/**
       - base-image/files/claude/skills/speckit-clarify/SKILL.md
       - devBenches/base-image/files/ct/ct-functions.zsh
+      - devBenches/base-image/upstream-pin.yaml
+      - devBenches/base-image/update-upstream.py
+      - devBenches/base-image/files/openreposhape/**
+      - devBenches/base-image/files/openrepotools/**
   workflow_dispatch:
 
 permissions:
@@ -55,6 +63,9 @@ jobs:
           bash --version | sed -n '1p'
           python3 --version
           zsh --version
+
+      - name: Check the vendored upstream copies against their pin
+        run: python3 ./devBenches/base-image/update-upstream.py check
 
       - name: Run bootstrap suite
         run: bash ./devBenches/devcontainer.test/test-openspeckit-bootstrap.sh

--- a/devBenches/base-image/Dockerfile
+++ b/devBenches/base-image/Dockerfile
@@ -135,6 +135,33 @@ RUN chmod 0755 /usr/local/bin/speckit-worktree-enable && \
     find /usr/local/share/speckit-worktree/templates -type f ! \( -name '*.sh' -o -name '*.zsh' -o -name '*.ps1' \) -exec chmod 0644 {} +
 
 # ========================================
+# ESTATE COMMANDS (openRepoShape)
+# ========================================
+# VENDORED, never fetched at build time: the build network may route github.com
+# through a VPN tunnel whose MTU breaks TLS, which is why the Oh My Zsh plugins
+# in Layer 0 come from apt rather than a clone. These copies are pinned by
+# commit and per-file sha256 in ../upstream-pin.yaml; `update-upstream.py check`
+# is what says they still are, and it runs in CI (.github/workflows/
+# speckit-git-bash.yml) and in the devcontainer suite.
+#
+# files/openreposhape/templates/ is NOT copied. It is a fixture input for
+# devBenches/devcontainer.test/test-speckit-git-feature.sh, which derives its
+# three-leg project.yaml from the pinned template; the image installs commands.
+# Do not "fix" the omission.
+#
+# PATH, said out loud: Layer 0 writes $HOME/.local/bin AHEAD of the inherited
+# PATH into /etc/skel/.zshrc and /etc/skel/.bashrc (base-image/Dockerfile:261
+# and :270), so `openRepoShape --install` run in an interactive container shell
+# SHADOWS these pinned copies with whatever the upstream main holds. A
+# non-interactive `docker exec` uses this image's own ENV PATH, where these
+# win. Accepted, not fixed: fetching at build time is what the network
+# constraint above forbids.
+COPY files/openreposhape/openRepoShape /usr/local/bin/openRepoShape
+COPY files/openreposhape/park /usr/local/bin/park
+COPY files/openreposhape/resume /usr/local/bin/resume
+RUN chmod 0755 /usr/local/bin/openRepoShape /usr/local/bin/park /usr/local/bin/resume
+
+# ========================================
 # AI META-HARNESS (OMNIGENT)
 # ========================================
 # Omnigent wraps the Layer 0 codex/claude CLIs behind one CLI + web UI.

--- a/devBenches/base-image/Dockerfile
+++ b/devBenches/base-image/Dockerfile
@@ -156,6 +156,11 @@ RUN chmod 0755 /usr/local/bin/speckit-worktree-enable && \
 # non-interactive `docker exec` uses this image's own ENV PATH, where these
 # win. Accepted, not fixed: fetching at build time is what the network
 # constraint above forbids.
+#
+# `openRepoShape --version` prints `(opensoft/openRepoShape @ main)`, not the
+# pinned commit: $OPENREPOSHAPE_REF defaults to `main` upstream and this image
+# does not set it. The identity of these bytes is ../upstream-pin.yaml, not
+# what the command says about itself.
 COPY files/openreposhape/openRepoShape /usr/local/bin/openRepoShape
 COPY files/openreposhape/park /usr/local/bin/park
 COPY files/openreposhape/resume /usr/local/bin/resume

--- a/devBenches/base-image/files/openreposhape/openRepoShape
+++ b/devBenches/base-image/files/openreposhape/openRepoShape
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# openRepoShape — the short way in: `openRepoShape Atlas --org <your-org>`.
+#
+# Install it once, from anywhere, with no checkout and no clone:
+#
+#   gh api repos/opensoft/openRepoShape/contents/openRepoShape \
+#       -H 'Accept: application/vnd.github.raw' | bash -s -- --install
+#
+# (or the raw-URL twin, `curl -fsSL …/main/openRepoShape | bash -s -- --install`).
+#
+# IT ADDS NO BEHAVIOUR: it fetches `setup.sh` from opensoft/openRepoShape and
+# runs it, turning the positional <Project> into `--project <Project>` and
+# passing every other argument through untouched. The README's long
+# `curl … | bash -s -- --org … --project …` line and this do the same thing.
+#
+# `--install` PLACES THREE COMMANDS, not one: this file, `park` and `resume`
+# (#82). One install line for the whole standard, so a second engineer gets
+# the estate verbs from the README's one line and nothing depends on anyone's
+# dotfiles. The two of them add no behaviour either — they find the estate and
+# run its own `make park` / `make resume`.
+
+set -euo pipefail
+
+# $OPENREPOSHAPE_REPO is an owner/name slug here (it is an API path), while
+# setup.sh reads the same variable as something to `git clone` — see
+# shape_clone_url below: one name, both uses.
+REPO="${OPENREPOSHAPE_REPO:-opensoft/openRepoShape}"
+REF="${OPENREPOSHAPE_REF:-main}"
+SELF="${BASH_SOURCE[0]:-$0}"
+
+PROJECT=""
+ORG=""
+MODE="run"
+DOCTOR=0
+PASSTHROUGH=()
+WORKDIR=""
+STAGED=""
+
+say() { printf '%s\n' "$*"; }
+die() { printf '\nREFUSED: %s\n' "$1" >&2; exit "${2:-2}"; }
+
+usage() {
+	cat <<'USAGE'
+openRepoShape <Project> [--org <org>] [setup-project.py options] [-- <scaffold flags>]
+openRepoShape --install            install (or update) this command into ~/.local/bin
+openRepoShape --doctor             check this machine and stop; creates nothing
+openRepoShape --help | --version
+
+<Project> is the assembly-root name, ONE CamelCase token (e.g. Atlas); omit it
+and setup.sh asks, if a terminal is attached. `--org` comes from that flag,
+else $OPENREPOSHAPE_ORG, else a prompt — it is NEVER defaulted. Every other
+argument reaches setup.sh unchanged: --visibility, --elected-by, --family,
+--into, --yes, --local-remote-dir, and anything after `--`, which setup.sh
+hands on to scaffold-project.py. `./setup.sh --help` prints setup-project.py's
+usage, which lists them all.
+
+`--install` places THREE commands, and each is one file:
+
+  openRepoShape <Project> --org <org>    scaffold a project
+  park [<Name>]                          commit, push and RECORD an estate's
+                                         open features, so another workstation
+                                         can take the work up
+  resume [<Name>]                        clone or fast-forward that estate here
+                                         and recreate those features
+
+`park --help` and `resume --help` say the rest. Neither implements any of the
+mechanics: they find the estate under your projects directory and run its own
+`make park` / `make resume`, which run the Speckit git extension's scripts.
+
+  $OPENREPOSHAPE_REPO       owner/name to fetch from (default opensoft/openRepoShape)
+  $OPENREPOSHAPE_REF        the ref to fetch it at   (default main)
+  $OPENREPOSHAPE_ORG        the organisation, when --org is not given
+  $OPENREPOSHAPE_BIN_DIR    where --install puts them (default ~/.local/bin)
+  $OPENREPOSHAPE_SETUP_SH   run this setup.sh on disk instead of fetching one
+USAGE
+}
+
+# THE TRAP BELONGS TO THE SHELL THAT DOES THE WRITING, so this makes the
+# directory and takes no output. It used to `printf` the path and every
+# caller read it as `$(workdir)` — a command substitution, which is a
+# SUBSHELL: `trap … EXIT` set in there is the SUBSHELL's trap and fires the
+# instant the substitution closes, so `rm -rf` ran before a single fetched
+# byte had landed in the directory, and $WORKDIR out here was still empty.
+# A trap only ever fires in the shell that set it. Callers read $WORKDIR.
+workdir() {
+	if [ -z "$WORKDIR" ]; then
+		WORKDIR="$(mktemp -d)"
+		trap 'rm -rf -- "$WORKDIR"' EXIT
+	fi
+}
+
+# THE API FIRST, the raw URL second. `gh api` is authenticated, so it still
+# works inside an organisation whose policy blocks raw.githubusercontent.com;
+# curl is the fallback for a machine with no `gh`. Each attempt writes to a
+# file and is checked before its bytes are used, so a half-written first
+# attempt is never mistaken for a fetch.
+fetch_from_repo() {
+	local path="$1" dest="$2"
+	if command -v gh >/dev/null 2>&1 &&
+		gh api "repos/$REPO/contents/$path?ref=$REF" \
+			-H 'Accept: application/vnd.github.raw' >"$dest" 2>/dev/null &&
+		[ -s "$dest" ]; then
+		return 0
+	fi
+	if command -v curl >/dev/null 2>&1 &&
+		curl -fsSL "https://raw.githubusercontent.com/$REPO/$REF/$path" \
+			>"$dest" 2>/dev/null && [ -s "$dest" ]; then
+		return 0
+	fi
+	# RETURNS rather than dying, so a caller fetching SEVERAL files can report
+	# the whole set instead of stopping mid-way through an install (#82, F10 of
+	# the review on #83). `fetch_or_die` is the one-file spelling.
+	return 1
+}
+
+fetch_or_die() {
+	fetch_from_repo "$1" "$2" || die "could not fetch $1 from $REPO at $REF. Both ways failed:
+    gh api repos/$REPO/contents/$1?ref=$REF
+    curl -fsSL https://raw.githubusercontent.com/$REPO/$REF/$1"
+}
+
+# setup.sh CLONES $OPENREPOSHAPE_REPO when it self-bootstraps, so the child is
+# handed the clone URL of the very repository these bytes came from: name a
+# fork or mirror once and it is used for the fetch AND the clone. A URL or a
+# path on disk (what the tests point it at) goes through untouched.
+shape_clone_url() {
+	case "$REPO" in
+	*://* | *@*:* | /* | .*) printf '%s' "$REPO" ;;
+	*) printf 'https://github.com/%s.git' "$REPO" ;;
+	esac
+}
+
+# THE THREE COMMANDS `--install` PLACES (#82). One list, so the installer, the
+# fetch fallback and the tests cannot disagree about what a complete install
+# is. `openRepoShape` is first because it is the one a person types to get the
+# other two.
+INSTALLABLES=(openRepoShape park resume)
+
+# ALL THREE IN HAND BEFORE ANY OF THEM IS PLACED (#82, F10 of the review on
+# #83). One file at a time, dying on the first fetch that failed, left a
+# person with a NEW `openRepoShape` and no `park` — a half-install that says
+# `installed at` and is not one — and there was nothing on screen to say which
+# of the three were missing. Now every one is collected into the temporary
+# directory first: a failure there replaces NOTHING, names what was not
+# fetched, and exits.
+collect_commands() {
+	local name selfdir="" missing=""
+	# Run from a file, install THOSE bytes: `--install` then needs no network
+	# and no `gh` at all — and `park` and `resume` sit BESIDE this file, in the
+	# checkout and in the repository alike, so the siblings that are there are
+	# copied and only a missing one is fetched. Run from stdin (`curl … | bash
+	# -s -- --install`) there is no file to copy from at all, so each of the
+	# three is fetched at this same ref.
+	if [ -f "$SELF" ]; then
+		selfdir="$(cd -- "$(dirname -- "$SELF")" && pwd)"
+	fi
+	workdir
+	STAGED="$WORKDIR/staged"
+	mkdir -p "$STAGED"
+	for name in "${INSTALLABLES[@]}"; do
+		if [ -n "$selfdir" ] && [ -f "$selfdir/$name" ]; then
+			cp -- "$selfdir/$name" "$STAGED/$name"
+			continue
+		fi
+		fetch_from_repo "$name" "$STAGED/$name" ||
+			missing="${missing:+$missing }$name"
+	done
+	[ -z "$missing" ] || die "could not fetch $missing from $REPO at $REF, so NOTHING was installed
+    and nothing already installed was replaced. \`--install\` places all
+    ${#INSTALLABLES[@]} commands or none: a new openRepoShape beside a missing park is
+    a half-install that reads like a whole one. Both ways were tried:
+    gh api repos/$REPO/contents/<file>?ref=$REF
+    curl -fsSL https://raw.githubusercontent.com/$REPO/$REF/<file>"
+}
+
+install_commands() {
+	local dir="${OPENREPOSHAPE_BIN_DIR:-$HOME/.local/bin}"
+	local name target source verb placed=0
+	collect_commands
+	mkdir -p "$dir"
+	for name in "${INSTALLABLES[@]}"; do
+		source="$STAGED/$name"
+		target="$dir/$name"
+		if [ -e "$target" ] && cmp -s "$source" "$target"; then
+			verb="already installed at $target (unchanged)"
+		else
+			if [ -e "$target" ]; then verb="updated at $target"; else verb="installed at $target"; fi
+			cp -- "$source" "$target"
+		fi
+		# Stamped every time: a copy that is not executable is not a command.
+		chmod 755 "$target"
+		placed=$((placed + 1))
+		say "$name: $verb"
+	done
+	# THE COUNT, out loud: a person reading three lines cannot tell whether a
+	# fourth was meant to be there, and this object is the one that made
+	# `--install` plural.
+	say "openRepoShape: $placed of ${#INSTALLABLES[@]} placed in $dir"
+	# ONE PATH NOTE for the three of them: the directory is the same one.
+	case ":${PATH:-}:" in
+	*":$dir:"*) ;;
+	*)
+		say "  $dir is not on \$PATH. Add it:"
+		say "    export PATH=\"$dir:\$PATH\""
+		;;
+	esac
+}
+
+# --- arguments ------------------------------------------------------------
+while [ $# -gt 0 ]; do
+	case "$1" in
+	-h | --help) usage; exit 0 ;;
+	--version) say "openRepoShape ($REPO @ $REF)"; exit 0 ;;
+	--install) MODE="install"; shift ;;
+	# NAMED, THOUGH `-*` BELOW WOULD ALREADY PASS IT ON. The case exists
+	# for the VARIABLE, not for the passing on: `--doctor` examines the
+	# machine and stops, so the organisation and the <Project> this command
+	# insists on further down — both of them about a run that would CREATE
+	# something — are skipped rather than asked for.
+	--doctor) DOCTOR=1; PASSTHROUGH+=("$1"); shift ;;
+	--org) ORG="${2:?--org needs a value}"; shift 2 ;;
+	--project) PROJECT="${2:?--project needs a value}"; shift 2 ;;
+	# setup.sh's value-taking flags, named so their VALUE is never mistaken
+	# for the positional <Project>. Anything else beginning with a dash is a
+	# lone flag and travels as-is: setup.sh refuses what it does not know, so
+	# a flag is never learned twice.
+	--id | --name | --visibility | --elected-by | --family | --into | --local-remote-dir | --shape-ref)
+		PASSTHROUGH+=("$1" "${2:?$1 needs a value}"); shift 2 ;;
+	--) shift; PASSTHROUGH+=(-- "$@"); break ;;
+	-*) PASSTHROUGH+=("$1"); shift ;;
+	*)
+		[ -z "$PROJECT" ] || die "two project names, '$PROJECT' and '$1'. One positional <Project>, then flags."
+		PROJECT="$1"; shift ;;
+	esac
+done
+
+if [ "$MODE" = "install" ]; then
+	[ -z "$PROJECT" ] && [ ${#PASSTHROUGH[@]} -eq 0 ] ||
+		die "--install takes no other arguments; it only installs the commands."
+	install_commands
+	exit 0
+fi
+
+# NEVER a default organisation. setup.sh refuses `--org opensoft` without
+# --allow-upstream-org for the same reason a guess is refused here: a wrong
+# answer creates three repositories in somebody else's namespace. So: no
+# guess, and --allow-upstream-org passed for nobody.
+#
+# BOTH REFUSALS BELOW ARE ABOUT CREATING SOMETHING, so `--doctor` skips both:
+# it examines the machine and stops, and asking a person which organisation
+# they meant before telling them their machine has no git would be a question
+# with nothing behind it.
+if [ "$DOCTOR" -eq 0 ]; then
+	[ -n "$ORG" ] || ORG="${OPENREPOSHAPE_ORG:-}"
+	if [ -z "$ORG" ] && [ -t 0 ]; then
+		printf 'organisation to scaffold into: '
+		read -r ORG || true
+	fi
+	[ -n "$ORG" ] || die "no organisation to scaffold into. Re-run with --org <your-org>, or set \$OPENREPOSHAPE_ORG."
+
+	# setup.sh prompts for a missing project when a terminal is attached;
+	# with no terminal it cannot, so say so before fetching a script to be
+	# refused by.
+	if [ -z "$PROJECT" ] && [ ! -t 0 ]; then
+		usage >&2
+		die "no <Project> given, and no terminal to ask on."
+	fi
+fi
+
+# An --org typed alongside --doctor is still forwarded rather than dropped —
+# the doctor ignores it, and a flag this command ATE would be a flag the
+# person has to type twice to find out about. Outside --doctor the block above
+# has already made $ORG non-empty or died, so this is what it always was.
+ARGS=()
+[ -z "$ORG" ] || ARGS+=(--org "$ORG")
+[ -z "$PROJECT" ] || ARGS+=(--project "$PROJECT")
+# Fetched at $REF, so setup.sh self-bootstraps its checkout at $REF too:
+# otherwise the script that runs and the standard it clones are two commits.
+[ -z "${OPENREPOSHAPE_REF:-}" ] || ARGS+=(--shape-ref "$REF")
+ARGS+=(${PASSTHROUGH[@]+"${PASSTHROUGH[@]}"})
+
+# $OPENREPOSHAPE_SETUP_SH is the OFFLINE TEST PATH: a setup.sh already on disk
+# instead of a fetched one. It runs where it lies, so setup.sh finds its own
+# checkout around it and clones nothing.
+if [ -n "${OPENREPOSHAPE_SETUP_SH:-}" ]; then
+	SETUP="$OPENREPOSHAPE_SETUP_SH"
+	[ -f "$SETUP" ] || die "\$OPENREPOSHAPE_SETUP_SH is '$SETUP', which is not a file."
+else
+	workdir
+	SETUP="$WORKDIR/setup.sh"
+	fetch_or_die setup.sh "$SETUP"
+fi
+
+# Run the script as a FILE rather than `bash -s --` from a pipe: setup.sh ASKS
+# — for the project name when it was not given, and for the one `yes` before
+# three repositories exist — and a script arriving on stdin is a script whose
+# stdin is not the terminal the person is typing at.
+export OPENREPOSHAPE_REPO="$(shape_clone_url)"
+set +e
+# `${ARGS[@]+...}`, the same guard $PASSTHROUGH gets above. $ARGS is no longer
+# seeded with `--org` unconditionally, so an empty array is reachable here in
+# principle — and under `set -u` bash 3.2, the /bin/bash on every Mac, treats
+# an empty array's `"${ARGS[@]}"` as an unbound variable rather than as
+# nothing at all.
+bash "$SETUP" ${ARGS[@]+"${ARGS[@]}"}
+STATUS=$?
+set -e
+exit "$STATUS"

--- a/devBenches/base-image/files/openreposhape/park
+++ b/devBenches/base-image/files/openreposhape/park
@@ -1,0 +1,842 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# park — leave this workstation with your half-finished work carried, from any
+# folder: `park InkRouter`, or just `park` from inside the estate.
+#
+# Installed with the other two by `openRepoShape --install`.
+#
+# IT ADDS NO MECHANICS, exactly as the `openRepoShape` command adds none. It
+# FINDS THE ESTATE and runs the estate's own `make park` — the family holder's,
+# which fans out to each member's, or the assembly root's — and those targets
+# run the SPECKIT GIT EXTENSION's `park.sh`, which is the one implementation of
+# the WIP commit, the push and the record (#77, RULING 2026-09-09 ruling 1).
+# Then it says what did NOT park and why none of it is park's to touch. It
+# creates nothing, commits nothing and pushes nothing of its own.
+#
+# openRepoShape #82, under Brett Heap's RULING of 2026-09-09: `--repo` matches
+# a LOCAL clone (ruling 1); the command is `park` (ruling 4). Ruling 3 of #82
+# ("with no <Name> and no estate around the cwd this REFUSES and lists what
+# it found") is SUPERSEDED for that one case by Brett Heap's RULING of
+# 2026-09-10 (#91): with no <Name> and no estate around the cwd, `park` now
+# discovers and PARKS EVERY ESTATE under the projects directory, in name
+# order, continuing past a refusal, instead of refusing. `park <Name>`,
+# `park --repo` and the walk-up inside an estate are unchanged either way.
+# `resume` deliberately KEEPS ruling 3's refusal for its own bare form (see
+# its header) — rebuilding every estate on a fresh machine by accident is the
+# opposite risk from failing to park the one you meant.
+
+set -euo pipefail
+
+SELF_NAME="park"
+
+NAME=""
+REPO_SLUG=""
+REPO_ARG=""
+DRY_RUN=0
+LANE=""
+PASSTHROUGH=()
+#: Set only in the bare, no-<Name>, no-estate-around-the-cwd case (#91): the
+#: walk-up found nothing, so every estate under the projects directory gets
+#: parked instead of one refusal. Every other path leaves this 0.
+PARK_ALL=0
+
+say() { printf '%s\n' "$*"; }
+# THE SAME STDERR SHAPE AS `die`, BUT IT RETURNS: a park-everything run (#91)
+# has to report one estate's refusal and carry on to the next, which `die`'s
+# own `exit` cannot do. `die` is this plus the exit, so the two can never
+# print differently by accident.
+refuse() { printf '\nREFUSED: %s\n' "$1" >&2; }
+die() { refuse "$1"; exit "${2:-2}"; }
+
+usage() {
+    cat <<'USAGE'
+park [<Name>] [--repo <owner/name>] [--dry-run] [--lane <name>] [-- ARGS...]
+park --help
+
+Commit, push and RECORD every open feature of one estate, so another
+workstation can take the work up with `resume <Name>`.
+
+<Name> is the estate's folder under your projects directory: a FAMILY folder
+(<Name>/<Name>/family.yaml) or a standalone project root (<Name>/project.yaml).
+With no <Name> the estate around the current directory is used. With NO
+estate around it either, `park` PARKS EVERY ESTATE under your projects
+directory instead of refusing (Brett Heap's RULING of 2026-09-10, #91,
+superseding ruling 3 of #82 for this one case): it lists what it found, then
+runs this same procedure on each one in name order, continuing past a
+refusal or a non-zero `make park`, and ends with a summary. `resume`
+deliberately keeps the old refusal for its own bare form: rebuilding every
+estate on a fresh machine by accident is a worse mistake than failing to park
+the one you meant. `--repo <owner/name>` names the estate by the origin of a
+clone you ALREADY HAVE - in any spelling: the slug, the slug with `.git`, or
+the whole https or ssh url. It never clones (`resume` is the command that
+clones).
+
+  --project <Name>    the positional under a flag (also --name)
+  --dry-run           rehearse: `make park ARGS=--dry-run`, which writes nothing
+  --lane <name>       the lane recorded in the WIP commit subject
+  -- ARGS...          passed on to the extension through `make park ARGS='...'`
+
+  $PROJECTS_DIR       your projects directory (default: ~/projects, then
+                      ~/Projects - people spell it both ways)
+
+WHAT PARK NEVER DOES: it creates nothing, and it moves nobody's HEAD. Commits
+on a `main` that were never pushed, a dirty root mid pin-bump, and ignored
+local files (.env, credentials) are REPORTED and left exactly where they are.
+USAGE
+}
+
+# --- BEGIN shared estate resolver (park and resume carry it byte for byte) --
+#
+# THIS BLOCK IS DUPLICATED IN THE OTHER COMMAND, DELIBERATELY, and
+# `tests/test_park_resume_commands.py` asserts the two copies are IDENTICAL.
+# Each of these is one file a person has on PATH: a shared `orp-estate.sh`
+# would be a fourth file for `--install` to place and a broken command the
+# first time somebody copied only one of them. The rules themselves are NOT
+# new: `<dir>/<Name>/family.yaml` carrying `kind: family-manifest` and naming
+# `<Name>` is `setup-project.py`'s `family_folder_here`, doubled-name layout
+# and all (#76, RULING ruling 3).
+
+# `$PROJECTS_DIR` names ONE directory when it is set. Otherwise both
+# spellings, in that order, because people really do use both - and DEDUPED by
+# inode, because on a case-insensitive filesystem (a stock Mac) `~/projects`
+# and `~/Projects` are the same directory, and listing every estate twice
+# would read as two estates.
+PROJECTS_DIRS=()
+if [ -n "${PROJECTS_DIR:-}" ]; then
+    PROJECTS_DIRS=("$PROJECTS_DIR")
+else
+    PROJECTS_DIRS=("$HOME/projects")
+    if [ -d "$HOME/Projects" ]; then
+        if [ -d "$HOME/projects" ] && [ "$HOME/Projects" -ef "$HOME/projects" ]; then
+            : # one directory under two spellings; name it once
+        else
+            PROJECTS_DIRS+=("$HOME/Projects")
+        fi
+    fi
+fi
+
+# Where a NEW clone would go: the first spelling that already exists, else the
+# first named.
+#
+# shellcheck disable=SC2329  # `park` creates nothing and never calls this. The
+# block is byte-identical in both commands BY DESIGN, so each carries a couple
+# of functions only the other one asks.
+projects_dir_for_new() {
+    local dir
+    for dir in "${PROJECTS_DIRS[@]}"; do
+        if [ -d "$dir" ]; then
+            printf '%s\n' "$dir"
+            return 0
+        fi
+    done
+    printf '%s\n' "${PROJECTS_DIRS[0]}"
+}
+
+trim_unquote() {
+    local value="$1"
+    value="${value%$'\r'}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    case "$value" in
+    '"'*'"') value="${value#\"}"; value="${value%\"}" ;;
+    "'"*"'") value="${value#\'}"; value="${value%\'}" ;;
+    esac
+    printf '%s' "$value"
+}
+
+# ONE FOLDER NAME, and never a path. A `<Name>` off the command line and a
+# `root:` out of somebody's workspace manifest both end up joined to the
+# projects directory, so both are held to this: no empty string, no `/`, and
+# no leading `.` — which is what stops `resume ../../elsewhere/X` from cloning
+# outside the projects directory at all, rather than noticing afterwards.
+is_safe_folder_name() {
+    local name="$1"
+    case "$name" in
+    "" | .* | */*) return 1 ;;
+    esac
+    case "$name" in
+    *[!A-Za-z0-9_.+@-]*) return 1 ;;
+    esac
+    return 0
+}
+
+# One indent-zero scalar out of a small YAML file, with parameter expansion
+# only: no YAML library, no python per line, no forks per line. This is the
+# reader the Speckit extension's `workspace_read_scalar` is, narrowed to the
+# keys these two commands read (`kind`, `name`, `family`, `tracking_branch`).
+YAML_VALUE=""
+yaml_scalar() {
+    local file="$1" key="$2" line
+    YAML_VALUE=""
+    [ -f "$file" ] || return 1
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+        "$key":*) ;;
+        *) continue ;;
+        esac
+        YAML_VALUE="$(trim_unquote "${line#"$key":}")"
+        return 0
+    done <"$file"
+    return 1
+}
+
+# A LINKED WORKTREE, not a checkout of its own: `.git` is a FILE holding a
+# `gitdir:` line, and `--git-dir` and `--git-common-dir` disagree. A
+# single-repository project's FEATURE worktree is a whole `project.yaml` root
+# by construction, so without this the walk-up would answer `<worktree_root>/
+# 001-my-feature` as an estate named after the branch — and `park` would run
+# the write verb inside the very worktree the extension is about to park.
+# GIT'S OWN ANSWER, and not the `.git`-is-a-file shortcut, because that shape
+# is shared with a SUBMODULE and a leg must not be mistaken for a worktree:
+# in a linked worktree `--git-dir` is `<common>/worktrees/<name>` and the two
+# differ; in a submodule both are `<super>/.git/modules/<name>`; in an
+# ordinary checkout both are `.git`. Verified against all three.
+is_linked_worktree() {
+    local dir="$1" gitdir common
+    [ -e "$dir/.git" ] || return 1
+    gitdir="$(git -C "$dir" rev-parse --git-dir 2>/dev/null || true)"
+    common="$(git -C "$dir" rev-parse --git-common-dir 2>/dev/null || true)"
+    [ -n "$gitdir" ] && [ -n "$common" ] && [ "$gitdir" != "$common" ]
+}
+
+# The PINNED copy inside a family holder: `<Family>/<Family>/members/<X>`, so
+# the grandparent carries the `family.yaml`. It is detached, it is what
+# `bootstrap` and `validate` read, and nobody's in-flight work is in it — a
+# walk-up that answered it would run a WRITE verb on a detached HEAD. The
+# working clone BESIDE the holder is the one a person works in, which is the
+# same rule #80's holder dispatch follows.
+is_pinned_member() {
+    local dir="$1" parent grandparent
+    parent="${dir%/*}"
+    [ -n "$parent" ] && [ "$parent" != "$dir" ] || return 1
+    grandparent="${parent%/*}"
+    [ -n "$grandparent" ] && [ "$grandparent" != "$parent" ] || return 1
+    yaml_scalar "$grandparent/family.yaml" kind || return 1
+    [ "$YAML_VALUE" = "family-manifest" ]
+}
+
+# Is `<dir>` a FAMILY FOLDER? All three facts have to agree, exactly as
+# `family_folder_here` requires them to: the holder clone sits at
+# `<dir>/<basename>`, its `family.yaml` says `kind: family-manifest`, and it
+# names that same family. A directory called Northwind is a directory called
+# Northwind; what makes it a family folder is read, never guessed from a name.
+is_family_folder() {
+    local dir="$1" name manifest
+    name="${dir##*/}"
+    [ -n "$name" ] || return 1
+    manifest="$dir/$name/family.yaml"
+    yaml_scalar "$manifest" kind || return 1
+    [ "$YAML_VALUE" = "family-manifest" ] || return 1
+    yaml_scalar "$manifest" name || return 1
+    [ "$YAML_VALUE" = "$name" ]
+}
+
+is_project_root() {
+    local dir="$1"
+    yaml_scalar "$dir/project.yaml" kind || return 1
+    [ "$YAML_VALUE" = "project-manifest" ] || return 1
+    is_pinned_member "$dir" && return 1
+    is_linked_worktree "$dir" && return 1
+    return 0
+}
+
+ESTATE_KIND=""
+ESTATE_DIR=""
+ESTATE_ROOT=""
+ESTATE_NAME=""
+
+# Is THIS directory an estate? A FAMILY FOLDER WINS over a standalone root of
+# the same name: the holder is what drives the members, so a family answered as
+# one of its own members would act on one project and report the estate done.
+estate_here() {
+    local dir="$1"
+    if is_family_folder "$dir"; then
+        ESTATE_KIND="family"
+        ESTATE_DIR="$dir"
+        ESTATE_NAME="${dir##*/}"
+        ESTATE_ROOT="$dir/$ESTATE_NAME"
+        return 0
+    fi
+    if is_project_root "$dir"; then
+        ESTATE_KIND="standalone"
+        ESTATE_DIR="$dir"
+        ESTATE_NAME="${dir##*/}"
+        ESTATE_ROOT="$dir"
+        return 0
+    fi
+    return 1
+}
+
+# The NEAREST estate at or above `<dir>`: the holder beside you, or the project
+# root you are standing in. NEAREST WINS, so standing inside a member of a
+# family acts on that member - the estate the person is standing in. A pinned
+# copy and a linked worktree are WALKED PAST rather than answered, so
+# `<Family>/<Family>/members/<X>` reaches the family folder and a feature
+# worktree reaches the root that owns it.
+estate_walk_up() {
+    local dir="$1"
+    while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+        estate_here "$dir" && return 0
+        dir="${dir%/*}"
+    done
+    return 1
+}
+
+estate_by_name() {
+    local want="$1" dir
+    is_safe_folder_name "$want" || return 1
+    for dir in "${PROJECTS_DIRS[@]}"; do
+        estate_here "$dir/$want" && return 0
+    done
+    return 1
+}
+
+# Every estate under the projects directory, one row each. What ruling 3 asks
+# a refusal to print: a person who typed the command in the wrong folder needs
+# the names, not an instruction to go and look for them.
+list_estates() {
+    local dir child
+    for dir in "${PROJECTS_DIRS[@]}"; do
+        [ -d "$dir" ] || continue
+        for child in "$dir"/*; do
+            [ -d "$child" ] || continue
+            if is_family_folder "$child"; then
+                printf '  family   %-20s %s\n' "${child##*/}" "$child"
+            elif is_project_root "$child"; then
+                printf '  project  %-20s %s\n' "${child##*/}" "$child"
+            fi
+        done
+    done
+}
+
+estates_or_none() {
+    local rows
+    rows="$(list_estates)"
+    if [ -n "$rows" ]; then
+        printf '%s\n' "$rows"
+    else
+        printf '  (none)\n'
+    fi
+}
+
+lower() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+
+# `owner/name` — CASE PRESERVED, so a refusal prints back what a person can
+# type — out of any spelling git accepts: owner/name, owner/name.git,
+# https://host/owner/name(.git), git@host:owner/name.git,
+# ssh://git@host/owner/name.git, and a token-bearing https url. Callers
+# compare with `lower` on both sides, because GitHub owners and names are
+# case-insensitive.
+#
+# A FILESYSTEM PATH IS REFUSED rather than parsed, for the reason the
+# extension's own `workspace_org_from_url` refuses one: `/srv/remotes/Name.git`
+# has a name but no owner, and inventing `remotes` as the owner would let
+# `--repo remotes/Name` match a bare repository on disk. Such a clone answers
+# `<Name>` and the walk-up; it does not answer `--repo`.
+repo_slug_of() {
+    local url="$1" rest owner name
+    rest="$url"
+    case "$rest" in
+    /* | ./* | ../* | [A-Za-z]:[/\\]* | file://*) return 1 ;;
+    esac
+    rest="${rest%/}"
+    rest="${rest%.git}"
+    case "$rest" in
+    *://*)
+        rest="${rest#*://}"
+        rest="${rest#*@}"
+        rest="${rest#*/}"
+        ;;
+    *@*:*)
+        rest="${rest#*@}"
+        rest="${rest#*:}"
+        ;;
+    esac
+    case "$rest" in
+    */*) ;;
+    *) return 1 ;;
+    esac
+    name="${rest##*/}"
+    owner="${rest%/*}"
+    owner="${owner##*/}"
+    [ -n "$owner" ] && [ -n "$name" ] || return 1
+    case "$owner$name" in
+    *[!A-Za-z0-9_.-]*) return 1 ;;
+    esac
+    printf '%s/%s\n' "$owner" "$name"
+}
+
+# The clone under the projects directory whose `origin` IS that repository -
+# ruling 1. Two levels deep, because the estates this standard places are
+# `<projects>/<Project>` and `<projects>/<Family>/<Project>`.
+clone_with_origin() {
+    local want dir candidate origin found
+    want="$(lower "$1")"
+    for dir in "${PROJECTS_DIRS[@]}"; do
+        [ -d "$dir" ] || continue
+        for candidate in "$dir"/*/ "$dir"/*/*/; do
+            candidate="${candidate%/}"
+            [ -e "$candidate/.git" ] || continue
+            origin="$(git -C "$candidate" remote get-url origin 2>/dev/null || true)"
+            [ -n "$origin" ] || continue
+            found="$(repo_slug_of "$origin" || true)"
+            [ -n "$found" ] || continue
+            if [ "$(lower "$found")" = "$want" ]; then
+                printf '%s\n' "$candidate"
+                return 0
+            fi
+        done
+    done
+    return 1
+}
+
+# The family's members, by the same `  - project: <Project>` row `family.py`
+# writes and `siblings.py` reads. The working clone is `<family folder>/
+# <Project>`, beside the holder.
+family_members() {
+    local manifest="$1" line
+    [ -f "$manifest" ] || return 0
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+        "  - project: "*) printf '%s\n' "$(trim_unquote "${line#  - project: }")" ;;
+        esac
+    done <"$manifest"
+}
+
+# The branch a checkout belongs on: its OWN manifest's `tracking_branch:` —
+# the field `scripts/bootstrap.py` already reads to place the legs — falling
+# back to `main`. The workspace manifest records a `tracking_branch` too, but
+# that is PROVENANCE from the machine that parked; the local declaration is
+# what this machine's clone actually tracks, and the extension takes the same
+# line about `worktree_root`.
+tracking_branch_of() {
+    local root="$1"
+    if yaml_scalar "$root/family.yaml" tracking_branch && [ -n "$YAML_VALUE" ]; then
+        printf '%s\n' "$YAML_VALUE"
+        return 0
+    fi
+    if yaml_scalar "$root/project.yaml" tracking_branch && [ -n "$YAML_VALUE" ]; then
+        printf '%s\n' "$YAML_VALUE"
+        return 0
+    fi
+    printf 'main\n'
+}
+
+# The legs a root declares, by path, out of `project.yaml`'s `legs:` block —
+# the same rows `scripts/bootstrap.py` reads, and in the order it reads them,
+# `role:` before `path:`. The assembly leg is `path: "."` and is the root
+# itself, so it is not one of these.
+#
+# shellcheck disable=SC2329  # only `resume` bootstraps a root, so only
+# `resume` has to ask where its legs are; see the note above.
+legs_of() {
+    local root="$1" line role="" path=""
+    [ -f "$root/project.yaml" ] || return 0
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
+        case "$line" in
+        '  - role:'*)
+            role="$(trim_unquote "${line#*:}")"
+            path=""
+            ;;
+        '    path:'*)
+            path="$(trim_unquote "${line#*:}")"
+            [ -n "$role" ] || continue
+            [ "$role" != "assembly" ] || continue
+            [ "$path" != "." ] || continue
+            [ -n "$path" ] && printf '%s\n' "$path"
+            ;;
+        [![:space:]]*) role=""; path="" ;;
+        esac
+    done <"$root/project.yaml"
+}
+# --- END shared estate resolver ---------------------------------------------
+
+# The legs AS MOUNTED, out of `.gitmodules` — the same file `make bootstrap`
+# mounts them from. Not the shared `legs_of`, which reads what `project.yaml`
+# DECLARES: the report is about what is on disk and might hold an unpushed
+# commit, so a leg mounted somewhere unusual, or one whose manifest row was
+# hand-edited away, still has to be asked. `git config --get-regexp` prints
+# `key value`, so the value is everything after the first space.
+submodule_paths() {
+    local root="$1" line path
+    [ -f "$root/.gitmodules" ] || return 0
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        path="${line#* }"
+        [ -n "$path" ] || continue
+        [ -e "$root/$path/.git" ] || continue
+        printf '%s\n' "$path"
+    done < <(git -C "$root" config --file .gitmodules \
+        --get-regexp '^submodule\..*\.path$' 2>/dev/null || true)
+}
+
+# --- what did not park ------------------------------------------------------
+
+# `label<TAB>path` per repository the report reads.
+#
+# `members/<Project>` INSIDE A FAMILY HOLDER IS DELIBERATELY NOT HERE. That
+# copy is pinned and DETACHED, for `bootstrap` and `validate`; nobody's
+# in-flight work is in it, and it carries no local `main` to be ahead of. The
+# working clone BESIDE the holder is where a person works, so it is what is
+# read - the same reason the holder's own `park` target dispatches there (#80).
+report_repos() {
+    local leg member branch
+    if [ "$ESTATE_KIND" = "family" ]; then
+        printf 'holder\t%s\t%s\n' "$(tracking_branch_of "$ESTATE_ROOT")" \
+            "$ESTATE_ROOT"
+        while IFS= read -r member; do
+            [ -e "$ESTATE_DIR/$member/.git" ] || continue
+            branch="$(tracking_branch_of "$ESTATE_DIR/$member")"
+            printf 'root\t%s\t%s\n' "$branch" "$ESTATE_DIR/$member"
+            while IFS= read -r leg; do
+                # A LEG'S branch is the ROOT's `tracking_branch:` — that is
+                # the one value `scripts/bootstrap.py` places every leg on.
+                printf 'leg\t%s\t%s\n' "$branch" "$ESTATE_DIR/$member/$leg"
+            done < <(submodule_paths "$ESTATE_DIR/$member")
+        done < <(family_members "$ESTATE_ROOT/family.yaml")
+        return 0
+    fi
+    branch="$(tracking_branch_of "$ESTATE_ROOT")"
+    printf 'root\t%s\t%s\n' "$branch" "$ESTATE_ROOT"
+    while IFS= read -r leg; do
+        printf 'leg\t%s\t%s\n' "$branch" "$ESTATE_ROOT/$leg"
+    done < <(submodule_paths "$ESTATE_ROOT")
+}
+
+# Commits on the TRACKING BRANCH that origin has never seen. The branch is
+# the root's own `tracking_branch:` and not a hard-coded `main`: a project
+# that ships from `trunk` would otherwise have been asked a question about a
+# branch it does not have and answered "nothing", which is worse than not
+# asking. BOTH refs must exist locally or there is no question to ask — a
+# detached pinned checkout has no local branch, and a clone with no remote has
+# no remote-tracking one. It is read against the remote-tracking ref this
+# machine already has: park fetches nothing, so the count is as of the last
+# fetch and the report says so.
+unpushed_on_tracking() {
+    local repo="$1" branch="$2"
+    [ -n "$branch" ] || return 1
+    git -C "$repo" rev-parse --verify -q "refs/heads/$branch" >/dev/null 2>&1 || return 1
+    git -C "$repo" rev-parse --verify -q "refs/remotes/origin/$branch" >/dev/null 2>&1 || return 1
+    git -C "$repo" rev-list --count "origin/$branch..$branch" 2>/dev/null || return 1
+}
+
+# A dirty ROOT, which is where a pin bump happens. It also answers for a dirty
+# LEG: `git status --porcelain` at a root with submodules reports a leg whose
+# checkout has changes as ` M <leg>`, so one question covers both.
+dirty_count() {
+    local repo="$1" out
+    out="$(git -C "$repo" status --porcelain 2>/dev/null || true)"
+    [ -n "$out" ] || return 1
+    printf '%s\n' "$out" | wc -l | tr -d ' '
+}
+
+LEFT=0
+
+not_parked_report() {
+    local label branch path count
+    say ""
+    say "what park does NOT carry, and why none of it is park's to touch:"
+    while IFS=$'\t' read -r label branch path; do
+        [ -n "${path:-}" ] || continue
+        count="$(unpushed_on_tracking "$path" "$branch" || true)"
+        if [ -n "$count" ] && [ "$count" != "0" ]; then
+            LEFT=$((LEFT + 1))
+            printf '  unpushed %-6s %-7s %s\n' "$branch" "$label" "$path"
+            printf '                 %s commit(s) on %s that origin has not seen (as of the last fetch).\n' "$count" "$branch"
+            if [ "$label" = "leg" ]; then
+                printf '                 A leg goes up as a pull request too; park carries FEATURE branches only.\n'
+            else
+                printf '                 The root is PR-only - land them as a pull request; park never pushes %s.\n' "$branch"
+            fi
+        fi
+        case "$label" in
+        holder | root)
+            count="$(dirty_count "$path" || true)"
+            if [ -n "$count" ]; then
+                LEFT=$((LEFT + 1))
+                printf '  uncommitted    %-7s %s\n' "$label" "$path"
+                printf '                 %s path(s) changed at the root. A pin bump in progress is not\n' "$count"
+                printf "                 park's to commit: the root carries no feature branch at all.\n"
+            fi
+            ;;
+        esac
+    done < <(report_repos)
+    printf '  ignored files  never travel. .env, credentials and every other\n'
+    printf '                 gitignored file come back from your secrets manager, not from git.\n'
+    if [ "$LEFT" -eq 0 ]; then
+        say "  nothing else was left behind: no unpushed tracking-branch commit, no dirty root."
+    fi
+}
+
+require_make() {
+    command -v make >/dev/null 2>&1 ||
+        die "no \`make\` on PATH, so the estate's own \`make park\` cannot be run.
+    Install it (\`xcode-select --install\` on macOS, \`sudo apt-get install -y
+    make\` on Debian and Ubuntu), then re-run \`$SELF_NAME\`."
+}
+
+# --- run one estate's own `make park` ---------------------------------------
+#
+# FACTORED OUT so park-everything (#91, below) calls exactly what `park
+# <Name>` calls: one `make park`, one not-carried report, one outcome line.
+# ESTATE_KIND / ESTATE_DIR / ESTATE_ROOT / ESTATE_NAME must already be set —
+# by `estate_walk_up`, `estate_by_name`, `clone_with_origin`, or, for
+# park-everything, a direct `estate_here` on a discovered child. RETURNS a
+# status rather than exiting, so a park-everything run can carry on to the
+# next estate instead of dying on the first refusal or non-zero `make`; the
+# single-estate call site below turns that same return straight into its own
+# exit code, so nothing here behaves differently for either caller.
+run_one_estate() {
+    LEFT=0
+    if [ ! -f "$ESTATE_ROOT/Makefile" ]; then
+        refuse "$ESTATE_ROOT has no Makefile, so it has no \`park\` target to run.
+    A scaffolded root and a family holder both ship one; a root that has lost
+    it is re-synced with \`update-shape.py\`."
+        return 2
+    fi
+
+    # ONE `ARGS=` STRING, because that is the whole interface the two
+    # Makefiles offer (#80): the recipe word-splits `$(ARGS)`, so an argument
+    # carrying a space cannot survive the trip and this command does not
+    # pretend otherwise.
+    MAKE_ARGS=""
+    [ "$DRY_RUN" -eq 0 ] || MAKE_ARGS="--dry-run"
+    if [ -n "$LANE" ]; then
+        MAKE_ARGS="${MAKE_ARGS:+$MAKE_ARGS }--lane $LANE"
+    fi
+    if [ ${#PASSTHROUGH[@]} -gt 0 ]; then
+        MAKE_ARGS="${MAKE_ARGS:+$MAKE_ARGS }${PASSTHROUGH[*]}"
+    fi
+
+    if [ "$ESTATE_KIND" = "family" ]; then
+        say "park: $ESTATE_NAME - the family holder at $ESTATE_ROOT"
+        say "  the members' working clones beside it are where the verb runs."
+    else
+        say "park: $ESTATE_NAME - the assembly root at $ESTATE_ROOT"
+    fi
+    # shellcheck disable=SC2016  # the single quotes are LITERAL: this line is
+    # the `make` invocation a person can copy, and `ARGS='...'` is how they
+    # must type it.
+    say "  make park${MAKE_ARGS:+ ARGS='$MAKE_ARGS'}"
+    say ""
+
+    # THE EXIT CODE IS MAKE'S, UNCHANGED. `park.sh`'s own 0/1/2/3 do not
+    # survive make - GNU make reports ANY non-zero recipe status as its own
+    # exit 2 and prints `Error <code>` - and this command neither rewrites
+    # nor rescues that: the code is in make's diagnostic, and a run that
+    # refused must never read as success. #80's Makefile says the same thing
+    # at the target.
+    # AN ARRAY, so `ARGS=--feature 001-a --dry-run` reaches make as ONE
+    # assignment. `${var:+"..."}` unquoted is one word in bash today and a
+    # thing a reader has to squint at; an array is neither.
+    local -a park_call=(make park)
+    [ -z "$MAKE_ARGS" ] || park_call+=("ARGS=$MAKE_ARGS")
+    local one_status
+    set +e
+    (cd "$ESTATE_ROOT" && exec "${park_call[@]}")
+    one_status=$?
+    set -e
+
+    not_parked_report
+
+    say ""
+    say "park: $ESTATE_NAME - \`make park\` exited $one_status; $LEFT thing(s) above are not park's to carry."
+    if [ "$DRY_RUN" -eq 1 ]; then
+        say "  --dry-run: nothing was committed, pushed or recorded."
+    fi
+    return "$one_status"
+}
+
+# --- park-everything (#91) ---------------------------------------------------
+#
+# Brett Heap's RULING, 2026-09-10, verbatim: "for the park-all, lets make
+# that be park with no estate option. so just park will do park-all." This
+# SUPERSEDES ruling 3 of #82 for THIS CASE ONLY: bare `park`, with no <Name>
+# and no estate around the cwd, no longer refuses. `park <Name>`, `park
+# --repo` and the walk-up above (NEAREST STILL WINS - standing inside an
+# estate parks THAT estate, never the workstation) are exactly as they were.
+# `resume` deliberately keeps ruling 3's refusal for its own bare form - see
+# the note in its header - because rebuilding every estate on a fresh machine
+# by accident is the opposite risk from failing to park the one you meant.
+
+# Every estate under the projects directory, `<name><TAB><dir>` per row, in
+# NAME order rather than discovery order: `~/projects` and `~/Projects` can
+# each hold estates when both exist, and reading them in discovery order
+# would print every estate under one spelling before any estate under the
+# other, instead of together, alphabetically. THE SAME RULES `list_estates`
+# USES - a family folder or a standalone project root, one level under a
+# projects directory - which is what already leaves out a pinned
+# `members/<X>` copy (three levels down) and a linked feature worktree
+# (rejected by `is_project_root` itself).
+all_estate_dirs() {
+    local dir child
+    for dir in "${PROJECTS_DIRS[@]}"; do
+        [ -d "$dir" ] || continue
+        for child in "$dir"/*; do
+            [ -d "$child" ] || continue
+            if is_family_folder "$child" || is_project_root "$child"; then
+                printf '%s\t%s\n' "${child##*/}" "$child"
+            fi
+        done
+    done | LC_ALL=C sort -t $'\t' -k1,1
+}
+
+# Discover every estate and run `run_one_estate` for each, in name order,
+# CONTINUING PAST A REFUSAL OR A NON-ZERO `make park`: one estate's trouble is
+# not a reason to leave the others unparked. A SKIP IS NOT A PASS (#80's
+# rule), so an estate whose own report is not clean - a non-zero `make park`,
+# or a zero one that still left something behind - counts against the
+# overall exit code exactly as a refusal does.
+park_every_estate() {
+    local rows name dir estate_status total=0 bad=0
+    local -a summary=()
+
+    rows="$(all_estate_dirs)"
+    if [ -z "$rows" ]; then
+        # NO ESTATES ANYWHERE ON THIS MACHINE: there is no "every estate" to
+        # park, so this is not park-everything's case to change - the
+        # refusal ruling 3 always printed here stands untouched.
+        die "no estate around $PWD, and no <Name> was given, so nothing was parked.
+    \`park\` never guesses which estate you meant, and it never parks all of
+    them. Name one of these:
+
+$(estates_or_none)
+    ...or \`park --repo <owner/name>\`, for the clone whose origin is that
+    repository."
+    fi
+
+    require_make
+
+    say "park: no estate around $PWD; parking every estate under ${PROJECTS_DIRS[*]}:"
+    say ""
+    say "$(estates_or_none)"
+    say ""
+
+    while IFS=$'\t' read -r name dir; do
+        [ -n "$name" ] || continue
+        estate_here "$dir" || continue
+        total=$((total + 1))
+        say "=== park $ESTATE_NAME ==="
+        estate_status=0
+        run_one_estate || estate_status=$?
+        if [ "$estate_status" -ne 0 ]; then
+            summary+=("  refused    $ESTATE_NAME (exit $estate_status)")
+            bad=$((bad + 1))
+        elif [ "$LEFT" -ne 0 ]; then
+            summary+=("  findings   $ESTATE_NAME ($LEFT thing(s) not carried)")
+            bad=$((bad + 1))
+        else
+            summary+=("  parked     $ESTATE_NAME")
+        fi
+        say ""
+    done <<<"$rows"
+
+    say "park: summary"
+    local line
+    for line in "${summary[@]}"; do
+        say "$line"
+    done
+    say "park: $((total - bad)) estate(s) parked, $bad refused or with findings"
+    [ "$bad" -eq 0 ]
+}
+
+# --- arguments -------------------------------------------------------------
+while [ $# -gt 0 ]; do
+    case "$1" in
+    -h | --help) usage; exit 0 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --lane) LANE="${2:?--lane needs a value}"; shift 2 ;;
+    --repo) REPO_SLUG="${2:?--repo needs a value}"; REPO_ARG="$REPO_SLUG"; shift 2 ;;
+    # `--project <Name>` and `--name <Name>` are the positional under a flag,
+    # because the issue's own words are "park --project <project> or park
+    # --repo <repo> and it defaults to project" (Brett Heap, 2026-09-09). The
+    # value is never mistaken for the positional this way, which is the same
+    # reason `openRepoShape` names its value-taking flags.
+    --name | --project) NAME="${2:?$1 needs a value}"; shift 2 ;;
+    # EVERYTHING AFTER `--` IS THE EXTENSION'S, verbatim. `park.sh` has flags
+    # this command has no opinion about (--feature, --message, --no-push,
+    # --retire-parked-wip) and a command that ate them would be a command
+    # people have to stop using the moment the extension grows one.
+    --) shift; PASSTHROUGH+=("$@"); break ;;
+    -*)
+        usage >&2
+        die "$SELF_NAME does not know $1. Its own flags are listed above; the
+    extension's own flags travel after a \`--\`, so what you want is:
+
+      $SELF_NAME -- $1"
+        ;;
+    *)
+        [ -z "$NAME" ] ||
+            die "two estate names, '$NAME' and '$1'. One positional <Name>, then flags."
+        NAME="$1"; shift ;;
+    esac
+done
+
+[ -z "$NAME" ] || [ -z "$REPO_SLUG" ] ||
+    die "both <Name> ('$NAME') and --repo '$REPO_SLUG'. One estate per run: name it
+    either way, not both."
+
+# --- resolve ---------------------------------------------------------------
+if [ -n "$REPO_SLUG" ]; then
+    # ANY SPELLING A PERSON MIGHT PASTE, through the same reader that reads a
+    # clone's `origin`: `TestOrg/Atlas`, `TestOrg/Atlas.git`, a trailing
+    # slash, or the whole https url they copied out of the browser. Both
+    # sides of the comparison then come from one parser, and the refusal
+    # below can print a clone line that is a url rather than a url wrapped
+    # around another one.
+    REPO_SLUG="$(repo_slug_of "$REPO_SLUG" || true)"
+    [ -n "$REPO_SLUG" ] || die "--repo '$REPO_ARG' is not a repository: it wants <owner>/<name>, or any
+    url spelling of one (https://…/<owner>/<name>.git, git@host:<owner>/<name>).
+    A family's members may live in another organisation, so there is no owner
+    to assume, and a path on disk has none to read."
+    MATCH="$(clone_with_origin "$REPO_SLUG" || true)"
+    [ -n "$MATCH" ] || die "no clone under your projects directory has origin $REPO_SLUG.
+    \`--repo\` names a clone you ALREADY HAVE; it never clones one (RULING
+    2026-09-09 ruling 1). Get it, or bring the whole estate back from its
+    record:
+
+      git clone --recurse-submodules https://github.com/$REPO_SLUG.git
+      resume <Name>          # rebuilds the estate from your workspace record
+
+estates found under your projects directory:
+$(estates_or_none)"
+    estate_walk_up "$MATCH" ||
+        die "$MATCH is a clone of $REPO_SLUG, but nothing at or above it is an
+    estate: no \`family.yaml\` holder beside it and no \`project.yaml\` root. It
+    is a clone, not a project of this shape - \`park\` has no verb to run in it."
+elif [ -n "$NAME" ]; then
+    # A FOLDER NAME, NEVER A PATH. `park ../x` or `park /abs` would otherwise
+    # be joined to the projects directory and land somewhere nobody named.
+    is_safe_folder_name "$NAME" ||
+        die "'$NAME' is not an estate name: it is a path, or it carries a
+    character an estate folder may not. <Name> is ONE folder name under your
+    projects directory — no slash, no leading dot. To act on a checkout
+    somewhere else, stand in it and run \`$SELF_NAME\` with no <Name>."
+    estate_by_name "$NAME" || die "no estate named '$NAME' under your projects directory.
+    An estate is a FAMILY folder ($NAME/$NAME/family.yaml) or a standalone
+    project root ($NAME/project.yaml). Bring it back with \`resume $NAME\`, or
+    park one of these:
+
+$(estates_or_none)"
+else
+    # RULING #91 (Brett Heap, 2026-09-10) SUPERSEDES ruling 3 of #82 for THIS
+    # CASE ONLY: with no <Name> and no estate around the cwd, `park` no
+    # longer refuses — it parks every estate it can find (park_every_estate,
+    # above). The walk-up still wins first: standing inside an estate parks
+    # THAT estate, never the whole workstation.
+    estate_walk_up "$PWD" || PARK_ALL=1
+fi
+
+if [ "$PARK_ALL" -eq 1 ]; then
+    STATUS=0
+    park_every_estate || STATUS=$?
+    exit "$STATUS"
+fi
+
+require_make
+
+STATUS=0
+run_one_estate || STATUS=$?
+exit "$STATUS"

--- a/devBenches/base-image/files/openreposhape/resume
+++ b/devBenches/base-image/files/openreposhape/resume
@@ -1,0 +1,1337 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# resume — arrive at a workstation and get the estate back: `resume InkRouter`.
+#
+# Installed with the other two by `openRepoShape --install`.
+#
+# IT ADDS NO MECHANICS, exactly as the `openRepoShape` command adds none. It
+# REBUILDS OR REFRESHES the estate with the tools that already exist — `git
+# clone`, the root's own `make bootstrap`, the holder's own `make siblings` —
+# and then runs the estate's own `make resume`, which runs the SPECKIT GIT
+# EXTENSION's `resume.sh`: the one implementation of `git worktree add`, the
+# `.specify/feature.json` rewrite and the soft reset (#77, RULING 2026-09-09
+# ruling 1). Every worktree, branch and refusal is that script's.
+#
+# openRepoShape #82, under Brett Heap's RULING of 2026-09-09: this is the ONLY
+# command that clones, and it clones from the manifest (ruling 1); it
+# fast-forwards each sibling's tracking branch with `--ff-only` and REFUSES BY
+# NAME a sibling that is dirty or on a feature branch, never resetting one
+# (ruling 2); the command is `resume` (ruling 4).
+#
+# BARE `resume`, WITH NO <Name> AND NO ESTATE AROUND THE CWD, STILL REFUSES —
+# deliberately NOT changed by Brett Heap's RULING of 2026-09-10 (#91), which
+# supersedes ruling 3 of #82 for `park`'s own bare form only. Rebuilding every
+# estate this machine has a record of, by accident, from one bare `resume` in
+# the wrong folder, is the opposite risk from `park` failing to park the one
+# estate you meant: a clone or a fast-forward per estate is real network and
+# real disk, and undoing an accidental one is not as simple as re-running the
+# command. Ruling #91 names `park` only; this refusal stands.
+#
+# THE ONLY FILE THIS STANDARD EVER WRITES OUTSIDE A REPOSITORY is the two-line
+# user config, and only when `--workspace <owner/name>` asks for it by name on
+# a machine that has none. A person names their own private repository.
+
+set -euo pipefail
+
+SELF_NAME="resume"
+
+NAME=""
+REPO_SLUG=""
+REPO_ARG=""
+WORKSPACE_SLUG=""
+ORG_WANTED=""
+DRY_RUN=0
+PASSTHROUGH=()
+
+say() { printf '%s\n' "$*"; }
+die() { printf '\nREFUSED: %s\n' "$1" >&2; exit "${2:-2}"; }
+
+usage() {
+    cat <<'USAGE'
+resume [<Name>] [--repo <owner/name>] [--workspace <owner/name>] [--org <org>]
+       [--dry-run] [-- ARGS...]
+resume --help
+
+Bring one estate back on this workstation: clone or fast-forward it, bootstrap
+it, place the family's members beside the holder, and then recreate every
+feature `park` recorded.
+
+<Name> is the family or the project as your workspace record names it - the
+manifest file `workspaces/<org>/<Name>.yaml` in the private repository you own.
+With no <Name> the estate around the current directory is refreshed.
+
+  --repo <owner/name>   the estate of a clone you already have, by its
+                        origin - in any url spelling of that repository
+  --workspace <owner/name>
+                        the FIRST time on a fresh machine: clone that private
+                        repository and write ~/.agents/workspace.yaml. This is
+                        the only thing here that writes that file, and only
+                        when you ask for it by name
+  --project <Name>      the positional under a flag (also --name)
+  --org <org>           which org's manifest, when two of them record a <Name>
+  --dry-run             say what would happen; clone nothing, pull nothing
+  -- ARGS...            passed on to the extension through `make resume ARGS=`
+
+  $PROJECTS_DIR             your projects directory (default: ~/projects, then
+                            ~/Projects - people spell it both ways)
+  $AGENT_PROTOCOL_ROOT      where workspace.yaml lives (default: ~/.agents)
+  $OPENREPOSHAPE_REMOTE_BASE
+                            TEST PATH: clone from bare repositories in this
+                            directory (<name>.git) instead of from GitHub, so
+                            the whole flow runs offline
+
+WHAT RESUME NEVER DOES: it resets nothing and it moves nobody's HEAD. A clone
+that is dirty, or on a branch that is not its tracking branch, is REFUSED BY
+NAME and skipped - it is neither fast-forwarded, nor bootstrapped, nor given
+the verb - and so is a root one of whose LEGS is off its tracking branch,
+because that root's own `make bootstrap` would move the leg. The rest of the
+estate still comes back.
+USAGE
+}
+
+# --- BEGIN shared estate resolver (park and resume carry it byte for byte) --
+#
+# THIS BLOCK IS DUPLICATED IN THE OTHER COMMAND, DELIBERATELY, and
+# `tests/test_park_resume_commands.py` asserts the two copies are IDENTICAL.
+# Each of these is one file a person has on PATH: a shared `orp-estate.sh`
+# would be a fourth file for `--install` to place and a broken command the
+# first time somebody copied only one of them. The rules themselves are NOT
+# new: `<dir>/<Name>/family.yaml` carrying `kind: family-manifest` and naming
+# `<Name>` is `setup-project.py`'s `family_folder_here`, doubled-name layout
+# and all (#76, RULING ruling 3).
+
+# `$PROJECTS_DIR` names ONE directory when it is set. Otherwise both
+# spellings, in that order, because people really do use both - and DEDUPED by
+# inode, because on a case-insensitive filesystem (a stock Mac) `~/projects`
+# and `~/Projects` are the same directory, and listing every estate twice
+# would read as two estates.
+PROJECTS_DIRS=()
+if [ -n "${PROJECTS_DIR:-}" ]; then
+    PROJECTS_DIRS=("$PROJECTS_DIR")
+else
+    PROJECTS_DIRS=("$HOME/projects")
+    if [ -d "$HOME/Projects" ]; then
+        if [ -d "$HOME/projects" ] && [ "$HOME/Projects" -ef "$HOME/projects" ]; then
+            : # one directory under two spellings; name it once
+        else
+            PROJECTS_DIRS+=("$HOME/Projects")
+        fi
+    fi
+fi
+
+# Where a NEW clone would go: the first spelling that already exists, else the
+# first named.
+#
+# shellcheck disable=SC2329  # `park` creates nothing and never calls this. The
+# block is byte-identical in both commands BY DESIGN, so each carries a couple
+# of functions only the other one asks.
+projects_dir_for_new() {
+    local dir
+    for dir in "${PROJECTS_DIRS[@]}"; do
+        if [ -d "$dir" ]; then
+            printf '%s\n' "$dir"
+            return 0
+        fi
+    done
+    printf '%s\n' "${PROJECTS_DIRS[0]}"
+}
+
+trim_unquote() {
+    local value="$1"
+    value="${value%$'\r'}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    case "$value" in
+    '"'*'"') value="${value#\"}"; value="${value%\"}" ;;
+    "'"*"'") value="${value#\'}"; value="${value%\'}" ;;
+    esac
+    printf '%s' "$value"
+}
+
+# ONE FOLDER NAME, and never a path. A `<Name>` off the command line and a
+# `root:` out of somebody's workspace manifest both end up joined to the
+# projects directory, so both are held to this: no empty string, no `/`, and
+# no leading `.` — which is what stops `resume ../../elsewhere/X` from cloning
+# outside the projects directory at all, rather than noticing afterwards.
+is_safe_folder_name() {
+    local name="$1"
+    case "$name" in
+    "" | .* | */*) return 1 ;;
+    esac
+    case "$name" in
+    *[!A-Za-z0-9_.+@-]*) return 1 ;;
+    esac
+    return 0
+}
+
+# One indent-zero scalar out of a small YAML file, with parameter expansion
+# only: no YAML library, no python per line, no forks per line. This is the
+# reader the Speckit extension's `workspace_read_scalar` is, narrowed to the
+# keys these two commands read (`kind`, `name`, `family`, `tracking_branch`).
+YAML_VALUE=""
+yaml_scalar() {
+    local file="$1" key="$2" line
+    YAML_VALUE=""
+    [ -f "$file" ] || return 1
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+        "$key":*) ;;
+        *) continue ;;
+        esac
+        YAML_VALUE="$(trim_unquote "${line#"$key":}")"
+        return 0
+    done <"$file"
+    return 1
+}
+
+# A LINKED WORKTREE, not a checkout of its own: `.git` is a FILE holding a
+# `gitdir:` line, and `--git-dir` and `--git-common-dir` disagree. A
+# single-repository project's FEATURE worktree is a whole `project.yaml` root
+# by construction, so without this the walk-up would answer `<worktree_root>/
+# 001-my-feature` as an estate named after the branch — and `park` would run
+# the write verb inside the very worktree the extension is about to park.
+# GIT'S OWN ANSWER, and not the `.git`-is-a-file shortcut, because that shape
+# is shared with a SUBMODULE and a leg must not be mistaken for a worktree:
+# in a linked worktree `--git-dir` is `<common>/worktrees/<name>` and the two
+# differ; in a submodule both are `<super>/.git/modules/<name>`; in an
+# ordinary checkout both are `.git`. Verified against all three.
+is_linked_worktree() {
+    local dir="$1" gitdir common
+    [ -e "$dir/.git" ] || return 1
+    gitdir="$(git -C "$dir" rev-parse --git-dir 2>/dev/null || true)"
+    common="$(git -C "$dir" rev-parse --git-common-dir 2>/dev/null || true)"
+    [ -n "$gitdir" ] && [ -n "$common" ] && [ "$gitdir" != "$common" ]
+}
+
+# The PINNED copy inside a family holder: `<Family>/<Family>/members/<X>`, so
+# the grandparent carries the `family.yaml`. It is detached, it is what
+# `bootstrap` and `validate` read, and nobody's in-flight work is in it — a
+# walk-up that answered it would run a WRITE verb on a detached HEAD. The
+# working clone BESIDE the holder is the one a person works in, which is the
+# same rule #80's holder dispatch follows.
+is_pinned_member() {
+    local dir="$1" parent grandparent
+    parent="${dir%/*}"
+    [ -n "$parent" ] && [ "$parent" != "$dir" ] || return 1
+    grandparent="${parent%/*}"
+    [ -n "$grandparent" ] && [ "$grandparent" != "$parent" ] || return 1
+    yaml_scalar "$grandparent/family.yaml" kind || return 1
+    [ "$YAML_VALUE" = "family-manifest" ]
+}
+
+# Is `<dir>` a FAMILY FOLDER? All three facts have to agree, exactly as
+# `family_folder_here` requires them to: the holder clone sits at
+# `<dir>/<basename>`, its `family.yaml` says `kind: family-manifest`, and it
+# names that same family. A directory called Northwind is a directory called
+# Northwind; what makes it a family folder is read, never guessed from a name.
+is_family_folder() {
+    local dir="$1" name manifest
+    name="${dir##*/}"
+    [ -n "$name" ] || return 1
+    manifest="$dir/$name/family.yaml"
+    yaml_scalar "$manifest" kind || return 1
+    [ "$YAML_VALUE" = "family-manifest" ] || return 1
+    yaml_scalar "$manifest" name || return 1
+    [ "$YAML_VALUE" = "$name" ]
+}
+
+is_project_root() {
+    local dir="$1"
+    yaml_scalar "$dir/project.yaml" kind || return 1
+    [ "$YAML_VALUE" = "project-manifest" ] || return 1
+    is_pinned_member "$dir" && return 1
+    is_linked_worktree "$dir" && return 1
+    return 0
+}
+
+ESTATE_KIND=""
+ESTATE_DIR=""
+ESTATE_ROOT=""
+ESTATE_NAME=""
+
+# Is THIS directory an estate? A FAMILY FOLDER WINS over a standalone root of
+# the same name: the holder is what drives the members, so a family answered as
+# one of its own members would act on one project and report the estate done.
+estate_here() {
+    local dir="$1"
+    if is_family_folder "$dir"; then
+        ESTATE_KIND="family"
+        ESTATE_DIR="$dir"
+        ESTATE_NAME="${dir##*/}"
+        ESTATE_ROOT="$dir/$ESTATE_NAME"
+        return 0
+    fi
+    if is_project_root "$dir"; then
+        ESTATE_KIND="standalone"
+        ESTATE_DIR="$dir"
+        ESTATE_NAME="${dir##*/}"
+        ESTATE_ROOT="$dir"
+        return 0
+    fi
+    return 1
+}
+
+# The NEAREST estate at or above `<dir>`: the holder beside you, or the project
+# root you are standing in. NEAREST WINS, so standing inside a member of a
+# family acts on that member - the estate the person is standing in. A pinned
+# copy and a linked worktree are WALKED PAST rather than answered, so
+# `<Family>/<Family>/members/<X>` reaches the family folder and a feature
+# worktree reaches the root that owns it.
+estate_walk_up() {
+    local dir="$1"
+    while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+        estate_here "$dir" && return 0
+        dir="${dir%/*}"
+    done
+    return 1
+}
+
+estate_by_name() {
+    local want="$1" dir
+    is_safe_folder_name "$want" || return 1
+    for dir in "${PROJECTS_DIRS[@]}"; do
+        estate_here "$dir/$want" && return 0
+    done
+    return 1
+}
+
+# Every estate under the projects directory, one row each. What ruling 3 asks
+# a refusal to print: a person who typed the command in the wrong folder needs
+# the names, not an instruction to go and look for them.
+list_estates() {
+    local dir child
+    for dir in "${PROJECTS_DIRS[@]}"; do
+        [ -d "$dir" ] || continue
+        for child in "$dir"/*; do
+            [ -d "$child" ] || continue
+            if is_family_folder "$child"; then
+                printf '  family   %-20s %s\n' "${child##*/}" "$child"
+            elif is_project_root "$child"; then
+                printf '  project  %-20s %s\n' "${child##*/}" "$child"
+            fi
+        done
+    done
+}
+
+estates_or_none() {
+    local rows
+    rows="$(list_estates)"
+    if [ -n "$rows" ]; then
+        printf '%s\n' "$rows"
+    else
+        printf '  (none)\n'
+    fi
+}
+
+lower() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+
+# `owner/name` — CASE PRESERVED, so a refusal prints back what a person can
+# type — out of any spelling git accepts: owner/name, owner/name.git,
+# https://host/owner/name(.git), git@host:owner/name.git,
+# ssh://git@host/owner/name.git, and a token-bearing https url. Callers
+# compare with `lower` on both sides, because GitHub owners and names are
+# case-insensitive.
+#
+# A FILESYSTEM PATH IS REFUSED rather than parsed, for the reason the
+# extension's own `workspace_org_from_url` refuses one: `/srv/remotes/Name.git`
+# has a name but no owner, and inventing `remotes` as the owner would let
+# `--repo remotes/Name` match a bare repository on disk. Such a clone answers
+# `<Name>` and the walk-up; it does not answer `--repo`.
+repo_slug_of() {
+    local url="$1" rest owner name
+    rest="$url"
+    case "$rest" in
+    /* | ./* | ../* | [A-Za-z]:[/\\]* | file://*) return 1 ;;
+    esac
+    rest="${rest%/}"
+    rest="${rest%.git}"
+    case "$rest" in
+    *://*)
+        rest="${rest#*://}"
+        rest="${rest#*@}"
+        rest="${rest#*/}"
+        ;;
+    *@*:*)
+        rest="${rest#*@}"
+        rest="${rest#*:}"
+        ;;
+    esac
+    case "$rest" in
+    */*) ;;
+    *) return 1 ;;
+    esac
+    name="${rest##*/}"
+    owner="${rest%/*}"
+    owner="${owner##*/}"
+    [ -n "$owner" ] && [ -n "$name" ] || return 1
+    case "$owner$name" in
+    *[!A-Za-z0-9_.-]*) return 1 ;;
+    esac
+    printf '%s/%s\n' "$owner" "$name"
+}
+
+# The clone under the projects directory whose `origin` IS that repository -
+# ruling 1. Two levels deep, because the estates this standard places are
+# `<projects>/<Project>` and `<projects>/<Family>/<Project>`.
+clone_with_origin() {
+    local want dir candidate origin found
+    want="$(lower "$1")"
+    for dir in "${PROJECTS_DIRS[@]}"; do
+        [ -d "$dir" ] || continue
+        for candidate in "$dir"/*/ "$dir"/*/*/; do
+            candidate="${candidate%/}"
+            [ -e "$candidate/.git" ] || continue
+            origin="$(git -C "$candidate" remote get-url origin 2>/dev/null || true)"
+            [ -n "$origin" ] || continue
+            found="$(repo_slug_of "$origin" || true)"
+            [ -n "$found" ] || continue
+            if [ "$(lower "$found")" = "$want" ]; then
+                printf '%s\n' "$candidate"
+                return 0
+            fi
+        done
+    done
+    return 1
+}
+
+# The family's members, by the same `  - project: <Project>` row `family.py`
+# writes and `siblings.py` reads. The working clone is `<family folder>/
+# <Project>`, beside the holder.
+family_members() {
+    local manifest="$1" line
+    [ -f "$manifest" ] || return 0
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+        "  - project: "*) printf '%s\n' "$(trim_unquote "${line#  - project: }")" ;;
+        esac
+    done <"$manifest"
+}
+
+# The branch a checkout belongs on: its OWN manifest's `tracking_branch:` —
+# the field `scripts/bootstrap.py` already reads to place the legs — falling
+# back to `main`. The workspace manifest records a `tracking_branch` too, but
+# that is PROVENANCE from the machine that parked; the local declaration is
+# what this machine's clone actually tracks, and the extension takes the same
+# line about `worktree_root`.
+tracking_branch_of() {
+    local root="$1"
+    if yaml_scalar "$root/family.yaml" tracking_branch && [ -n "$YAML_VALUE" ]; then
+        printf '%s\n' "$YAML_VALUE"
+        return 0
+    fi
+    if yaml_scalar "$root/project.yaml" tracking_branch && [ -n "$YAML_VALUE" ]; then
+        printf '%s\n' "$YAML_VALUE"
+        return 0
+    fi
+    printf 'main\n'
+}
+
+# The legs a root declares, by path, out of `project.yaml`'s `legs:` block —
+# the same rows `scripts/bootstrap.py` reads, and in the order it reads them,
+# `role:` before `path:`. The assembly leg is `path: "."` and is the root
+# itself, so it is not one of these.
+#
+# shellcheck disable=SC2329  # only `resume` bootstraps a root, so only
+# `resume` has to ask where its legs are; see the note above.
+legs_of() {
+    local root="$1" line role="" path=""
+    [ -f "$root/project.yaml" ] || return 0
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
+        case "$line" in
+        '  - role:'*)
+            role="$(trim_unquote "${line#*:}")"
+            path=""
+            ;;
+        '    path:'*)
+            path="$(trim_unquote "${line#*:}")"
+            [ -n "$role" ] || continue
+            [ "$role" != "assembly" ] || continue
+            [ "$path" != "." ] || continue
+            [ -n "$path" ] && printf '%s\n' "$path"
+            ;;
+        [![:space:]]*) role=""; path="" ;;
+        esac
+    done <"$root/project.yaml"
+}
+# --- END shared estate resolver ---------------------------------------------
+
+# --- the user config and the workspace repository ---------------------------
+
+CONFIG_FILE="${AGENT_PROTOCOL_ROOT:-$HOME/.agents}/workspace.yaml"
+
+# shellcheck disable=SC2088  # a literal leading ~ is what is matched here
+expand_home() {
+    local value="$1"
+    case "$value" in
+    '~') printf '%s\n' "$HOME" ;;
+    '~/'*) printf '%s\n' "$HOME/${value#\~/}" ;;
+    *) printf '%s\n' "$value" ;;
+    esac
+}
+
+# The optional per-org override, as `org<TAB>path` rows. The config's shape is
+# the plan's own (#77 S1, §2.3):
+#
+#     repository: opensoft/brett-wip
+#     path: ~/projects/brett-wip
+#     orgs:
+#       MedxSoft:
+#         repository: MedxSoft/brett-wip
+#         path: ~/projects/MedxSoft-wip
+#
+# READ ONLY, AND NEVER A REFUSAL HERE. The extension refuses a malformed
+# `orgs:` block because it is about to WRITE a manifest and filing a
+# confidential org's work in the wrong repository is the one thing that
+# override exists to prevent. Nothing in this command writes a manifest: it
+# looks for one, so an entry it cannot read is an entry it does not find, and
+# `park.sh`'s own refusal is still the authority on the block being wrong.
+config_org_paths() {
+    local file="$1" line org="" path="" in_orgs=0
+    [ -f "$file" ] || return 0
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
+        case "$line" in
+        '#'*) continue ;;
+        orgs:*)
+            in_orgs=1; org=""; path=""
+            continue
+            ;;
+        [![:space:]]*)
+            # ANY other indent-zero key ends the block, so a two-space key
+            # under something else is never read as an org override.
+            [ -z "$org" ] || [ -z "$path" ] || printf '%s\t%s\n' "$org" "$path"
+            in_orgs=0; org=""; path=""
+            continue
+            ;;
+        esac
+        [ "$in_orgs" -eq 1 ] || continue
+        case "$line" in
+        '  '[![:space:]]*)
+            [ -z "$org" ] || [ -z "$path" ] || printf '%s\t%s\n' "$org" "$path"
+            org="$(trim_unquote "${line%:}")"
+            path=""
+            ;;
+        '    path:'*) path="$(trim_unquote "${line#*path:}")" ;;
+        esac
+    done <"$file"
+    [ -z "$org" ] || [ -z "$path" ] || printf '%s\t%s\n' "$org" "$path"
+}
+
+config_path_for_org() {
+    local want org path
+    want="$(lower "$1")"
+    while IFS=$'\t' read -r org path; do
+        [ -n "${path:-}" ] || continue
+        if [ "$(lower "$org")" = "$want" ]; then
+            expand_home "$path"
+            return 0
+        fi
+    done < <(config_org_paths "$CONFIG_FILE")
+    return 1
+}
+
+is_checkout() {
+    local path="$1"
+    [ -n "$path" ] || return 1
+    [ -e "$path/.git" ] || return 1
+    git -C "$path" rev-parse --git-dir >/dev/null 2>&1
+}
+
+# `https://github.com/<owner>/<name>.git` by default.
+#
+# `$OPENREPOSHAPE_REMOTE_BASE` IS THE OFFLINE TEST PATH, and it is the same
+# concession `setup-project.py --local-remote-dir` and `family.py
+# --local-remote-dir` make: a directory of BARE repositories named
+# `<name>.git`, used as origins, so this whole flow — clone the workspace,
+# clone the holder, place the siblings — is provable with no network and no
+# real repository. It is documented here for the same reason the shim
+# documents `$OPENREPOSHAPE_SETUP_SH`, and it grants no file-protocol
+# permission of its own: a test that needs `protocol.file.allow` sets it in
+# git's own environment, which is how it stays a test's decision.
+clone_url_for() {
+    local slug="$1" base="${OPENREPOSHAPE_REMOTE_BASE:-}"
+    if [ -n "$base" ]; then
+        printf '%s/%s.git\n' "${base%/}" "${slug##*/}"
+        return 0
+    fi
+    printf 'https://github.com/%s.git\n' "$slug"
+}
+
+# --- the manifest -----------------------------------------------------------
+
+# `<org>\t<file>\t<workspace>` for every `workspaces/<org>/<Name>.yaml` that
+# records this name, in every workspace checkout this config knows about. The
+# basename is compared CASE-INSENSITIVELY: a standalone project's manifest is
+# named for its `project.yaml` id (`atlas`), and the folder a person types is
+# the repository name (`Atlas`).
+manifest_candidates() {
+    local want workspace dir file base
+    want="$(lower "$1")"
+    shift
+    for workspace in "$@"; do
+        [ -d "$workspace/workspaces" ] || continue
+        for dir in "$workspace"/workspaces/*/; do
+            dir="${dir%/}"
+            [ -d "$dir" ] || continue
+            for file in "$dir"/*.yaml; do
+                [ -f "$file" ] || continue
+                base="${file##*/}"
+                base="${base%.yaml}"
+                [ "$(lower "$base")" = "$want" ] || continue
+                printf '%s\t%s\t%s\n' "${dir##*/}" "$file" "$workspace"
+            done
+        done
+    done
+}
+
+# One field of the FIRST `projects[]` block, read the way the extension's own
+# reader does: on the indent width and the leading `- ` of a list item, which
+# is safe because this file is written by that extension with a fixed layout.
+manifest_project_field() {
+    local file="$1" field="$2" line seen=0
+    [ -f "$file" ] || return 1
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
+        case "$line" in
+        '  - id:'*)
+            [ "$seen" -eq 0 ] || return 1
+            seen=1
+            continue
+            ;;
+        esac
+        [ "$seen" -eq 1 ] || continue
+        case "$line" in
+        "    $field:"*)
+            printf '%s\n' "$(trim_unquote "${line#*:}")"
+            return 0
+            ;;
+        esac
+    done <"$file"
+    return 1
+}
+
+# --- the refresh ------------------------------------------------------------
+
+REFUSED=0
+
+# RULING 2, and its whole point: a clone that is dirty or on a feature branch
+# is REFUSED BY NAME AND SKIPPED, never reset. `pull --ff-only origin <branch>`
+# rather than a bare `pull`, so a clone with no upstream configured is
+# fast-forwarded rather than told to set one - and `--ff-only` is what makes a
+# divergent branch a refusal from git itself instead of a merge commit nobody
+# asked for.
+pull_ff_only() {
+    local label="$1" repo="$2" branch="${3:-}" head dirty
+    # THE BRANCH IS AN ARGUMENT so the WORKSPACE repository can be checked
+    # too: it is a private repository with no `project.yaml` and no declared
+    # tracking branch, and refusing it for being on `master` rather than
+    # `main` would be a refusal about nothing. Its caller passes the branch it
+    # is already on, which keeps the dirty guard and the `--ff-only` guard and
+    # drops only the off-branch one.
+    [ -n "$branch" ] || branch="$(tracking_branch_of "$repo")"
+    head="$(git -C "$repo" rev-parse --abbrev-ref HEAD 2>/dev/null || printf '?')"
+    if [ "$head" != "$branch" ]; then
+        REFUSED=$((REFUSED + 1))
+        say "  REFUSED $label: HEAD is '$head', not its tracking branch '$branch'."
+        say "          Nothing was fast-forwarded and nothing was reset. Your work is where you left it."
+        say "            look:  git -C $repo status --short --branch"
+        say "            then:  git -C $repo checkout $branch && $SELF_NAME $ESTATE_NAME"
+        return 1
+    fi
+    dirty="$(git -C "$repo" status --porcelain 2>/dev/null || true)"
+    if [ -n "$dirty" ]; then
+        REFUSED=$((REFUSED + 1))
+        say "  REFUSED $label: uncommitted changes in $repo."
+        say "          Nothing was fast-forwarded and nothing was reset."
+        say "            look:  git -C $repo status --short"
+        say "            then:  commit or stash them yourself, and re-run \`$SELF_NAME $ESTATE_NAME\`."
+        return 1
+    fi
+    if [ "$DRY_RUN" -eq 1 ]; then
+        say "  would fast-forward $label: git -C $repo pull --ff-only origin $branch"
+        return 0
+    fi
+    if ! git -C "$repo" pull --ff-only origin "$branch"; then
+        REFUSED=$((REFUSED + 1))
+        say "  REFUSED $label: \`git pull --ff-only origin $branch\` did not fast-forward."
+        say "          Local commits are on that branch, or the remote has none. Nothing was reset."
+        return 1
+    fi
+    return 0
+}
+
+# THE LEGS, BEFORE A ROOT IS BOOTSTRAPPED (F3 of the review on #83). A root's
+# own `make bootstrap` — `templates/assembly-root/scripts/bootstrap.py`,
+# `checkout_tracking_branch` — runs `git checkout <tracking>` in a leg whose
+# local tracking-branch tip equals the pin, and `checkout -b <tracking> <pin>`
+# in a leg that has no local one. Either MOVES A LEG'S HEAD. A leg sitting on
+# a clean feature branch at the pin makes the superproject clean, so the dirty
+# and off-branch guards above see nothing and say nothing — and `resume` used
+# to walk that leg off `001-my-feature` onto `main` and exit 0.
+#
+# So the legs are asked first, and a root with one off its tracking branch is
+# REFUSED BY NAME and neither pulled nor bootstrapped. DETACHED AT THE PIN is
+# not a refusal: that is the state a fresh clone arrives in and precisely what
+# bootstrap exists to fix.
+root_legs_ok() {
+    local label="$1" root="$2" branch leg head pin at
+    branch="$(tracking_branch_of "$root")"
+    while IFS= read -r leg; do
+        [ -n "$leg" ] || continue
+        [ -e "$root/$leg/.git" ] || continue
+        head="$(git -C "$root/$leg" rev-parse --abbrev-ref HEAD 2>/dev/null || printf '?')"
+        [ "$head" != "$branch" ] || continue
+        if [ "$head" = "HEAD" ]; then
+            pin="$(git -C "$root" rev-parse "HEAD:$leg" 2>/dev/null || true)"
+            at="$(git -C "$root/$leg" rev-parse HEAD 2>/dev/null || true)"
+            if [ -n "$pin" ] && [ "$pin" = "$at" ]; then
+                continue
+            fi
+            head="detached at ${at:-?}, and the pin is ${pin:-?}"
+        fi
+        REFUSED=$((REFUSED + 1))
+        say "  REFUSED $label: leg $leg is on '$head', not its tracking branch '$branch';"
+        say "          \`make bootstrap\` would move it - nothing was touched."
+        say "            look:  git -C $root/$leg status --short --branch"
+        say "            then:  finish or park that leg's work, put it back on $branch, and re-run."
+        return 1
+    done < <(legs_of "$root")
+    return 0
+}
+
+# One root: the legs, then the fast-forward, then its own bootstrap - and a
+# REFUSAL AT ANY STEP SKIPS THE ONES AFTER IT (F1 of the review on #83). The
+# holder's bootstrap is `git submodule update --init --recursive`, which snaps
+# every `members/<X>` back to the recorded gitlink: running it after saying
+# "nothing was reset" would have reset exactly the pin bump the refusal was
+# protecting. Returns 1 when the root was refused.
+refresh_root() {
+    local label="$1" root="$2"
+    root_legs_ok "$label" "$root" || {
+        say "  [$label] bootstrap skipped: refused above. Nothing here was fetched, moved or reset."
+        return 1
+    }
+    pull_ff_only "$label" "$root" || {
+        say "  [$label] bootstrap skipped: refused above. Nothing here was fetched, moved or reset."
+        return 1
+    }
+    run_make "$label" "$root" bootstrap || {
+        REFUSED=$((REFUSED + 1))
+        say "  FINDING: [$label] \`make bootstrap\` did not exit 0; its legs may not be placed."
+    }
+    return 0
+}
+
+run_make() {
+    local label="$1" root="$2" target="$3" args="${4:-}" status
+    if [ ! -f "$root/Makefile" ]; then
+        say "  [$label] no Makefile; \`make $target\` skipped. Re-sync the root with update-shape.py."
+        return 0
+    fi
+    if [ "$DRY_RUN" -eq 1 ]; then
+        # shellcheck disable=SC2016  # the single quotes are LITERAL: this is
+        # the `make` line a person can copy, and `ARGS='...'` is how it is typed.
+        say "  would run: make $target${args:+ ARGS='$args'}   ($root)"
+        return 0
+    fi
+    say "  --- $label: make $target ---"
+    # AN ARRAY, so `ARGS=--feature 001-a --dry-run` reaches make as ONE
+    # assignment. `${var:+"..."}` unquoted is one word in bash today and a
+    # thing a reader has to squint at; an array is neither.
+    local call=(make "$target")
+    [ -z "$args" ] || call+=("ARGS=$args")
+    set +e
+    (cd "$root" && exec "${call[@]}")
+    status=$?
+    set -e
+    return "$status"
+}
+
+# --- arguments -------------------------------------------------------------
+while [ $# -gt 0 ]; do
+    case "$1" in
+    -h | --help) usage; exit 0 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --repo) REPO_SLUG="${2:?--repo needs a value}"; REPO_ARG="$REPO_SLUG"; shift 2 ;;
+    --workspace) WORKSPACE_SLUG="${2:?--workspace needs a value}"; shift 2 ;;
+    --org) ORG_WANTED="${2:?--org needs a value}"; shift 2 ;;
+    --name | --project) NAME="${2:?$1 needs a value}"; shift 2 ;;
+    # EVERYTHING AFTER `--` IS THE EXTENSION'S, verbatim: `resume.sh` has
+    # flags this command has no opinion about (--feature, --keep-staged), and
+    # a command that ate them would be a command people stop using the moment
+    # the extension grows one. NOTE that `--workspace` above is THIS
+    # command's, and takes `<owner/name>`; the extension's own `--workspace`
+    # takes a PATH and reaches it through `--`.
+    --) shift; PASSTHROUGH+=("$@"); break ;;
+    -*)
+        usage >&2
+        die "$SELF_NAME does not know $1. Its own flags are listed above; the
+    extension's own flags travel after a \`--\`, so what you want is:
+
+      $SELF_NAME -- $1"
+        ;;
+    *)
+        [ -z "$NAME" ] ||
+            die "two estate names, '$NAME' and '$1'. One positional <Name>, then flags."
+        NAME="$1"; shift ;;
+    esac
+done
+
+[ -z "$NAME" ] || [ -z "$REPO_SLUG" ] ||
+    die "both <Name> ('$NAME') and --repo '$REPO_SLUG'. One estate per run: name it
+    either way, not both."
+
+# A FOLDER NAME, NEVER A PATH. `resume ../x` or `resume /abs` would otherwise
+# be joined to the projects directory and clone somewhere nobody named.
+[ -z "$NAME" ] || is_safe_folder_name "$NAME" ||
+    die "'$NAME' is not an estate name: it is a path, or it carries a character
+    an estate folder may not. <Name> is ONE name — the family or project your
+    workspace record names — with no slash and no leading dot."
+
+command -v git >/dev/null 2>&1 ||
+    die "no \`git\` on PATH, so nothing can be cloned or fast-forwarded."
+command -v make >/dev/null 2>&1 ||
+    die "no \`make\` on PATH, so the estate's own \`make resume\` cannot be run.
+    Install it (\`xcode-select --install\` on macOS, \`sudo apt-get install -y
+    make\` on Debian and Ubuntu), then re-run \`$SELF_NAME\`."
+
+# --- which estate, by name ---------------------------------------------------
+if [ -n "$REPO_SLUG" ]; then
+    # ANY SPELLING A PERSON MIGHT PASTE, through the same reader that reads a
+    # clone's `origin`, so both sides of the comparison come from one parser.
+    REPO_SLUG="$(repo_slug_of "$REPO_SLUG" || true)"
+    [ -n "$REPO_SLUG" ] || die "--repo '$REPO_ARG' is not a repository: it wants <owner>/<name>, or any
+    url spelling of one (https://…/<owner>/<name>.git, git@host:<owner>/<name>).
+    A family's members may live in another organisation, so there is no owner
+    to assume, and a path on disk has none to read."
+    MATCH="$(clone_with_origin "$REPO_SLUG" || true)"
+    [ -n "$MATCH" ] || die "no clone under your projects directory has origin $REPO_SLUG.
+    \`--repo\` names a clone you ALREADY HAVE (RULING 2026-09-09 ruling 1). To
+    bring an estate back that is not here yet, name it as your workspace
+    record does:
+
+      $SELF_NAME <Name>
+
+estates found under your projects directory:
+$(estates_or_none)"
+    estate_walk_up "$MATCH" ||
+        die "$MATCH is a clone of $REPO_SLUG, but nothing at or above it is an
+    estate: no \`family.yaml\` holder beside it and no \`project.yaml\` root."
+    NAME="$ESTATE_NAME"
+elif [ -z "$NAME" ]; then
+    estate_walk_up "$PWD" || die "no estate around $PWD, and no <Name> was given.
+    On a machine that has none of it yet, \`$SELF_NAME <Name>\` is how it comes
+    back - <Name> being the family or project your workspace record names.
+    Estates already here:
+
+$(estates_or_none)"
+    NAME="$ESTATE_NAME"
+fi
+
+# --- (1) the workspace repository -------------------------------------------
+say "resume: $NAME"
+say ""
+say "(1) the workspace record"
+
+CONFIG_REPO=""
+CONFIG_PATH=""
+if [ -f "$CONFIG_FILE" ]; then
+    yaml_scalar "$CONFIG_FILE" repository && CONFIG_REPO="$YAML_VALUE"
+    yaml_scalar "$CONFIG_FILE" path && CONFIG_PATH="$(expand_home "$YAML_VALUE")"
+fi
+
+WORKSPACE=""
+if [ -f "$CONFIG_FILE" ]; then
+    say "  config          $CONFIG_FILE"
+    [ -n "$CONFIG_PATH" ] || die "$CONFIG_FILE names no \`path:\`, so there is no workspace checkout
+    to read your record from. It wants exactly two lines:
+
+      repository: <owner>/<repo>
+      path: ~/projects/<repo>"
+    # `--workspace` NEVER SILENTLY REPLACES AN EXISTING CONFIG. Two different
+    # private repositories for one person's work is a state nothing here can
+    # arbitrate, so it is said out loud rather than picked.
+    if [ -n "$WORKSPACE_SLUG" ] && [ -n "$CONFIG_REPO" ] &&
+        [ "$(lower "$WORKSPACE_SLUG")" != "$(lower "$CONFIG_REPO")" ]; then
+        die "--workspace $WORKSPACE_SLUG, but $CONFIG_FILE already names
+    $CONFIG_REPO. This command writes that file only on a machine that has
+    none, and it never overwrites one. Drop the flag to use the config, or
+    edit the file yourself."
+    fi
+    if is_checkout "$CONFIG_PATH"; then
+        WORKSPACE="$CONFIG_PATH"
+        # THE SAME GUARD EVERY OTHER CHECKOUT GETS, and a refusal here is a
+        # refusal: the record is what the whole run reads, and cloning an
+        # estate out of a manifest whose checkout is dirty or mid-conflict is
+        # exactly the wrong thing to do quietly. The branch passed is the one
+        # it is already on — a private repository declares no tracking branch,
+        # so being on `master` is not a finding.
+        if ! pull_ff_only "workspace" "$WORKSPACE" \
+            "$(git -C "$WORKSPACE" rev-parse --abbrev-ref HEAD 2>/dev/null || printf 'main')"; then
+            die "your workspace checkout at $WORKSPACE was not fast-forwarded, so the
+    record this run would read may not be the one \`park\` last wrote.
+    Nothing was cloned and nothing was resumed. Sort that checkout out — the
+    lines above name what it is — and re-run \`$SELF_NAME $NAME\`."
+        fi
+    else
+        [ -n "$CONFIG_REPO" ] || die "$CONFIG_PATH, which $CONFIG_FILE names as your workspace checkout,
+    is not a Git checkout, and the config names no \`repository:\` to clone.
+    Add it, or clone the repository there yourself."
+        WORKSPACE="$CONFIG_PATH"
+        if [ "$DRY_RUN" -eq 1 ]; then
+            say "  would clone      $(clone_url_for "$CONFIG_REPO") -> $WORKSPACE"
+        else
+            say "  cloning         $CONFIG_REPO -> $WORKSPACE"
+            mkdir -p -- "$(dirname -- "$WORKSPACE")"
+            git clone "$(clone_url_for "$CONFIG_REPO")" "$WORKSPACE"
+        fi
+    fi
+else
+    [ -n "$WORKSPACE_SLUG" ] || die "no workspace record is configured, so there is nothing to resume from.
+    \`park\` writes the feature list into a PRIVATE REPOSITORY YOU OWN, and
+    this machine has not been told which one. Name it once, by name:
+
+      $SELF_NAME $NAME --workspace <owner>/<repo>
+
+    which clones it and writes two lines into
+
+      $CONFIG_FILE
+
+    Nothing else in this standard writes that file, and nothing guesses the
+    repository."
+    case "$WORKSPACE_SLUG" in
+    */*) ;;
+    *) die "--workspace '$WORKSPACE_SLUG' is not <owner/name>." ;;
+    esac
+    WORKSPACE="$(projects_dir_for_new)/${WORKSPACE_SLUG##*/}"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        say "  would clone      $(clone_url_for "$WORKSPACE_SLUG") -> $WORKSPACE"
+        say "  would write      $CONFIG_FILE (repository:, path:)"
+    else
+        say "  cloning         $WORKSPACE_SLUG -> $WORKSPACE"
+        mkdir -p -- "$(dirname -- "$WORKSPACE")"
+        git clone "$(clone_url_for "$WORKSPACE_SLUG")" "$WORKSPACE"
+        # THE ONLY WRITE TO THIS FILE ANYWHERE IN THIS STANDARD, and only
+        # because it was asked for by name. Two keys, `~` where the path is
+        # under $HOME so the file travels with the thing it points at.
+        CONFIG_WRITTEN="$WORKSPACE"
+        case "$WORKSPACE" in
+        "$HOME"/*) CONFIG_WRITTEN="~${WORKSPACE#"$HOME"}" ;;
+        esac
+        mkdir -p -- "$(dirname -- "$CONFIG_FILE")"
+        [ ! -e "$CONFIG_FILE" ] ||
+            die "$CONFIG_FILE appeared while this ran; it was not overwritten."
+        printf 'repository: %s\npath: %s\n' "$WORKSPACE_SLUG" "$CONFIG_WRITTEN" \
+            >"$CONFIG_FILE"
+        say "  wrote           $CONFIG_FILE"
+        say "                  repository: $WORKSPACE_SLUG"
+        say "                  path: $CONFIG_WRITTEN"
+    fi
+fi
+
+# --- (2) the manifest -------------------------------------------------------
+say ""
+say "(2) the manifest for $NAME"
+
+# ONE ENTRY PER DIRECTORY, compared as a PHYSICAL path (F4 of the review on
+# #83): two spellings of one checkout — an `orgs:` override pointing at the
+# same clone as the default, a symlinked projects directory — would otherwise
+# be searched twice and every manifest in it counted twice, which read as
+# "two orgs record this name" and could not be answered by `--org` at all.
+WORKSPACES=()
+add_workspace() {
+    local candidate="$1" physical existing
+    [ -n "$candidate" ] || return 0
+    is_checkout "$candidate" || return 0
+    physical="$(cd "$candidate" 2>/dev/null && pwd -P)" || physical="$candidate"
+    for existing in ${WORKSPACES[@]+"${WORKSPACES[@]}"}; do
+        [ "$existing" != "$physical" ] || return 0
+    done
+    WORKSPACES+=("$physical")
+}
+add_workspace "$WORKSPACE"
+# `orgs:` IS HONOURED IN THE ONLY ORDER THAT IS POSSIBLE. The override is
+# keyed by the estate's org, and the org is a fact recorded IN the manifest
+# (`workspaces/<org>/<Name>.yaml`), so the file has to be found before the org
+# is known: every workspace the config names is searched, and `--org` says
+# which answer was meant when two of them have one.
+if [ -n "$ORG_WANTED" ]; then
+    ORG_PATH="$(config_path_for_org "$ORG_WANTED" || true)"
+    [ -z "$ORG_PATH" ] || add_workspace "$ORG_PATH"
+fi
+while IFS=$'\t' read -r _ override; do
+    [ -n "${override:-}" ] || continue
+    add_workspace "$(expand_home "$override")"
+done < <(config_org_paths "$CONFIG_FILE")
+# Nothing readable at all: the dry-run branch below says so, and a real run
+# has already refused if the config named no checkout it could clone.
+[ ${#WORKSPACES[@]} -gt 0 ] || WORKSPACES=("$WORKSPACE")
+
+MANIFEST_ORG=""
+MANIFEST_FILE=""
+FOUND=0
+FOUND_ORGS=""
+FOUND_ROWS=""
+if [ "$DRY_RUN" -eq 1 ] && [ ! -d "${WORKSPACES[0]}" ]; then
+    say "  (--dry-run: the workspace is not here, so no manifest could be read)"
+else
+    # WHAT MAKES THE QUESTION UNANSWERABLE IS TWO ORGS, not two files (F4 of
+    # the review on #83). The same `<org>/<name>.yaml` reached through two
+    # checkouts of one workspace repository is ONE record, and `--org` could
+    # not have told them apart; two DISTINCT orgs is the case `--org` exists
+    # for. So the pairs are deduped on `<org>` plus the file's basename and
+    # the refusal counts the orgs that are left.
+    while IFS=$'\t' read -r org file _; do
+        [ -n "${file:-}" ] || continue
+        if [ -n "$ORG_WANTED" ] && [ "$(lower "$org")" != "$(lower "$ORG_WANTED")" ]; then
+            continue
+        fi
+        case " $FOUND_ORGS " in
+        *" $(lower "$org")/${file##*/} "*) continue ;;
+        esac
+        FOUND_ORGS="$FOUND_ORGS $(lower "$org")/${file##*/}"
+        FOUND=$((FOUND + 1))
+        FOUND_ROWS="$FOUND_ROWS  $org/${file##*/}   $file
+"
+        MANIFEST_ORG="$org"
+        MANIFEST_FILE="$file"
+    done < <(manifest_candidates "$NAME" "${WORKSPACES[@]}")
+fi
+
+if [ "$FOUND" -gt 1 ]; then
+    die "$FOUND workspace manifests record '$NAME', in different orgs:
+
+$FOUND_ROWS
+    Two projects in two organisations may share a name, so nothing here picks
+    one. Say which:
+
+      $SELF_NAME $NAME --org <org>"
+fi
+
+ESTATE_PRESENT=0
+if estate_by_name "$NAME"; then
+    ESTATE_PRESENT=1
+fi
+
+if [ "$FOUND" -eq 0 ]; then
+    if [ "$ESTATE_PRESENT" -eq 0 ] && [ "$DRY_RUN" -eq 0 ]; then
+        die "no workspace manifest records '$NAME', and there is no estate of that
+    name here, so there is nothing to clone and nothing to recreate.
+    Either it was never parked, or it was parked under another name:
+
+      grep -rn 'id: ' $WORKSPACE/workspaces/
+      ls $WORKSPACE/workspaces/*/
+
+    A family's manifest is \`workspaces/<org>/<Family>.yaml\`; a standalone
+    project's is named for its \`project.yaml\` id."
+    fi
+    say "  none found; the estate that IS here will be refreshed, and \`make resume\`"
+    say "  will print the extension's own refusal if it has no record either."
+else
+    say "  $MANIFEST_FILE"
+    say "  org             $MANIFEST_ORG"
+fi
+
+# --- what the manifest says the estate is -----------------------------------
+MANIFEST_KIND=""
+MANIFEST_DIRNAME=""
+ROOT_REPOSITORY=""
+if [ -n "$MANIFEST_FILE" ]; then
+    MANIFEST_ROOT_VALUE="$(manifest_project_field "$MANIFEST_FILE" root || true)"
+    if yaml_scalar "$MANIFEST_FILE" family && [ -n "$YAML_VALUE" ]; then
+        MANIFEST_KIND="family"
+        # THE FOLDER COMES FROM `root:`, NEVER FROM `family:` (F2 of the
+        # review on #83, and the headline of it). `park.sh` writes `family:`
+        # from `family.yaml`'s `id:` — `workspace_family_name` reads that key
+        # — and an id is LOWERCASE by construction (`family.py`'s
+        # `--id ... or family.lower()`, checked against
+        # `PROJECT_ID_RE = ^[a-z0-9][a-z0-9-]*$`). The FOLDER is the family's
+        # `name:`, CamelCase, which is what `is_family_folder` requires to
+        # match the directory. Deriving the folder from `family:` therefore
+        # produced `~/projects/inkrouter/inkrouter`, a clone of
+        # `<org>/inkrouter` that 404s on any case-sensitive remote, and then a
+        # "not an estate" refusal over the half-estate it had just made.
+        #
+        # `workspace_manifest_root_value` writes each MEMBER's `root:` as
+        # `<family folder>/<project folder>` with the real casing, so the
+        # first segment is the family folder and — the holder repository being
+        # the family's own name in its org, #76 ruling 3's doubled-name layout
+        # — it is the holder repository's name too. `family:` stays what it is
+        # good for: the flag that says this file is a family's at all.
+        MANIFEST_DIRNAME="${MANIFEST_ROOT_VALUE%%/*}"
+        [ -n "$MANIFEST_ROOT_VALUE" ] &&
+            [ "$MANIFEST_DIRNAME" != "$MANIFEST_ROOT_VALUE" ] ||
+            die "$MANIFEST_FILE says \`family: $YAML_VALUE\` but its first project records
+    \`root: ${MANIFEST_ROOT_VALUE:-(nothing)}\`, which names no family folder. A member of a
+    family is recorded as <family folder>/<project folder>, so this file
+    cannot say where the holder goes. It is written by \`park\`; a
+    hand-edited one is fixed by hand."
+        ROOT_REPOSITORY="$MANIFEST_ORG/$MANIFEST_DIRNAME"
+    else
+        MANIFEST_KIND="standalone"
+        ROOT_REPOSITORY="$(manifest_project_field "$MANIFEST_FILE" repository || true)"
+        MANIFEST_DIRNAME="$MANIFEST_ROOT_VALUE"
+        [ -n "$MANIFEST_DIRNAME" ] || MANIFEST_DIRNAME="${ROOT_REPOSITORY##*/}"
+        [ -n "$ROOT_REPOSITORY" ] || die "$MANIFEST_FILE records no \`repository:\` for its first project, so
+    there is no repository to clone. That file is written by \`park\`; a
+    hand-edited one is fixed by hand."
+    fi
+    # A NAME, NEVER A PATH (F7 of the review on #83). `root:` is somebody's
+    # file and the schema's own invariant is that it is relative and POSIX —
+    # but a hand-edited `root: ../../elsewhere/X` would otherwise be joined to
+    # the projects directory and cloned outside it. Checked BEFORE any path is
+    # built from it, so nothing is created to be noticed afterwards.
+    is_safe_folder_name "$MANIFEST_DIRNAME" ||
+        die "$MANIFEST_FILE records \`root: $MANIFEST_ROOT_VALUE\`, whose folder name
+    '$MANIFEST_DIRNAME' is not one: an estate folder is a single name under your
+    projects directory, with no slash and no leading dot. Nothing was cloned.
+    That file is written by \`park\`; a hand-edited one is fixed by hand."
+    say "  records         a $MANIFEST_KIND estate, root repository $ROOT_REPOSITORY"
+fi
+
+# THE ESTATE ON DISK WINS over the manifest's idea of where it is: the manifest
+# records a RELATIVE folder name and this machine's own layout is the truth
+# about where that folder sits.
+if [ "$ESTATE_PRESENT" -eq 0 ] && [ -n "$MANIFEST_DIRNAME" ] &&
+    [ "$MANIFEST_DIRNAME" != "$NAME" ]; then
+    if estate_by_name "$MANIFEST_DIRNAME"; then
+        ESTATE_PRESENT=1
+    fi
+fi
+
+# --- (3) rebuild or refresh the estate --------------------------------------
+say ""
+say "(3) the estate"
+
+SIBLINGS_LOG=""
+# shellcheck disable=SC2329  # invoked by the EXIT trap on the next line but one
+cleanup() { [ -z "$SIBLINGS_LOG" ] || rm -f -- "$SIBLINGS_LOG"; }
+# THE TRAP BELONGS TO THE SHELL THAT DOES THE WRITING, so it is set here in
+# the main shell and never inside a `$(...)` — the defect #74 was, in the shim.
+trap cleanup EXIT
+
+# WHICH MEMBERS ALREADY HAD A WORKING CLONE, as a space-delimited list with
+# sentinel spaces so `case` can ask about one. A project name carries no space
+# — `family.py` refuses one that does — so this is a set and not a guess.
+EXISTING_SIBLINGS=" "
+# Members whose working clone was refused, so the verb is not run in them
+# either (F9 of the review on #83), and the root itself when it was refused.
+REFUSED_MEMBERS=" "
+ROOT_REFUSED=0
+
+if [ "$ESTATE_PRESENT" -eq 1 ]; then
+    say "  present         $ESTATE_DIR ($ESTATE_KIND)"
+    if [ "$ESTATE_KIND" = "family" ]; then
+        refresh_root "holder $ESTATE_NAME" "$ESTATE_ROOT" || ROOT_REFUSED=1
+    else
+        refresh_root "root $ESTATE_NAME" "$ESTATE_ROOT" || ROOT_REFUSED=1
+    fi
+else
+    if [ -z "$ROOT_REPOSITORY" ]; then
+        # A DRY RUN ON A FRESH MACHINE CANNOT KNOW MORE THAN THIS, and saying
+        # so is the honest answer: the manifest lives in a workspace this run
+        # deliberately did not clone, so the plan genuinely stops here. It is
+        # not a refusal - nothing was asked for that could not be answered.
+        if [ "$DRY_RUN" -eq 1 ]; then
+            say "  absent          the workspace was not cloned, so the manifest that names the"
+            say "                  estate's repository could not be read. A real run clones the"
+            say "                  workspace first and then the estate."
+            say ""
+            say "resume: $NAME - --dry-run: nothing was cloned, pulled, bootstrapped or recreated."
+            exit 0
+        fi
+        die "there is no estate named '$NAME' here and no manifest to clone one
+    from, so nothing was created."
+    fi
+    ESTATE_KIND="$MANIFEST_KIND"
+    ESTATE_NAME="$MANIFEST_DIRNAME"
+    if [ "$ESTATE_KIND" = "family" ]; then
+        ESTATE_DIR="$(projects_dir_for_new)/$ESTATE_NAME"
+        ESTATE_ROOT="$ESTATE_DIR/$ESTATE_NAME"
+    else
+        ESTATE_DIR="$(projects_dir_for_new)/$ESTATE_NAME"
+        ESTATE_ROOT="$ESTATE_DIR"
+    fi
+    say "  absent          cloning $ROOT_REPOSITORY -> $ESTATE_ROOT"
+    if [ "$DRY_RUN" -eq 1 ]; then
+        say "  would clone      git clone --recurse-submodules $(clone_url_for "$ROOT_REPOSITORY") $ESTATE_ROOT"
+        say "  would run        make bootstrap in $ESTATE_ROOT"
+        [ "$ESTATE_KIND" != "family" ] || say "  would run        make siblings in $ESTATE_ROOT"
+        say ""
+        say "resume: $NAME - --dry-run: nothing was cloned, pulled, bootstrapped or recreated."
+        exit 0
+    fi
+    mkdir -p -- "$ESTATE_DIR"
+    git clone --recurse-submodules "$(clone_url_for "$ROOT_REPOSITORY")" "$ESTATE_ROOT"
+    # The clone is what makes the estate readable; from here on the facts come
+    # off disk, exactly as they would for an estate that was already here.
+    estate_here "$ESTATE_DIR" ||
+        die "$ESTATE_ROOT was cloned, but $ESTATE_DIR is not an estate: no
+    \`family.yaml\` holder and no \`project.yaml\` root. The manifest named
+    $ROOT_REPOSITORY; that repository is not a root of this shape."
+    run_make "$ESTATE_NAME" "$ESTATE_ROOT" bootstrap || {
+        REFUSED=$((REFUSED + 1))
+        say "  FINDING: \`make bootstrap\` did not exit 0 in $ESTATE_ROOT; its legs may not be placed."
+    }
+fi
+
+if [ "$ESTATE_KIND" = "family" ]; then
+    # WHICH SIBLINGS WERE ALREADY HERE, recorded BEFORE `make siblings` runs:
+    # a clone that command places is already on its tracking branch with its
+    # own bootstrap run, so fast-forwarding it again would be work for
+    # nothing. The ones that were here are the ones ruling 2 is about.
+    while IFS= read -r member; do
+        [ -e "$ESTATE_DIR/$member/.git" ] || continue
+        EXISTING_SIBLINGS="$EXISTING_SIBLINGS$member "
+    done < <(family_members "$ESTATE_ROOT/family.yaml")
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        say "  would run: make siblings   ($ESTATE_ROOT)"
+    else
+        SIBLINGS_LOG="$(mktemp)"
+        say "  --- $ESTATE_NAME: make siblings ---"
+        set +e
+        (cd "$ESTATE_ROOT" && exec make siblings) 2>&1 | tee "$SIBLINGS_LOG"
+        SIBLINGS_STATUS=${PIPESTATUS[0]}
+        set -e
+        if [ "$SIBLINGS_STATUS" -ne 0 ]; then
+            REFUSED=$((REFUSED + 1))
+            say "  FINDING: \`make siblings\` exited $SIBLINGS_STATUS; read its findings above."
+        fi
+    fi
+
+    say ""
+    say "  each member's own working clone, fast-forwarded (RULING ruling 2)"
+    while IFS= read -r member; do
+        [ -n "$member" ] || continue
+        if [ ! -e "$ESTATE_DIR/$member/.git" ]; then
+            # `make siblings` above is what places one, and it has already
+            # reported this as a finding of its own. Said again here because
+            # the line a person reads next is this list.
+            say "  [$member] still no working clone beside the holder; \`make siblings\` places one."
+            continue
+        fi
+        case "$EXISTING_SIBLINGS" in
+        *" $member "*) ;;
+        *)
+            # JUST PLACED by `make siblings`, which clones on the tracking
+            # branch and runs the member's own bootstrap. Fast-forwarding a
+            # clone one command old would be work for nothing.
+            say "  [$member] placed by \`make siblings\`: on its tracking branch, its own bootstrap run."
+            continue
+            ;;
+        esac
+        refresh_root "$member" "$ESTATE_DIR/$member" ||
+            REFUSED_MEMBERS="$REFUSED_MEMBERS$member "
+    done < <(family_members "$ESTATE_ROOT/family.yaml")
+fi
+
+# --- (4) the verb -----------------------------------------------------------
+# ONE `ARGS=` STRING, because that is the whole interface the two Makefiles
+# offer (#80): the recipe word-splits `$(ARGS)`, so an argument carrying a
+# space cannot survive the trip and this command does not pretend otherwise.
+MAKE_ARGS=""
+[ "$DRY_RUN" -eq 0 ] || MAKE_ARGS="--dry-run"
+if [ ${#PASSTHROUGH[@]} -gt 0 ]; then
+    MAKE_ARGS="${MAKE_ARGS:+$MAKE_ARGS }${PASSTHROUGH[*]}"
+fi
+
+say ""
+# shellcheck disable=SC2016  # the single quotes are LITERAL, as above
+say "(4) make resume${MAKE_ARGS:+ ARGS='$MAKE_ARGS'}   ($ESTATE_ROOT)"
+
+# THE EXIT CODE IS MAKE'S, UNCHANGED. `resume.sh`'s own 0/1/2/3 do not survive
+# make - GNU make reports ANY non-zero recipe status as its own exit 2 and
+# prints `Error <code>` - and this command neither rewrites nor rescues that:
+# the code is in make's diagnostic, and a run that refused must never read as
+# success. #80's Makefile says the same thing at the target.
+STATUS=0
+RESUME_CALL=(make resume)
+[ -z "$MAKE_ARGS" ] || RESUME_CALL+=("ARGS=$MAKE_ARGS")
+
+# A CLONE THIS RUN REFUSED DOES NOT GET THE VERB EITHER (F9 of the review on
+# #83). The holder's `make resume` is `siblings.py --make resume`, whose whole
+# flag set is `--root`, `--dry-run`, `--make` and `--make-arg`: there is no
+# exclusion to hand it, so with a refusal on the board the verb is run PER
+# NON-REFUSED SIBLING here instead, and the holder's own dispatch is used
+# whenever there is nothing to exclude - which is every ordinary run. Adding
+# an `--exclude` to `siblings.py` is a change to a PINNED template file that
+# reaches every holder through `update-shape.py`, and it is not this object's
+# to make; #82's follow-up can propose it.
+run_the_verb_per_sibling() {
+    local member status worst=0
+    say "  the holder's dispatch is NOT used: it has no way to leave a refused member out,"
+    say "  so the verb runs in each member that was not refused, and in no other."
+    while IFS= read -r member; do
+        [ -n "$member" ] || continue
+        case "$REFUSED_MEMBERS" in
+        *" $member "*)
+            say "  [$member] refused above; \`make resume\` NOT run. Nothing here was touched."
+            continue
+            ;;
+        esac
+        [ -e "$ESTATE_DIR/$member/.git" ] || continue
+        status=0
+        run_make "$member" "$ESTATE_DIR/$member" resume "$MAKE_ARGS" || status=$?
+        [ "$status" -eq 0 ] || worst="$status"
+    done < <(family_members "$ESTATE_ROOT/family.yaml")
+    return "$worst"
+}
+
+if [ "$DRY_RUN" -eq 1 ] && [ ! -f "$ESTATE_ROOT/Makefile" ]; then
+    say "  would run: make resume"
+elif [ "$ROOT_REFUSED" -eq 1 ] && [ "$ESTATE_KIND" != "family" ]; then
+    # A standalone root that was refused is one checkout, and it is the one
+    # the verb would run in. Nothing here was touched, and that includes this.
+    say "  NOT run: $ESTATE_ROOT was refused above. Nothing here was touched."
+    say "  Sort that checkout out - the lines above name what it is - and re-run."
+elif [ "$REFUSED_MEMBERS" != " " ]; then
+    set +e
+    run_the_verb_per_sibling
+    STATUS=$?
+    set -e
+else
+    set +e
+    (cd "$ESTATE_ROOT" && exec "${RESUME_CALL[@]}")
+    STATUS=$?
+    set -e
+fi
+
+# --- (5) the layout, and the summary ----------------------------------------
+say ""
+say "(5) the layout"
+if [ -n "$SIBLINGS_LOG" ] && [ -s "$SIBLINGS_LOG" ] &&
+    grep -q '^(b) the layout$' "$SIBLINGS_LOG"; then
+    # `make siblings`' OWN TABLE, reprinted rather than recomputed: two
+    # readings of "what is beside the holder" is how they start disagreeing.
+    sed -n '/^(b) the layout$/,/^$/p' "$SIBLINGS_LOG"
+elif [ "$ESTATE_KIND" = "standalone" ]; then
+    printf '  %-9s %-18s %-22s %s\n' "what" "name" "state" "branch"
+    printf '  %-9s %-18s %-22s %s\n' "root" "$ESTATE_NAME" "the assembly root" \
+        "$(git -C "$ESTATE_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || printf '?')"
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        printf '  %-9s %-18s %-22s %s\n' "leg" "$line" "mounted" \
+            "$(git -C "$ESTATE_ROOT/$line" rev-parse --abbrev-ref HEAD 2>/dev/null || printf '?')"
+    done < <(git -C "$ESTATE_ROOT" config --file .gitmodules \
+        --get-regexp '^submodule\..*\.path$' 2>/dev/null | sed 's/^[^ ]* //' || true)
+else
+    say "  (no layout table: \`make siblings\` did not run)"
+fi
+
+say ""
+say "resume: $ESTATE_NAME - \`make resume\` exited $STATUS; $REFUSED refusal(s) or finding(s) above."
+say "  ct / cts land you in the feature the record named active; agent sessions do not travel,"
+say "  and a handoff document is the bridge for those."
+if [ "$DRY_RUN" -eq 1 ]; then
+    say "  --dry-run: nothing was cloned, pulled, bootstrapped or recreated."
+fi
+
+[ "$STATUS" -eq 0 ] || exit "$STATUS"
+# A REFUSAL IS NOT A PASS, and neither is a skip: a run that could not
+# fast-forward a member must not exit 0, or somebody reads it as the estate
+# being current when part of it is not (#80's rule, for the same reason).
+[ "$REFUSED" -eq 0 ] || exit 1
+exit 0

--- a/devBenches/base-image/files/openreposhape/templates/assembly-root/project.yaml
+++ b/devBenches/base-image/files/openreposhape/templates/assembly-root/project.yaml
@@ -1,0 +1,154 @@
+schema_version: 1
+kind: project-manifest
+
+# ===========================================================================
+# project.yaml — this project's SELF-DESCRIBING MANIFEST, and the SOURCE.
+#
+# Where an aggregation exists, its `project-register.yaml` row is DERIVED from
+# this file; this file is never derived from the register. That direction is
+# what lets an organisation with no aggregation, no register and no
+# openxFactory still be conformant — a file inside the project is readable by
+# anyone who cloned it, which is exactly the population that needs it.
+#
+# IT CONFERS NOTHING. `schema`, `legs[].role` and `topic` are descriptive
+# navigation. No field here grants review authority, clearance eligibility,
+# gate standing or lifecycle state over any repository it names. A project
+# that declines this schema is reviewed identically to this one, because the
+# authority travels in the grants rather than in the layout. A consumer
+# deriving a permission from `role:` is defective.
+# ===========================================================================
+
+id: {{PROJECT_ID}}
+name: "{{PROJECT_NAME}}"
+
+# The elected schema, and the document the election followed. For a project
+# elected on or after 2026-09-02 this is openxFactory's ratified
+# `docs/project-repo-schema.md`; a project elected earlier recorded the staged
+# fragment's path and keeps it. The default the scaffold writes FOLLOWS
+# `elected_on` below, for that reason, and `--reference` overrides it.
+# Recording it is what makes a project started ahead of ratification legible
+# rather than undeclared.
+schema: project-repo-schema
+reference: "{{REFERENCE}}"
+
+# Electing the shape is a human's act (a `PA` decision, `CA`-constrained and
+# `PM`-sequenced), so the manifest records whose act it was and when.
+elected_by: "{{ELECTED_BY}}"
+elected_on: {{ELECTED_ON}}
+
+# The GitHub topic every one of this project's repositories carries. Names
+# carry the human eye, topics carry the organisation's search, and the
+# register — where one exists — is the only one of the three that is reviewed.
+topic: {{TOPIC}}
+
+# `private`, `public` or `internal` (an enterprise org-internal repository).
+# NOT ENFORCED HERE — GitHub is the source of truth for what a repository's
+# visibility actually is — but recording it is what lets a reader tell,
+# without three `gh repo view` calls, why the legs are internal. For a
+# scaffolded project this is all three repositories' visibility; for an
+# in-place adoption it is the value the two NEW legs were created with — the
+# assembly root IS the adopted source and keeps whatever visibility it
+# already had on GitHub, unchanged by this tool.
+visibility: {{VISIBILITY}}
+
+# The branch `scripts/bootstrap.py` places each leg on, AT its pinned commit.
+# The pin stays exact: `.gitmodules` carries no `branch=`, so there is exactly
+# one authoritative answer to "what commit is this project".
+tracking_branch: {{TRACKING_BRANCH}}
+
+# The openRepoShape revision this project was scaffolded from, pinned by
+# commit and digest under the same rule the family's neutral products use: a
+# tag can be moved and a commit cannot. `contracts/shape-pin.yaml` carries the
+# same commit plus a per-file sha256 for every file the scaffold COPIED out of
+# openRepoShape, which is how an edit to a copied validator is detected.
+shape:
+  repository: {{SHAPE_REPOSITORY}}
+  revision_kind: commit
+  commit: "{{SHAPE_COMMIT}}"
+  digest_algorithm: sha256
+  digest_definition: {{DIGEST_DEFINITION}}
+  digests:
+    tree_sha256: "{{SHAPE_TREE_SHA256}}"
+
+# The neutral products this project declares a pin on, by name. OPTIONAL, and
+# empty in a fresh scaffold. It is what makes a `<Domainx><Product>` name a
+# domain DESCENDANT rather than merely a name shaped like one: ruled by Brett
+# Heap on 2026-09-02, "descendant only if it pins open<Product>". Add the name
+# here and the matching `contracts/<name lowercased>-pin.yaml` beside it, in
+# one commit, and the classification changes with the pin — never before it.
+# The check is OFFLINE: this list is a fact in this tree, so no lookup of any
+# organisation's repositories is involved.
+#
+# A project may pin a LAYER of the product rather than the product itself —
+# `codexDox` pins `openXdox`, which pins `openDox` — and then the referent is
+# reached through the chain the leg's `naming.referent_chain:` records, below.
+# The first entry of that chain is one of the names in THIS list, because it
+# is the pin this project actually holds.
+neutral_product_pins: {{NEUTRAL_PRODUCT_PINS}}
+
+# The three legs. `assembly` is THIS repository — the one an engineer clones —
+# and its path is `.`; `spec` and `code` are submodules mounted at the paths
+# below. Roles are exactly {assembly, spec, code}, once each.
+#
+# Each leg carries an OPTIONAL `naming:` record: the form the name classified
+# as, the role it was declared in, and `also_matches` — every OTHER form the
+# name satisfies. `MedxScribe` is an ordinary assembly root that also matches
+# the descendant form; recording that is how the next reader sees an overlap
+# that was RESOLVED rather than one nobody noticed. It confers nothing, like
+# every other field here; `scripts/validate-manifest.py` checks it agrees with
+# the name, and refuses `referent_declared: true` with no pin file beside it.
+#
+# THE ASSEMBLY LEG NEED NOT BE A BARE CamelCase TOKEN. Two other forms may be
+# the root, and both RECORD the overlap here rather than losing it:
+#
+#   - a DECLARED domain descendant (Brett Heap, 2026-09-02) — `MedxGlass` pins
+#     `openGlass` AND mounts `MedxGlass-spec` and `MedxGlass-code`;
+#   - a NEUTRAL PRODUCT that has elected the shape (Brett Heap, 2026-09-05,
+#     "elect the shape for both, follow the pin chain, no family yet") —
+#     `openDox` mounts `openDox-spec` and `openDox-code` and records
+#
+#         naming:
+#           form: neutral-product
+#           role: assembly
+#           also_matches: [project-leg/assembly]
+#
+# In both cases the FORM won the classification and the declared role was
+# ADDED to it; electing confers nothing, so a neutral product that is its own
+# root is a fact about LAYOUT and not a claim about its neutrality. The legs
+# are unaffected either way: `openDox-spec` carries the lowercase suffix and
+# is an ordinary project leg, a descendant of nothing and a neutral product of
+# nothing. An `<X>-Install` is admitted into no role at all.
+#
+# A descendant that reaches its referent through a CHAIN records that chain
+# too (ruled by Brett Heap on 2026-09-05, "follow the pin chain"):
+#
+#     naming:
+#       form: domain-descendant
+#       role: assembly
+#       also_matches: [project-leg/assembly]
+#       descendant_referent: openDox        # what the NAME claims
+#       referent_declared: true
+#       referent_chain: [openXdox, openDox] # how it is REACHED
+#
+# The FIRST entry is what `neutral_product_pins:` above declares and what
+# `contracts/<it>-pin.yaml` holds; the LAST is the referent the name claims;
+# each link between them is a declaration in THAT link's own `project.yaml`
+# (`openXdox` declaring `neutral_product_pins: [openDox]`). The validator
+# verifies a link when that repository is checked out beside this one — or
+# named by `SHAPE_PIN_SOURCE_<PRODUCT>` — and otherwise reports it as
+# `declared-unverified`, which is a warning and not a finding: the check is
+# offline, and a recorded declaration is the fact it reads. A chain that does
+# NOT hold is a finding, and it names the link that broke.
+legs:
+  - role: assembly
+    repository: {{ASSEMBLY_REPOSITORY}}
+    path: "."
+{{ASSEMBLY_NAMING}}
+  - role: spec
+    repository: {{SPEC_REPOSITORY}}
+    path: {{SPEC_PATH}}
+{{SPEC_NAMING}}
+  - role: code
+    repository: {{CODE_REPOSITORY}}
+    path: {{CODE_PATH}}
+{{CODE_NAMING}}

--- a/devBenches/base-image/update-upstream.py
+++ b/devBenches/base-image/update-upstream.py
@@ -33,7 +33,16 @@ ON PURPOSE, and the finding names both.
 
 EVERY FILE UNDER A VENDOR DIRECTORY IS A PINNED COPY, by construction. A file
 there with no row is a finding as loud as a changed byte: it is bytes from
-somewhere nobody recorded, sitting in the directory a reader trusts.
+somewhere nobody recorded, sitting in the directory a reader trusts. So is a
+copy that stopped being a regular file, or one that resolves out of the tree:
+a link is followed by every read and write in the standard library, so neither
+verb will touch a path whose `realpath` leaves the vendor directory.
+
+A NEW SOURCE'S ROWS ARE HAND-WRITTEN, ONCE. The block — id, repository,
+`vendor_dir` and one `- path: <upstream path>` per file, with no `sha256:` or
+an empty one — is a human's decision. The first `apply` fetches those paths and
+fills the digests in; `check` refuses an unfilled row, because a row with no
+digest pins nothing. Both refusals name that sequence.
 
 WHAT `apply` REFUSES, because a pin it cannot justify must not be recorded:
 
@@ -48,7 +57,13 @@ WHAT `apply` REFUSES, because a pin it cannot justify must not be recorded:
   * a fetch that failed for ANY file in the set: NOTHING is written, no
     vendored copy is replaced, and every file it could not get is named, with
     both forms it tried. All the bytes in hand before any one of them is
-    placed — openRepoShape #82's F10 rule, for its reason.
+    placed — openRepoShape #82's F10 rule, for its reason;
+  * a `--remove` set that would leave a source with NO rows. An empty `files:`
+    block is a pin this tool's own `check` refuses, so `apply` must not be able
+    to write one and then print `NEXT … check`; emptying a source means
+    deleting its block, by hand and on purpose;
+  * a repeated `--add` or `--remove` value, and a destination that is a link
+    or resolves outside the vendor directory.
 
 THE FETCH ORDER IS THE SHIMS'. `gh api …/contents/<path>?ref=<sha>` with
 `Accept: application/vnd.github.raw` first, because it is authenticated and so
@@ -201,6 +216,10 @@ def read_pin(path: Path) -> tuple[dict[str, str], list[Source], list[str]]:
         text = path.read_text(encoding="utf-8")
     except OSError as exc:
         raise Refusal("pin-unreadable", f"{exc}") from exc
+    except UnicodeDecodeError as exc:
+        # A pin is text. Bytes that are not UTF-8 are a mis-written file, and
+        # a mis-written file must exit 2 with a name, not a traceback.
+        raise Refusal("pin-not-utf8", f"{display(path)}: {exc}") from exc
     lines = text.split("\n")
 
     top: dict[str, str] = {}
@@ -232,6 +251,12 @@ def read_pin(path: Path) -> tuple[dict[str, str], list[Source], list[str]]:
                         f"{display(path)}:{number}: `sources:` takes a block "
                         f"sequence, "
                         f"not {value!r}")
+                if "sources" in top:
+                    raise Refusal(
+                        "pin-duplicate-key",
+                        f"{display(path)}:{number}: `sources:` is set twice; "
+                        f"the second block would merge into the first")
+                top["sources"] = ""
                 in_sources = True
                 continue
             if key in top:
@@ -401,18 +426,29 @@ def validate_pin(path: Path, top: dict[str, str], sources: list[Source],
                 f"lowercase hex — a tag can be moved and a commit cannot")
         vendor_dir = source.value("vendor_dir")
         _checked_relative(vendor_dir, where, "vendor_dir")
-        if vendor_dir in seen_dirs:
-            raise Refusal(
-                "pin-vendor-dir-shared",
-                f"{where}: '{source.id}' and '{seen_dirs[vendor_dir]}' both "
-                f"vendor into {vendor_dir}; one directory, one source")
+        for other, owner in seen_dirs.items():
+            if vendor_dir == other or _under(vendor_dir, other) \
+                    or _under(other, vendor_dir):
+                raise Refusal(
+                    "pin-vendor-dir-shared",
+                    f"{where}: '{source.id}' vendors into {vendor_dir} and "
+                    f"'{owner}' into {other}; one directory per source, and "
+                    f"never one inside another — the outer source's walk "
+                    f"would report the inner source's files as unpinned")
         seen_dirs[vendor_dir] = source.id
         if source.files_line is None:
             raise Refusal("pin-no-files",
                           f"{where}: source '{source.id}' has no `files:` key")
         if not source.rows:
-            raise Refusal("pin-no-rows",
-                          f"{where}: source '{source.id}' has no `files:` rows")
+            raise Refusal(
+                "pin-no-rows",
+                f"{where}: source '{source.id}' has no `files:` rows.\n"
+                f"A source's rows are HAND-WRITTEN once, one `- path: "
+                f"<path in {source.value('source_repository')}>` per file,\n"
+                f"with no `sha256:` (or an empty one); the first `apply` "
+                f"fetches the bytes and fills\nthe digests in:\n"
+                f"    python3 {TOOL} apply --source {source.id} "
+                f"--at <40-hex> --yes")
         seen_paths: set[str] = set()
         for row in source.rows:
             row_where = f"{display(path)}:{row.first_line}"
@@ -420,14 +456,25 @@ def validate_pin(path: Path, top: dict[str, str], sources: list[Source],
             if row.path in seen_paths:
                 raise Refusal("pin-row-duplicate",
                               f"{row_where}: '{row.path}' has two rows")
+            for other in seen_paths:
+                if _under(row.path, other) or _under(other, row.path):
+                    raise Refusal(
+                        "pin-row-nested",
+                        f"{row_where}: '{row.path}' and '{other}' cannot both "
+                        f"be files; one is inside the other")
             seen_paths.add(row.path)
-            if row.sha256 is None:
+            if not row.sha256:
+                # A row written with no digest, or an empty one, is a row
+                # WAITING to be filled: that is how a new source block is
+                # hand-written. `apply` fills it; `check` refuses it, because
+                # a row with no digest pins nothing.
                 if digests_required:
                     raise Refusal(
-                        "pin-row-no-digest",
-                        f"{row_where}: '{row.path}' has no sha256. A row with "
-                        f"no digest pins nothing; run `{TOOL} apply --source "
-                        f"{source.id} --at {source.value('commit')} --yes`")
+                        "pin-row-unfilled",
+                        f"{row_where}: '{row.path}' has no sha256, so it pins "
+                        f"nothing.\nFill it from the upstream bytes:\n"
+                        f"    python3 {TOOL} apply --source {source.id} "
+                        f"--at {source.value('commit')} --yes")
                 continue
             if not SHA256_RE.match(row.sha256):
                 raise Refusal(
@@ -439,6 +486,16 @@ def validate_pin(path: Path, top: dict[str, str], sources: list[Source],
 #: A path that is not relative-and-downward. Anchored at the front so a drive
 #: letter, a UNC prefix and a leading slash are all one check.
 NOT_RELATIVE_RE = re.compile(r"^(?:/|\\\\|[A-Za-z]:)")
+
+
+def _under(inner: str, outer: str) -> bool:
+    """True when `inner` sits beneath `outer`, compared segment by segment.
+
+    String prefixes are not enough: `files/openreposhapex` starts with
+    `files/openreposhape` and is a different directory.
+    """
+    a, b = inner.split("/"), outer.split("/")
+    return len(a) > len(b) and a[:len(b)] == b
 
 
 def _checked_relative(value: str, where: str, label: str) -> None:
@@ -468,9 +525,35 @@ def file_sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def contained(base: Path, target: Path) -> bool:
+    """True when `target` REALLY lives under `base`, every link resolved.
+
+    `_checked_relative` rejects `..` and an absolute path, which is lexical.
+    This is the other half: a symlinked `vendor_dir`, or a symlinked directory
+    inside one, would otherwise let `check` hash — and `apply` write — bytes
+    outside the tree the pin describes. `realpath` resolves what exists and
+    leaves the rest alone, so it answers for a destination not created yet.
+    """
+    base_real = Path(os.path.realpath(base))
+    target_real = Path(os.path.realpath(target))
+    return target_real == base_real or base_real in target_real.parents
+
+
 def vendor_root(pin_path: Path, source: Source) -> Path:
-    """`vendor_dir` is relative to the pin file's own directory."""
-    return pin_path.resolve().parent / source.value("vendor_dir")
+    """`vendor_dir` is relative to the pin file's own directory.
+
+    REFUSES a vendor directory that resolves outside the pin's own directory:
+    that is a link, and a pin cannot describe bytes it does not sit above.
+    """
+    pin_dir = pin_path.resolve().parent
+    root = pin_dir / source.value("vendor_dir")
+    if not contained(pin_dir, root):
+        raise Refusal(
+            "pin-vendor-dir-escapes",
+            f"{source.value('vendor_dir')} resolves outside the pin's own "
+            f"directory ({pin_dir}); a vendor directory is a real directory "
+            f"beside the pin, never a link")
+    return root
 
 
 def display(path: Path) -> str:
@@ -484,6 +567,10 @@ def display(path: Path) -> str:
     """
     here = Path.cwd().resolve()
     resolved = Path(path).resolve()
+    if here == Path(here.root):
+        # Run from `/`, every path is "under" the working directory and
+        # `relative_to` would strip the leading slash off an absolute path.
+        return str(resolved)
     if resolved == here or here in resolved.parents:
         return str(resolved.relative_to(here))
     return str(resolved)
@@ -560,6 +647,11 @@ def cmd_check(args: argparse.Namespace) -> int:
             if copy.is_symlink():
                 drift.append(f"  SYMLINK  {shown}  a vendored copy is a "
                              f"regular file, never a link")
+                _blame(guilty, source)
+                continue
+            if copy.exists() and not contained(root, copy):
+                drift.append(f"  ESCAPES  {shown}  resolves outside the "
+                             f"vendor directory")
                 _blame(guilty, source)
                 continue
             if not copy.is_file():
@@ -714,9 +806,10 @@ def assert_on_default_branch(repository: str, commit: str) -> str:
 def fetch_file(repository: str, commit: str, path: str) -> bytes | None:
     """The shims' order: the API first, the raw URL second.
 
-    Each attempt is checked — a zero exit AND a non-empty body — before its
-    bytes are used, so a half-written first attempt is never mistaken for a
-    fetch. The bytes are RETURNED and held in memory rather than written
+    THE EXIT CODE IS THE CHECK, and the body's length is not: both `gh api`
+    and `curl -f` exit non-zero on a 404 or a truncated transfer, and a
+    zero-byte file is a perfectly ordinary git blob that this must be able to
+    vendor. The bytes are RETURNED and held in memory rather than written
     anywhere: nothing reaches a vendor directory until every file in the set
     is in hand. Returns None rather than dying, so the caller can report the
     whole set of failures instead of stopping at the first.
@@ -724,12 +817,12 @@ def fetch_file(repository: str, commit: str, path: str) -> bytes | None:
     code, out, _ = run_capture(
         ["gh", "api", f"repos/{repository}/contents/{path}?ref={commit}",
          "-H", GH_RAW_ACCEPT])
-    if code == 0 and out:
+    if code == 0:
         return out
     code, out, _ = run_capture(
         ["curl", "-fsSL",
          f"https://raw.githubusercontent.com/{repository}/{commit}/{path}"])
-    if code == 0 and out:
+    if code == 0:
         return out
     return None
 
@@ -752,9 +845,11 @@ def rewrite_pin(pin_path: Path, lines: list[str], source: Source,
     assert source.commit_line is not None
     assert source.files_line is not None and source.files_indent is not None
     commit_index = source.commit_line - 1
-    indent = " " * (len(lines[commit_index])
-                    - len(lines[commit_index].lstrip(" ")))
-    lines[commit_index] = f'{indent}commit: "{commit}"'
+    original = lines[commit_index]
+    # Everything in front of the key, so a `  - commit:` opening item keeps
+    # its sequence marker and an ordinary `    commit:` keeps its indentation.
+    prefix = original[:original.index("commit:")]
+    lines[commit_index] = f'{prefix}commit: "{commit}"'
 
     item_indent = " " * (source.files_indent + 2)
     key_indent = " " * (source.files_indent + 4)
@@ -784,6 +879,13 @@ def cmd_apply(args: argparse.Namespace) -> int:
     root = vendor_root(pin_path, source)
 
     have = [row.path for row in source.rows]
+    for flag, given in (("--add", args.add), ("--remove", args.remove)):
+        for path in given:
+            if given.count(path) > 1:
+                raise Refusal(
+                    "upstream-repeated-flag",
+                    f"{flag} {path!r} is given {given.count(path)} times; "
+                    f"one row is one row")
     for path in args.add:
         _checked_relative(path, "--add", "path")
         if path in have:
@@ -802,6 +904,16 @@ def cmd_apply(args: argparse.Namespace) -> int:
                           f"{path!r} is both --add and --remove")
     wanted = [path for path in have if path not in args.remove]
     wanted += [path for path in args.add if path not in wanted]
+    if not wanted:
+        # Refused HERE, before the fetch and before any byte moves: an empty
+        # `files:` block is a pin its own `check` refuses, so `apply` must not
+        # be able to write one and then print `NEXT … check`.
+        raise Refusal(
+            "upstream-empty-source",
+            f"--remove would leave source '{source.id}' with no rows, and a "
+            f"source with no\nfiles is a source that should not be in the "
+            f"pin — `check` refuses one. Delete the\nblock from "
+            f"{display(pin_path)} by hand, on purpose, instead.")
 
     branch = assert_on_default_branch(repository, args.at)
     print(f"source      {source.id} ({repository})")
@@ -866,6 +978,14 @@ def cmd_apply(args: argparse.Namespace) -> int:
     for path, digest in rows:
         copy = root / path
         copy.parent.mkdir(parents=True, exist_ok=True)
+        if copy.is_symlink() or not contained(root, copy):
+            raise Refusal(
+                "upstream-destination-escapes",
+                f"{source.value('vendor_dir')}/{path} is a link, or resolves "
+                f"outside the vendor directory.\n`write_bytes` and `chmod` "
+                f"follow a link, so this would overwrite bytes no row "
+                f"describes.\nRestore the directory first: git checkout -- "
+                f"{display(root)}/")
         data = staged[path]
         copy.write_bytes(data)
         mode = mode_for(data)
@@ -873,9 +993,16 @@ def cmd_apply(args: argparse.Namespace) -> int:
         print(f"  wrote     {source.value('vendor_dir')}/{path}  {mode:04o}")
     for path in args.remove:
         copy = root / path
-        if copy.is_file():
+        # `is_file()` is False for a directory AND for a broken link, either of
+        # which would have outlived its row. Links are unlinked, not followed;
+        # a directory is a shape no row ever described, so it is named.
+        if copy.is_symlink() or copy.is_file():
             copy.unlink()
             print(f"  deleted   {source.value('vendor_dir')}/{path}")
+        elif copy.is_dir():
+            print(f"  KEPT      {source.value('vendor_dir')}/{path} is a "
+                  f"directory, not a vendored copy; its row is gone and it "
+                  f"is not — remove it by hand")
     rewrite_pin(pin_path, lines, source, args.at, rows)
     print(f"  re-pinned {display(pin_path)}  "
           f"{len(rows)} row(s) at {args.at[:12]}")

--- a/devBenches/base-image/update-upstream.py
+++ b/devBenches/base-image/update-upstream.py
@@ -1,0 +1,941 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Check, and re-take, the COPIES this repository holds of other repositories.
+
+    python3 devBenches/base-image/update-upstream.py check [--source <id>]
+    python3 devBenches/base-image/update-upstream.py apply --source <id> \
+        --at <40-hex commit> --yes [--add <path>]... [--remove <path>]...
+    python3 devBenches/base-image/update-upstream.py list
+
+THE REFLECTION OF openRepoShape's `update-shape.py`, from the consumer's side
+and with the same two verbs on purpose, so that a reader who knows one knows
+this one. There, a project holds copies of the standard's validators and
+re-syncs them; here, this repository holds copies of another repository's
+COMMANDS, because the Docker build that installs them cannot reach github.com
+reliably — the build network may route it through a VPN tunnel whose MTU breaks
+TLS mid-transfer, which is why the Oh My Zsh plugins in the Dockerfile beside
+these come from apt rather than from a clone. So the bytes live in this tree,
+and their identity is `upstream-pin.yaml`.
+
+WHAT `check` IS FOR. It is the run that says the copies still are what the pin
+says they are, and it is wired into the two places that both matter: the
+`regression` job of `.github/workflows/speckit-git-bash.yml`, and one scenario
+of `devBenches/devcontainer.test/test-speckit-git-feature.sh` — which also runs
+inside two containers that mount the workspace READ-ONLY. `check` therefore
+writes nothing at all: no temporary file, no cache, no rewritten row, and it
+needs no network.
+
+IT NEVER OFFERS TO RECOMPUTE A ROW. Recomputing the digest of a file somebody
+edited locally records the local edit as the upstream, which is the failure
+`shape-pin.yaml`'s own header spends a paragraph forbidding. The two ways out
+of a drift finding are to restore the bytes, or to take a new upstream commit
+ON PURPOSE, and the finding names both.
+
+EVERY FILE UNDER A VENDOR DIRECTORY IS A PINNED COPY, by construction. A file
+there with no row is a finding as loud as a changed byte: it is bytes from
+somewhere nobody recorded, sitting in the directory a reader trusts.
+
+WHAT `apply` REFUSES, because a pin it cannot justify must not be recorded:
+
+  * an `--at` that is not a full 40-character commit — a tag can be moved and
+    a commit cannot;
+  * a `--source` the pin does not name: a new source is a new block in that
+    file and a human's decision, not a flag;
+  * a commit that is NOT reachable from the source repository's default
+    branch. openRepoShape squash-merges, so a commit on a pull-request branch
+    is orphaned by the merge and a raw fetch of it 404s for the next person. A
+    pin the rest of the world cannot fetch is a pin nobody can reproduce;
+  * a fetch that failed for ANY file in the set: NOTHING is written, no
+    vendored copy is replaced, and every file it could not get is named, with
+    both forms it tried. All the bytes in hand before any one of them is
+    placed — openRepoShape #82's F10 rule, for its reason.
+
+THE FETCH ORDER IS THE SHIMS'. `gh api …/contents/<path>?ref=<sha>` with
+`Accept: application/vnd.github.raw` first, because it is authenticated and so
+still works inside an organisation whose policy blocks
+raw.githubusercontent.com; `curl` at the raw URL second, for a machine with no
+`gh`. Each attempt is written to a temporary file and checked before its bytes
+are used, so a half-written first attempt is never mistaken for a fetch.
+
+MODES ARE NOT PINNED, AND THAT IS DELIBERATE. A fetched file whose first two
+bytes are `#!` is a command and is placed 0755; anything else is data and is
+placed 0644. The pin records BYTES: the Dockerfile chmods 0755 explicitly when
+it installs the commands, so no image depends on the in-tree bit, and a
+`check` that compared filesystem modes would report a finding on any checkout
+made by a tool that does not carry them.
+
+STANDARD LIBRARY ONLY, and its own reader for the small subset of YAML the pin
+is written in. Importing the upstream's `repo_shape.py` would give this checker
+the one property it must not have: breaking on exactly the refactor it exists
+to notice.
+
+EXIT CODES
+    check   0  every row matches its bytes
+            1  a FINDING: a copy drifted, went missing, stopped being a
+               regular file, or a file under a vendor directory has no row
+            2  a REFUSAL: no pin, an unreadable or malformed pin, an unknown
+               --source
+    apply   0  applied
+            2  a REFUSAL, including the plan printed without --yes
+    list    0  the sources; 2 if the pin cannot be read
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+TOOL = "devBenches/base-image/" + Path(__file__).name
+DEFAULT_PIN = Path(__file__).resolve().parent / "upstream-pin.yaml"
+
+SCHEMA_VERSION = "1"
+KIND = "pinned_copy_manifest"
+DIGEST_ALGORITHM = "sha256"
+
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+SOURCE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+#: Every key a `sources:` block must carry. `files:` is checked separately,
+#: because it is a block and not a scalar.
+SOURCE_KEYS = ("id", "source_repository", "materialization", "revision_kind",
+               "commit", "vendor_dir")
+
+GH_RAW_ACCEPT = "Accept: application/vnd.github.raw"
+
+
+class Refusal(Exception):
+    """A named refusal that names its own fix.
+
+    `code` is machine-readable and `detail` is for a human; `str(exc)` renders
+    both, so a caller that prints the exception cannot drop the remedy.
+    """
+
+    def __init__(self, code: str, detail: str):
+        super().__init__(code, detail)
+        self.code = code
+        self.detail = detail
+
+    def __str__(self) -> str:
+        return f"REFUSED {self.code}: {self.detail}"
+
+
+# ---------------------------------------------------------------------------
+# The pin reader
+# ---------------------------------------------------------------------------
+#
+# SUPPORTED, and nothing else: one document, `#` comment lines, blank lines,
+# indent-zero `key: value` scalars, one indent-zero `sources:` key whose value
+# is a block sequence of mappings, and inside each of those a `files:` key
+# whose value is a block sequence of mappings. Scalars may be bare or wrapped
+# in one pair of single or double quotes.
+#
+# REFUSED, by line number: a tab in the indentation, a construct this reader
+# would have to invent a meaning for, a key at an indentation the shape does
+# not put a key at. An invented meaning in a checker is a wrong answer with a
+# confident tone — and this reader's whole job is to be unable to mis-read the
+# file it is the checker for.
+#
+# The reader also records LINE NUMBERS, because `apply` rewrites the rows it
+# owns in place rather than re-emitting the file: the header prose, the key
+# order and every other source's block survive an `apply` byte for byte, so a
+# reviewer reading `git diff` after one sees the commit and the digests move
+# and nothing else.
+
+
+class Row:
+    """One `- path: … / sha256: …` record, and where it sits in the file."""
+
+    def __init__(self, path: str, line: int):
+        self.path = path
+        self.sha256: str | None = None
+        self.first_line = line
+        self.last_line = line
+
+
+class Source:
+    """One `sources:` block: its scalars, its rows, and their line spans."""
+
+    def __init__(self, line: int, indent: int):
+        self.values: dict[str, str] = {}
+        self.rows: list[Row] = []
+        self.item_line = line
+        self.item_indent = indent
+        self.key_indent = indent + 2
+        self.commit_line: int | None = None
+        self.files_line: int | None = None
+        self.files_indent: int | None = None
+
+    def value(self, key: str) -> str:
+        return self.values.get(key, "")
+
+    @property
+    def id(self) -> str:
+        return self.value("id")
+
+
+def _unquote(raw: str) -> str:
+    text = raw.strip()
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in "\"'":
+        return text[1:-1]
+    return text
+
+
+def _split_key(text: str, path: Path, number: int) -> tuple[str, str]:
+    if ":" not in text:
+        raise Refusal("pin-unparsable",
+                      f"{display(path)}:{number}: expected `key: value`, got {text!r}")
+    key, _, value = text.partition(":")
+    return key.strip(), _unquote(value)
+
+
+def read_pin(path: Path) -> tuple[dict[str, str], list[Source], list[str]]:
+    """Parse the pin. Returns its top-level scalars, its sources, its lines."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise Refusal("pin-unreadable", f"{exc}") from exc
+    lines = text.split("\n")
+
+    top: dict[str, str] = {}
+    sources: list[Source] = []
+    in_sources = False
+    source: Source | None = None
+    row: Row | None = None
+
+    for index, raw in enumerate(lines):
+        number = index + 1
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        if raw.startswith("\t") or (raw[: len(raw) - len(raw.lstrip())]
+                                    .count("\t")):
+            raise Refusal("pin-unparsable",
+                          f"{display(path)}:{number}: a tab in the indentation")
+        indent = len(raw) - len(raw.lstrip(" "))
+        body = raw.strip()
+
+        if indent == 0:
+            in_sources = False
+            source = None
+            row = None
+            key, value = _split_key(body, path, number)
+            if key == "sources":
+                if value:
+                    raise Refusal(
+                        "pin-unparsable",
+                        f"{display(path)}:{number}: `sources:` takes a block "
+                        f"sequence, "
+                        f"not {value!r}")
+                in_sources = True
+                continue
+            if key in top:
+                raise Refusal("pin-duplicate-key",
+                              f"{display(path)}:{number}: `{key}:` is set "
+                              f"twice at the top level")
+            top[key] = value
+            continue
+
+        if not in_sources:
+            raise Refusal("pin-unparsable",
+                          f"{display(path)}:{number}: indented line outside "
+                          f"`sources:`")
+
+        # A new `- ` item at the sources indentation opens a source block.
+        if source is None or indent == source.item_indent:
+            if not body.startswith("- "):
+                raise Refusal(
+                    "pin-unparsable",
+                    f"{display(path)}:{number}: expected a `- ` source item at "
+                    f"indent "
+                    f"{indent}")
+            source = Source(number, indent)
+            sources.append(source)
+            row = None
+            key, value = _split_key(body[2:], path, number)
+            if key == "files":
+                raise Refusal(
+                    "pin-unparsable",
+                    f"{display(path)}:{number}: a source opens with a scalar "
+                    f"key, not `files:`")
+            source.values[key] = value
+            if key == "commit":
+                source.commit_line = number
+            continue
+
+        if source.files_indent is not None and indent > source.files_indent:
+            item_indent = source.files_indent + 2
+            if indent == item_indent:
+                if not body.startswith("- "):
+                    raise Refusal(
+                        "pin-unparsable",
+                        f"{display(path)}:{number}: expected a `- ` file row at "
+                        f"indent "
+                        f"{indent}")
+                key, value = _split_key(body[2:], path, number)
+                if key != "path":
+                    raise Refusal(
+                        "pin-unparsable",
+                        f"{display(path)}:{number}: a file row opens with `path:`, "
+                        f"not "
+                        f"{key!r}")
+                row = Row(value, number)
+                source.rows.append(row)
+                continue
+            if indent == item_indent + 2 and row is not None:
+                key, value = _split_key(body, path, number)
+                if key != "sha256":
+                    raise Refusal(
+                        "pin-unparsable",
+                        f"{display(path)}:{number}: a file row carries `path:` and "
+                        f"`sha256:`, not {key!r}")
+                if row.sha256 is not None:
+                    raise Refusal(
+                        "pin-duplicate-key",
+                        f"{display(path)}:{number}: '{row.path}' sets "
+                        f"`sha256:` twice")
+                row.sha256 = value
+                row.last_line = number
+                continue
+            raise Refusal("pin-unparsable",
+                          f"{display(path)}:{number}: unexpected indent {indent} inside "
+                          f"`files:`")
+
+        if indent != source.key_indent:
+            raise Refusal("pin-unparsable",
+                          f"{display(path)}:{number}: unexpected indent {indent} in "
+                          f"source '{source.id or '?'}'")
+        key, value = _split_key(body, path, number)
+        if key == "files":
+            if value:
+                raise Refusal(
+                    "pin-unparsable",
+                    f"{display(path)}:{number}: `files:` takes a block "
+                    f"sequence, not {value!r}")
+            if source.files_line is not None:
+                raise Refusal(
+                    "pin-duplicate-key",
+                    f"{display(path)}:{number}: source '{source.id}' has two "
+                    f"`files:` blocks")
+            source.files_line = number
+            source.files_indent = indent
+            row = None
+            continue
+        if key in source.values:
+            raise Refusal("pin-duplicate-key",
+                          f"{display(path)}:{number}: source '{source.id}' "
+                          f"sets `{key}:` twice")
+        source.values[key] = value
+        if key == "commit":
+            source.commit_line = number
+        row = None
+
+    return top, sources, lines
+
+
+def validate_pin(path: Path, top: dict[str, str], sources: list[Source],
+                 digests_required: bool) -> None:
+    """Refuse a pin that does not say what it claims to say.
+
+    `digests_required` is False for `apply`, and only for `apply`: a source
+    block is HAND-WRITTEN with its `path:` rows and no digests, once, and the
+    first `apply` is what fills them in. `check` requires every one of them,
+    because a row with no digest pins nothing.
+    """
+    if top.get("schema_version") != SCHEMA_VERSION:
+        raise Refusal("pin-schema",
+                      f"{display(path)}: schema_version is "
+                      f"{top.get('schema_version')!r}, not {SCHEMA_VERSION!r}")
+    if top.get("kind") != KIND:
+        raise Refusal("pin-kind",
+                      f"{display(path)}: kind is {top.get('kind')!r}, not {KIND!r}")
+    if top.get("digest_algorithm") != DIGEST_ALGORITHM:
+        raise Refusal(
+            "pin-digest-algorithm",
+            f"{display(path)}: digest_algorithm is "
+            f"{top.get('digest_algorithm')!r}, not {DIGEST_ALGORITHM!r}")
+    if not sources:
+        raise Refusal("pin-no-sources",
+                      f"{display(path)}: `sources:` names no source")
+
+    seen_ids: set[str] = set()
+    seen_dirs: dict[str, str] = {}
+    for source in sources:
+        where = f"{display(path)}:{source.item_line}"
+        missing = [key for key in SOURCE_KEYS if not source.value(key)]
+        if missing:
+            raise Refusal("pin-source-keys",
+                          f"{where}: source '{source.id or '?'}' is missing "
+                          + ", ".join(missing))
+        if not SOURCE_ID_RE.match(source.id):
+            raise Refusal("pin-source-id",
+                          f"{where}: {source.id!r} is not a lowercase id")
+        if source.id in seen_ids:
+            raise Refusal("pin-source-duplicate",
+                          f"{where}: '{source.id}' is named twice")
+        seen_ids.add(source.id)
+        if not REPOSITORY_RE.match(source.value("source_repository")):
+            raise Refusal(
+                "pin-source-repository",
+                f"{where}: source_repository "
+                f"{source.value('source_repository')!r} is not `owner/repo`")
+        if source.value("materialization") != "copied":
+            raise Refusal(
+                "pin-materialization",
+                f"{where}: materialization is "
+                f"{source.value('materialization')!r}; this pin records copies")
+        if source.value("revision_kind") != "commit":
+            raise Refusal(
+                "pin-revision-kind",
+                f"{where}: revision_kind is "
+                f"{source.value('revision_kind')!r}, not 'commit'")
+        if not COMMIT_RE.match(source.value("commit")):
+            raise Refusal(
+                "pin-commit",
+                f"{where}: commit {source.value('commit')!r} is not 40 "
+                f"lowercase hex — a tag can be moved and a commit cannot")
+        vendor_dir = source.value("vendor_dir")
+        _checked_relative(vendor_dir, where, "vendor_dir")
+        if vendor_dir in seen_dirs:
+            raise Refusal(
+                "pin-vendor-dir-shared",
+                f"{where}: '{source.id}' and '{seen_dirs[vendor_dir]}' both "
+                f"vendor into {vendor_dir}; one directory, one source")
+        seen_dirs[vendor_dir] = source.id
+        if source.files_line is None:
+            raise Refusal("pin-no-files",
+                          f"{where}: source '{source.id}' has no `files:` key")
+        if not source.rows:
+            raise Refusal("pin-no-rows",
+                          f"{where}: source '{source.id}' has no `files:` rows")
+        seen_paths: set[str] = set()
+        for row in source.rows:
+            row_where = f"{display(path)}:{row.first_line}"
+            _checked_relative(row.path, row_where, "path")
+            if row.path in seen_paths:
+                raise Refusal("pin-row-duplicate",
+                              f"{row_where}: '{row.path}' has two rows")
+            seen_paths.add(row.path)
+            if row.sha256 is None:
+                if digests_required:
+                    raise Refusal(
+                        "pin-row-no-digest",
+                        f"{row_where}: '{row.path}' has no sha256. A row with "
+                        f"no digest pins nothing; run `{TOOL} apply --source "
+                        f"{source.id} --at {source.value('commit')} --yes`")
+                continue
+            if not SHA256_RE.match(row.sha256):
+                raise Refusal(
+                    "pin-row-digest",
+                    f"{row_where}: '{row.path}' has sha256 {row.sha256!r}, "
+                    f"which is not 64 lowercase hex")
+
+
+#: A path that is not relative-and-downward. Anchored at the front so a drive
+#: letter, a UNC prefix and a leading slash are all one check.
+NOT_RELATIVE_RE = re.compile(r"^(?:/|\\\\|[A-Za-z]:)")
+
+
+def _checked_relative(value: str, where: str, label: str) -> None:
+    """A path in the pin is relative, and stays inside the vendor tree."""
+    if not value:
+        raise Refusal("pin-path-empty", f"{where}: {label} is empty")
+    if NOT_RELATIVE_RE.match(value) or "\\" in value:
+        raise Refusal("pin-path-absolute",
+                      f"{where}: {label} {value!r} is not a relative POSIX "
+                      f"path")
+    if any(part in ("", ".", "..") for part in value.split("/")):
+        raise Refusal("pin-path-traversal",
+                      f"{where}: {label} {value!r} does not stay inside the "
+                      f"vendor directory")
+
+
+# ---------------------------------------------------------------------------
+# Digests and the tree
+# ---------------------------------------------------------------------------
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def vendor_root(pin_path: Path, source: Source) -> Path:
+    """`vendor_dir` is relative to the pin file's own directory."""
+    return pin_path.resolve().parent / source.value("vendor_dir")
+
+
+def display(path: Path) -> str:
+    """A path as a reader of this repository would type it.
+
+    Relative to the working directory when it is INSIDE it, so the strings in
+    every message are the strings a person can paste — and so that no output
+    of this tool carries a host-absolute path when it is run from the
+    repository root, which is the only place CI runs it from. A path outside
+    the working directory is printed in full rather than as a ladder of `..`.
+    """
+    here = Path.cwd().resolve()
+    resolved = Path(path).resolve()
+    if resolved == here or here in resolved.parents:
+        return str(resolved.relative_to(here))
+    return str(resolved)
+
+
+def walk_vendor_dir(root: Path) -> list[tuple[str, bool]]:
+    """Every entry under a vendor directory: (relative path, is a symlink).
+
+    Links are never followed and a linked DIRECTORY is reported as an entry
+    of its own, because `os.walk` does not descend into one — a file hidden
+    behind a link would otherwise be a file under a vendor directory that no
+    row records and no walk sees.
+    """
+    found: list[tuple[str, bool]] = []
+    if not root.is_dir():
+        return found
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        here = Path(dirpath)
+        names = list(filenames)
+        names += [name for name in dirnames
+                  if (here / name).is_symlink()]
+        for name in sorted(names):
+            full = here / name
+            found.append((full.relative_to(root).as_posix(),
+                          full.is_symlink()))
+        dirnames.sort()
+    return found
+
+
+# ---------------------------------------------------------------------------
+# check
+# ---------------------------------------------------------------------------
+
+
+def selected(sources: list[Source], wanted: str | None,
+             pin_path: Path) -> list[Source]:
+    if wanted is None:
+        return sources
+    for source in sources:
+        if source.id == wanted:
+            return [source]
+    raise Refusal(
+        "upstream-unknown-source",
+        f"{display(pin_path)} names no source '{wanted}'.\n"
+        "It names: " + ", ".join(s.id for s in sources) + ".\n"
+        "A new source is a new block in that file and a decision, not a flag.")
+
+
+def _blame(guilty: list[Source], source: Source) -> None:
+    if source not in guilty:
+        guilty.append(source)
+
+
+def cmd_check(args: argparse.Namespace) -> int:
+    pin_path = Path(args.pin)
+    top, sources, _ = read_pin(pin_path)
+    validate_pin(pin_path, top, sources, digests_required=True)
+
+    drift: list[str] = []
+    unpinned: list[str] = []
+    #: The sources a finding was raised against, so the remediation can name
+    #: the directory to restore rather than a `<id>` the reader must expand.
+    guilty: list[Source] = []
+    checked = 0
+
+    for source in selected(sources, args.source, pin_path):
+        root = vendor_root(pin_path, source)
+        rows = {row.path: row for row in source.rows}
+        print(f"source      {source.id} ({source.value('source_repository')}) "
+              f"@ {source.value('commit')[:12]}")
+        for row in source.rows:
+            copy = root / row.path
+            shown = f"{source.value('vendor_dir')}/{row.path}"
+            if copy.is_symlink():
+                drift.append(f"  SYMLINK  {shown}  a vendored copy is a "
+                             f"regular file, never a link")
+                _blame(guilty, source)
+                continue
+            if not copy.is_file():
+                drift.append(f"  MISSING  {shown}")
+                _blame(guilty, source)
+                continue
+            computed = file_sha256(copy)
+            checked += 1
+            if computed != row.sha256:
+                drift.append(f"  CHANGED  {shown}  recorded {row.sha256[:8]}  "
+                             f"computed {computed[:8]}")
+                _blame(guilty, source)
+                continue
+            print(f"  ok      {shown}  {computed[:12]}")
+        for found, is_link in walk_vendor_dir(root):
+            if found in rows:
+                continue
+            unpinned.append(f"  UNPINNED {source.value('vendor_dir')}/{found}"
+                            + ("  (a symbolic link)" if is_link else ""))
+            _blame(guilty, source)
+
+    if not drift and not unpinned:
+        print()
+        print(f"{checked} vendored copy(ies) match {display(pin_path)}")
+        return 0
+
+    print()
+    sys.stdout.flush()
+    if drift:
+        print(f"REFUSED: {len(drift)} vendored copy(ies) no longer match "
+              f"{display(pin_path)}.", file=sys.stderr)
+        for line in drift:
+            print(line, file=sys.stderr)
+        print(
+            "Do not recompute the row to make this pass — that records the "
+            "local edit as\nthe upstream. Either restore the bytes:",
+            file=sys.stderr)
+        for source in guilty:
+            print(f"    git checkout -- "
+                  f"{display(vendor_root(pin_path, source))}/",
+                  file=sys.stderr)
+        print("or take a NEW upstream revision on purpose:", file=sys.stderr)
+        for source in guilty:
+            print(f"    python3 {TOOL} apply --source {source.id} "
+                  f"--at <40-hex> --yes", file=sys.stderr)
+    if unpinned:
+        if drift:
+            print(file=sys.stderr)
+        print(f"REFUSED: {len(unpinned)} file(s) under a vendor directory have "
+              f"no row in {display(pin_path)}.", file=sys.stderr)
+        for line in unpinned:
+            print(line, file=sys.stderr)
+        print("Every file under a vendor directory is a pinned copy by "
+              "construction.\nTake it from upstream:", file=sys.stderr)
+        for source in guilty:
+            print(f"    python3 {TOOL} apply --source {source.id} "
+                  f"--at {source.value('commit')} --add <path> --yes",
+                  file=sys.stderr)
+        print("or delete it.", file=sys.stderr)
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    pin_path = Path(args.pin)
+    top, sources, _ = read_pin(pin_path)
+    validate_pin(pin_path, top, sources, digests_required=True)
+    print(f"{display(pin_path)}  schema_version {top['schema_version']}  "
+          f"{top['kind']}  {top['digest_algorithm']}")
+    for source in sources:
+        print()
+        print(f"{source.id}")
+        print(f"  source_repository  {source.value('source_repository')}")
+        print(f"  materialization    {source.value('materialization')}")
+        print(f"  revision_kind      {source.value('revision_kind')}")
+        print(f"  commit             {source.value('commit')}")
+        print(f"  vendor_dir         {source.value('vendor_dir')}")
+        for row in source.rows:
+            print(f"    {row.sha256[:12]}  {row.path}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# apply
+# ---------------------------------------------------------------------------
+
+
+def run_capture(argv: list[str]) -> tuple[int, bytes, str]:
+    """Run a command, never through a shell. Missing binary is returncode 127."""
+    try:
+        proc = subprocess.run(argv, capture_output=True, check=False)
+    except FileNotFoundError as exc:
+        return 127, b"", str(exc)
+    return (proc.returncode, proc.stdout,
+            proc.stderr.decode("utf-8", "replace").strip())
+
+
+def gh_api(endpoint: str, jq: str | None = None) -> tuple[int, str, str]:
+    argv = ["gh", "api", endpoint]
+    if jq is not None:
+        argv += ["-q", jq]
+    code, out, err = run_capture(argv)
+    return code, out.decode("utf-8", "replace").strip(), err
+
+
+def default_branch(repository: str) -> str:
+    code, out, err = gh_api(f"repos/{repository}", ".default_branch")
+    if code == 127:
+        raise Refusal(
+            "upstream-no-gh",
+            f"`apply` needs the `gh` CLI to prove that a commit is reachable "
+            f"from\n{repository}'s default branch, and it is not on PATH: "
+            f"{err}\n`check` needs no network and no `gh` at all.")
+    if code != 0 or not out:
+        raise Refusal(
+            "upstream-default-branch",
+            f"could not read {repository}'s default branch: {err or code}")
+    return out
+
+
+def assert_on_default_branch(repository: str, commit: str) -> str:
+    """Refuse a commit the rest of the world cannot fetch.
+
+    `compare/<default>...<commit>` answers `identical` when the commit IS the
+    branch tip and `behind` when the branch has moved on past it. `ahead` and
+    `diverged` both mean the commit is not on that branch: for a repository
+    that squash-merges, that is exactly a pull-request branch commit, which the
+    merge orphans and a raw fetch of which 404s for the next person.
+    """
+    branch = default_branch(repository)
+    code, out, err = gh_api(
+        f"repos/{repository}/compare/{branch}...{commit}", ".status")
+    if code != 0 or not out:
+        raise Refusal(
+            "upstream-unreachable-commit",
+            f"could not compare {commit[:12]} against {repository}'s "
+            f"{branch}: {err or code}")
+    if out not in ("identical", "behind"):
+        raise Refusal(
+            "upstream-not-on-default-branch",
+            f"{commit[:12]} is not on {repository}'s {branch}; `compare` says "
+            f"'{out}'.\nA pin the rest of the world cannot fetch is a pin "
+            f"nobody can reproduce — land\nthe change first, then pin the "
+            f"commit {branch} carries.")
+    return branch
+
+
+def fetch_file(repository: str, commit: str, path: str) -> bytes | None:
+    """The shims' order: the API first, the raw URL second.
+
+    Each attempt is checked — a zero exit AND a non-empty body — before its
+    bytes are used, so a half-written first attempt is never mistaken for a
+    fetch. The bytes are RETURNED and held in memory rather than written
+    anywhere: nothing reaches a vendor directory until every file in the set
+    is in hand. Returns None rather than dying, so the caller can report the
+    whole set of failures instead of stopping at the first.
+    """
+    code, out, _ = run_capture(
+        ["gh", "api", f"repos/{repository}/contents/{path}?ref={commit}",
+         "-H", GH_RAW_ACCEPT])
+    if code == 0 and out:
+        return out
+    code, out, _ = run_capture(
+        ["curl", "-fsSL",
+         f"https://raw.githubusercontent.com/{repository}/{commit}/{path}"])
+    if code == 0 and out:
+        return out
+    return None
+
+
+def mode_for(data: bytes) -> int:
+    """A fetched file that starts with `#!` is a command; anything else data."""
+    return 0o755 if data[:2] == b"#!" else 0o644
+
+
+def rewrite_pin(pin_path: Path, lines: list[str], source: Source,
+                commit: str, rows: list[tuple[str, str]]) -> None:
+    """Move this source's `commit:` and re-emit its `files:` rows, in place.
+
+    Only those lines change. The header prose, every other source's block, the
+    key order and the trailing bytes of the file survive an `apply` exactly as
+    they were — which is what makes `git diff` after one readable. Comment
+    lines BETWEEN two file rows do not survive, because the rows are re-emitted
+    as a block; the pin's own header says so.
+    """
+    assert source.commit_line is not None
+    assert source.files_line is not None and source.files_indent is not None
+    commit_index = source.commit_line - 1
+    indent = " " * (len(lines[commit_index])
+                    - len(lines[commit_index].lstrip(" ")))
+    lines[commit_index] = f'{indent}commit: "{commit}"'
+
+    item_indent = " " * (source.files_indent + 2)
+    key_indent = " " * (source.files_indent + 4)
+    block: list[str] = []
+    for path, digest in rows:
+        block.append(f"{item_indent}- path: {path}")
+        block.append(f'{key_indent}sha256: "{digest}"')
+
+    start = source.files_line          # the line after `files:`
+    end = max((row.last_line for row in source.rows), default=start)
+    pin_path.write_text("\n".join(lines[:start] + block + lines[end:]),
+                        encoding="utf-8")
+
+
+def cmd_apply(args: argparse.Namespace) -> int:
+    pin_path = Path(args.pin)
+    if not COMMIT_RE.match(args.at):
+        raise Refusal(
+            "upstream-bad-commit",
+            f"--at {args.at!r} is not a commit. `apply` takes a full "
+            f"40-character\nlowercase commit; a tag can be moved and a commit "
+            f"cannot.")
+    top, sources, lines = read_pin(pin_path)
+    validate_pin(pin_path, top, sources, digests_required=False)
+    source = selected(sources, args.source, pin_path)[0]
+    repository = source.value("source_repository")
+    root = vendor_root(pin_path, source)
+
+    have = [row.path for row in source.rows]
+    for path in args.add:
+        _checked_relative(path, "--add", "path")
+        if path in have:
+            raise Refusal(
+                "upstream-already-pinned",
+                f"--add {path!r}: source '{source.id}' already has a row for "
+                f"it.")
+    for path in args.remove:
+        if path not in have:
+            raise Refusal(
+                "upstream-not-pinned",
+                f"--remove {path!r}: source '{source.id}' has no row for it. "
+                f"It has: " + ", ".join(have))
+        if path in args.add:
+            raise Refusal("upstream-add-and-remove",
+                          f"{path!r} is both --add and --remove")
+    wanted = [path for path in have if path not in args.remove]
+    wanted += [path for path in args.add if path not in wanted]
+
+    branch = assert_on_default_branch(repository, args.at)
+    print(f"source      {source.id} ({repository})")
+    print(f"pinned      {source.value('commit')[:12]}")
+    print(f"target      {args.at[:12]} (on {branch})")
+    print(f"vendor      {source.value('vendor_dir')}")
+    print()
+
+    # ALL THE BYTES IN HAND BEFORE ANY ONE OF THEM IS PLACED (#82, F10). A
+    # fetch that fails halfway through leaves a vendor directory holding some
+    # files from the new commit and some from the old, which no pin describes.
+    staged: dict[str, bytes] = {}
+    missing: list[str] = []
+    for path in wanted:
+        data = fetch_file(repository, args.at, path)
+        if data is None:
+            missing.append(path)
+        else:
+            staged[path] = data
+    if missing:
+        raise Refusal(
+            "upstream-fetch-failed",
+            f"{len(missing)} of {len(wanted)} file(s) could not be fetched "
+            f"from {repository}\nat {args.at[:12]}, so NOTHING was written and "
+            f"no vendored copy was replaced:\n"
+            + "".join(f"    {path}\n" for path in missing)
+            + "Both ways were tried, for each:\n"
+            f"    gh api repos/{repository}/contents/<path>?ref={args.at} "
+            f"-H '{GH_RAW_ACCEPT}'\n"
+            f"    curl -fsSL https://raw.githubusercontent.com/{repository}/"
+            f"{args.at}/<path>")
+
+    rows: list[tuple[str, str]] = []
+    plan: list[str] = []
+    for path in wanted:
+        data = staged[path]
+        digest = hashlib.sha256(data).hexdigest()
+        rows.append((path, digest))
+        copy = root / path
+        if path not in have:
+            plan.append(f"  add       {path}  {digest[:12]}")
+        elif copy.is_file() and file_sha256(copy) == digest:
+            plan.append(f"  unchanged {path}")
+        else:
+            plan.append(f"  take      {path}  {digest[:12]}")
+    for path in args.remove:
+        plan.append(f"  remove    {path}")
+    if source.value("commit") != args.at:
+        plan.append(f"  re-pin    commit {source.value('commit')[:12]} -> "
+                    f"{args.at[:12]}")
+    for line in plan:
+        print(line)
+
+    if not args.yes:
+        print()
+        raise Refusal(
+            "upstream-declined",
+            "NOTHING was written: this is the plan, not the run. Re-run it "
+            "with --yes.")
+
+    print()
+    for path, digest in rows:
+        copy = root / path
+        copy.parent.mkdir(parents=True, exist_ok=True)
+        data = staged[path]
+        copy.write_bytes(data)
+        mode = mode_for(data)
+        os.chmod(copy, mode)
+        print(f"  wrote     {source.value('vendor_dir')}/{path}  {mode:04o}")
+    for path in args.remove:
+        copy = root / path
+        if copy.is_file():
+            copy.unlink()
+            print(f"  deleted   {source.value('vendor_dir')}/{path}")
+    rewrite_pin(pin_path, lines, source, args.at, rows)
+    print(f"  re-pinned {display(pin_path)}  "
+          f"{len(rows)} row(s) at {args.at[:12]}")
+    print()
+    print(f"NEXT  python3 {TOOL} check")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# argv
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog=TOOL,
+        description="Check, and re-take, this repository's vendored copies.")
+    subparsers = parser.add_subparsers(dest="verb", required=True)
+
+    check = subparsers.add_parser(
+        "check", help="every vendored copy still matches its row (writes "
+                      "nothing, needs no network)")
+    check.add_argument("--pin", default=str(DEFAULT_PIN),
+                       help="the pin file (default: beside this tool)")
+    check.add_argument("--source", default=None,
+                       help="check one source instead of all of them")
+    check.set_defaults(func=cmd_check)
+
+    apply_ = subparsers.add_parser(
+        "apply", help="take one source's files at a commit and re-pin them")
+    apply_.add_argument("--pin", default=str(DEFAULT_PIN))
+    apply_.add_argument("--source", required=True)
+    apply_.add_argument("--at", required=True,
+                        metavar="COMMIT", help="a full 40-character commit")
+    apply_.add_argument("--yes", action="store_true",
+                        help="without it, the plan is printed and nothing runs")
+    apply_.add_argument("--add", action="append", default=[], metavar="PATH",
+                        help="pin a file this source does not carry yet")
+    apply_.add_argument("--remove", action="append", default=[],
+                        metavar="PATH",
+                        help="drop a row and delete its vendored copy")
+    apply_.set_defaults(func=cmd_apply)
+
+    listing = subparsers.add_parser("list", help="what the pin names")
+    listing.add_argument("--pin", default=str(DEFAULT_PIN))
+    listing.set_defaults(func=cmd_list)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return args.func(args)
+    except Refusal as exc:
+        # Flush first: a refusal that lands on a terminal ahead of the plan or
+        # the per-file report it refers to reads as a refusal about nothing.
+        sys.stdout.flush()
+        print(str(exc), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/devBenches/base-image/update-upstream.py
+++ b/devBenches/base-image/update-upstream.py
@@ -848,7 +848,12 @@ def rewrite_pin(pin_path: Path, lines: list[str], source: Source,
     original = lines[commit_index]
     # Everything in front of the key, so a `  - commit:` opening item keeps
     # its sequence marker and an ordinary `    commit:` keeps its indentation.
-    prefix = original[:original.index("commit:")]
+    # The bare word, not `commit:`: the reader tolerates `commit : "…"` (it
+    # strips the key before comparing), and searching for the colon spelling
+    # raised ValueError on one — a traceback where this file's own rule is
+    # that a mis-written pin exits 2 with a name. Only whitespace and an
+    # optional `- ` can precede the key, so the first occurrence is the key.
+    prefix = original[:original.index("commit")]
     lines[commit_index] = f'{prefix}commit: "{commit}"'
 
     item_indent = " " * (source.files_indent + 2)
@@ -974,18 +979,28 @@ def cmd_apply(args: argparse.Namespace) -> int:
             "NOTHING was written: this is the plan, not the run. Re-run it "
             "with --yes.")
 
+    # EVERY DESTINATION JUDGED BEFORE ANY IS TOUCHED, the same rule as the
+    # fetch above: `write_bytes` and `chmod` follow a link, and a refusal
+    # raised halfway down the write loop would leave some rows at the new
+    # commit and some at the old, which no pin describes.
+    escaping = [path for path, _ in rows
+                if (root / path).is_symlink()
+                or not contained(root, root / path)]
+    if escaping:
+        raise Refusal(
+            "upstream-destination-escapes",
+            f"{len(escaping)} destination(s) are links, or resolve outside "
+            f"the vendor directory,\nso NOTHING was written:\n"
+            + "".join(f"    {source.value('vendor_dir')}/{path}\n"
+                      for path in escaping)
+            + "`write_bytes` and `chmod` follow a link, so this would "
+            "overwrite bytes no row\ndescribes. Restore the directory first: "
+            f"git checkout -- {display(root)}/")
+
     print()
     for path, digest in rows:
         copy = root / path
         copy.parent.mkdir(parents=True, exist_ok=True)
-        if copy.is_symlink() or not contained(root, copy):
-            raise Refusal(
-                "upstream-destination-escapes",
-                f"{source.value('vendor_dir')}/{path} is a link, or resolves "
-                f"outside the vendor directory.\n`write_bytes` and `chmod` "
-                f"follow a link, so this would overwrite bytes no row "
-                f"describes.\nRestore the directory first: git checkout -- "
-                f"{display(root)}/")
         data = staged[path]
         copy.write_bytes(data)
         mode = mode_for(data)

--- a/devBenches/base-image/upstream-pin.yaml
+++ b/devBenches/base-image/upstream-pin.yaml
@@ -1,0 +1,56 @@
+schema_version: 1
+kind: pinned_copy_manifest
+
+# ===========================================================================
+# upstream-pin.yaml — the files this repository holds COPIES of, per source
+# repository, at a commit.
+#
+# A COPY PIN, and not a build-time fetch either. The Docker build cannot reach
+# github.com reliably: a VPN tunnel's MTU breaks TLS mid-clone, which is why
+# the Oh My Zsh plugins come from apt rather than a `git clone`. So the bytes
+# live here, and their identity is these rows.
+#
+# EDITING A VENDORED COPY IS DRIFT AND IS REPORTED AS SUCH.
+# `update-upstream.py check` recomputes every sha256 below, in CI and in the
+# devcontainer suite. The exit from a drift finding is to restore the bytes or
+# to take a new upstream commit ON PURPOSE — never to recompute the row, which
+# records the local edit as the upstream.
+#
+# EVERY FILE UNDER A `vendor_dir` IS A PINNED COPY, by construction: one with
+# no row below is a finding as loud as a changed byte.
+#
+# Each source's `commit:` and every `sha256:` are WRITTEN BY
+# `update-upstream.py apply`; do not hand-edit them, and do not put a comment
+# between two `files:` rows, because `apply` re-emits that block. A NEW source
+# is a human's decision, so its block — id, repository, vendor_dir and the
+# `path:` rows it wants — is hand-written ONCE, with no digests, and the first
+# `apply` fills them in. Everything else in this file survives an `apply` byte
+# for byte.
+#
+# `vendor_dir` is relative to THIS file's directory. `path` is both the path
+# in the source repository and the path under `vendor_dir`: one string, two
+# meanings, because the vendored tree mirrors the upstream's own layout.
+#
+# There is deliberately NO `digests.tree_sha256` here, unlike openRepoShape's
+# `shape-pin.yaml`: nothing is mounted, so no offline run could ever recompute
+# it, and a number no run checks is decoration.
+# ===========================================================================
+
+digest_algorithm: sha256
+
+sources:
+  - id: openreposhape
+    source_repository: opensoft/openRepoShape
+    materialization: copied
+    revision_kind: commit
+    commit: "d090a7a141048b214f0420a8c7afbfff62472d1a"
+    vendor_dir: files/openreposhape
+    files:
+      - path: openRepoShape
+        sha256: "dd273fc39e6771a87450bb1b71fda6f8b728a2ddba3f1c0e44106e7f865b6e3a"
+      - path: park
+        sha256: "432f00236053d3648a061d12c02d9f449982f8a17f100f39de78f41f9013ad13"
+      - path: resume
+        sha256: "3953174297b30a41eb0ae8a57dc59fdb25d2afc3248192dda679501e503566fa"
+      - path: templates/assembly-root/project.yaml
+        sha256: "45a0fb89f7f7f873665d24c0d26a79dab5113364808bd61e914eb07f46eab0c7"

--- a/devBenches/devcontainer.test/docker-compose.yml
+++ b/devBenches/devcontainer.test/docker-compose.yml
@@ -30,5 +30,5 @@ services:
       - PATH=/home/${USER:-brett}/.local/bin:/home/${USER:-brett}/.npm-global/bin:/home/${USER:-brett}/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
       # Where the suite finds the pinned openRepoShape fixture inputs when
       # only this directory is mounted as the workspace.
-      - OPENREPOSHAPE_TEMPLATE_ROOT=/test-fixtures/base-image/files/openreposhape/templates
+      - WORKBENCHES_SHAPE_TEMPLATE_ROOT=/test-fixtures/base-image/files/openreposhape/templates
       - UPDATE_UPSTREAM_FILE=/test-fixtures/base-image/update-upstream.py

--- a/devBenches/devcontainer.test/docker-compose.yml
+++ b/devBenches/devcontainer.test/docker-compose.yml
@@ -10,6 +10,15 @@ services:
     volumes:
       # Mount test script
       - .:/test:cached
+
+      # The pinned openRepoShape copies and their pin checker.
+      # test-speckit-git-feature.sh DERIVES its three-leg project.yaml from
+      # files/openreposhape/templates/assembly-root/project.yaml and runs
+      # update-upstream.py over the vendored copies. The image deliberately
+      # installs the estate COMMANDS and not these templates, so the suite
+      # cannot find them on PATH or under /usr/local/share; read-only is
+      # enough, because `check` writes nothing.
+      - ../base-image:/test-fixtures/base-image:ro
       
     command: sleep infinity
     
@@ -19,3 +28,7 @@ services:
       - HOME=/home/${USER:-brett}
       # PATH for dev tools
       - PATH=/home/${USER:-brett}/.local/bin:/home/${USER:-brett}/.npm-global/bin:/home/${USER:-brett}/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      # Where the suite finds the pinned openRepoShape fixture inputs when
+      # only this directory is mounted as the workspace.
+      - OPENREPOSHAPE_TEMPLATE_ROOT=/test-fixtures/base-image/files/openreposhape/templates
+      - UPDATE_UPSTREAM_FILE=/test-fixtures/base-image/update-upstream.py

--- a/devBenches/devcontainer.test/test-speckit-git-feature.sh
+++ b/devBenches/devcontainer.test/test-speckit-git-feature.sh
@@ -17,6 +17,24 @@ WORKSPACE_COMMON_SCRIPT="$TEMPLATE_ROOT/specify/extensions/git/scripts/bash/work
 PARK_SCRIPT="$TEMPLATE_ROOT/specify/extensions/git/scripts/bash/park.sh"
 RESUME_SCRIPT="$TEMPLATE_ROOT/specify/extensions/git/scripts/bash/resume.sh"
 SELECT_WORKTREE_SCRIPT="$TEMPLATE_ROOT/specify/shell/select-worktree.sh"
+
+# The pinned openRepoShape files this suite READS. The three-leg fixture's
+# manifest is derived from the assembly-root template
+# (write_three_leg_manifest), and one scenario runs the pin checker over the
+# vendored copies themselves.
+#
+# TWO ways, not the three above: the image deliberately does NOT carry these
+# templates — they are a fixture input, not a command, and
+# devBenches/base-image/Dockerfile says so — so there is no
+# /usr/local/share fallback to invent. A run with only devcontainer.test/
+# mounted names them through the environment instead, which is what this
+# directory's own docker-compose.yml does.
+SOURCE_SHAPE_TEMPLATE_ROOT="$REPO_ROOT/devBenches/base-image/files/openreposhape/templates"
+SHAPE_TEMPLATE_ROOT="${OPENREPOSHAPE_TEMPLATE_ROOT:-$SOURCE_SHAPE_TEMPLATE_ROOT}"
+THREE_LEG_MANIFEST_TEMPLATE="$SHAPE_TEMPLATE_ROOT/assembly-root/project.yaml"
+SOURCE_UPDATE_UPSTREAM_FILE="$REPO_ROOT/devBenches/base-image/update-upstream.py"
+UPDATE_UPSTREAM_FILE="${UPDATE_UPSTREAM_FILE:-$SOURCE_UPDATE_UPSTREAM_FILE}"
+
 REAL_GIT="$(command -v git)"
 
 FIXTURE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/speckit-git-feature.XXXXXX")"
@@ -25,6 +43,19 @@ trap 'rm -rf "$FIXTURE_ROOT"' EXIT
 for required_script in "$FEATURE_SCRIPT" "$GET_LAST_WORKTREE_SCRIPT" "$GIT_COMMON_SCRIPT" "$AUTO_COMMIT_SCRIPT" "$WORKSPACE_COMMON_SCRIPT" "$PARK_SCRIPT" "$RESUME_SCRIPT" "$SELECT_WORKTREE_SCRIPT"; do
     if [ ! -x "$required_script" ]; then
         printf 'Checked-in Speckit script is missing or not executable: %s\n' "$required_script" >&2
+        exit 1
+    fi
+done
+
+# `[ -f ]` and not `[ -x ]`: the manifest template is data, and the pin checker
+# is invoked through `python3`. Both are vendored under
+# devBenches/base-image/files/openreposhape/ and pinned by
+# devBenches/base-image/upstream-pin.yaml.
+for required_file in "$THREE_LEG_MANIFEST_TEMPLATE" "$UPDATE_UPSTREAM_FILE"; do
+    if [ ! -f "$required_file" ]; then
+        printf 'Pinned openRepoShape fixture input is missing: %s\n' "$required_file" >&2
+        printf 'Set $OPENREPOSHAPE_TEMPLATE_ROOT and $UPDATE_UPSTREAM_FILE when only\n' >&2
+        printf 'devBenches/devcontainer.test/ is mounted; the image does not carry them.\n' >&2
         exit 1
     fi
 done
@@ -1499,74 +1530,126 @@ add_local_submodule() {
     git -C "$repo" submodule add -q "$source" "$mount"
 }
 
-# The manifest mirrors openRepoShape's assembly-root template with dummy
-# values. The comment block and the nested `naming:` records are deliberate:
-# a naive parser would read the commented `role:` lines, or the code leg's
-# nested `role: spec`, and mount the legs in the wrong place.
+# The three-leg fixture's manifest is DERIVED from the pinned copy of
+# openRepoShape's own assembly-root template, not hand-mirrored: every
+# `{{PLACEHOLDER}}` is substituted with a dummy value and the derivation
+# REFUSES if any survives. A field the standard adds therefore fails here,
+# loudly, instead of leaving a fixture that quietly stops resembling the thing
+# it stands for. The template's own ~140-line comment block reaches the
+# readers with it, which is the point: `workspace_read_scalar`,
+# `workspace_project_repository` and `load_repo_shape` all strip comments
+# before anything else, and this is the run that says so.
+#
+# The nested `naming:` records are the deliberate trap, and they arrive
+# through the substituted values: a naive parser that takes the last `role:`
+# it saw reads the CODE leg's nested `role: spec` and mounts that leg at
+# spec/. The commented decoy leg is the FIXTURE's own and is appended after
+# substitution — the template carries no commented leg block.
 write_three_leg_manifest() {
     local manifest="$1"
 
-    cat > "$manifest" <<'YAML'
-schema_version: 1
-kind: project-manifest
+    python3 - "$THREE_LEG_MANIFEST_TEMPLATE" "$manifest" <<'PY' || return 1
+import re
+import sys
 
+template, destination = sys.argv[1], sys.argv[2]
+
+# One entry per `{{...}}` in openRepoShape's assembly-root project.yaml. A
+# placeholder the standard ADDS has no entry here, so the refusal below names
+# it; a placeholder it REMOVES leaves an unused entry, which is harmless and
+# is not what this fixture is guarding.
+#
+# The `*_NAMING` values carry their own indentation, because the template puts
+# those placeholders at column zero and the block they stand for is nested
+# under the leg at indent 4.
+VALUES = {
+    "PROJECT_ID": "fixture-project",
+    "PROJECT_NAME": "Fixture Project",
+    "REFERENCE": "dummy reference",
+    "ELECTED_BY": "spec-kit-test",
+    "ELECTED_ON": "2026-01-01",
+    "TOPIC": "xf-project-fixture",
+    "VISIBILITY": "private",
+    "TRACKING_BRANCH": "main",
+    "SHAPE_REPOSITORY": "dummy/openRepoShape",
+    "SHAPE_COMMIT": "0" * 40,
+    "DIGEST_DEFINITION": "sorted-ls-tree-r-v1",
+    "SHAPE_TREE_SHA256": "0" * 64,
+    "NEUTRAL_PRODUCT_PINS": "[]",
+    "ASSEMBLY_REPOSITORY": "dummy/fixture-project",
+    "SPEC_REPOSITORY": "dummy/fixture-project-spec",
+    "SPEC_PATH": "spec",
+    "CODE_REPOSITORY": "dummy/fixture-project-code",
+    "CODE_PATH": "code",
+    "ASSEMBLY_NAMING": "    naming:\n      form: project-leg\n"
+                       "      role: assembly\n      also_matches: []",
+    "SPEC_NAMING": "    naming:\n      form: project-leg\n"
+                   "      role: spec\n      also_matches: []",
+    "CODE_NAMING": "    naming:\n      form: project-leg\n"
+                   "      role: spec\n      also_matches: []",
+}
+
+# The fixture's own decoy, carried by no openRepoShape template. A parser that
+# greps for `role:` reads these two commented lines as a fourth leg mounted at
+# a path that does not exist; every reader in the git extension strips comments
+# first (workspace-common.sh, git-common.sh), and this block is what makes that
+# a tested property rather than a claim.
+DECOY = """
 # ===========================================================================
-# project.yaml — this project's SELF-DESCRIBING MANIFEST, and the SOURCE.
-# IT CONFERS NOTHING. `schema`, `legs[].role` and `topic` are descriptive
-# navigation, for example:
+# THE LINES BELOW ARE THIS FIXTURE'S, not openRepoShape's, and they are a
+# DECOY: a naive `grep role:` reader mounts a leg named here that does not
+# exist. Every reader must strip comments before it reads anything.
 #   - role: spec
 #     path: not-a-real-leg
 # ===========================================================================
+"""
 
-id: fixture-project
-name: "Fixture Project"
+with open(template, "r", encoding="utf-8") as stream:
+    text = stream.read()
+for name, value in VALUES.items():
+    text = text.replace("{{%s}}" % name, value)
 
-schema: project-repo-schema
-reference: "dummy reference"
+leftover = sorted(set(re.findall(r"\{\{[^{}]*\}\}", text)))
+if leftover:
+    raise SystemExit(
+        "the pinned openRepoShape manifest template carries "
+        "placeholder(s) this fixture has no value for: %s\n"
+        "    template: %s\n"
+        "Add them to VALUES in write_three_leg_manifest "
+        "(devBenches/devcontainer.test/test-speckit-git-feature.sh)."
+        % (", ".join(leftover), template))
 
-elected_by: "spec-kit-test"
-elected_on: 2026-01-01
+# Three properties the helpers below depend on, asserted where the derivation
+# happens so that a template change is named here rather than three scenarios
+# later.
+#
+# (1) `set_assembly_repository` replaces this exact line and refuses unless it
+#     is unique. The spec and code legs render with a suffix, and the `shape:`
+#     block's repository: sits at indent 2, so it is.
+assembly = "    repository: dummy/fixture-project\n"
+if text.count(assembly) != 1:
+    raise SystemExit(
+        "the derived manifest holds %d assembly-leg repository lines, not 1; "
+        "set_assembly_repository cannot work" % text.count(assembly))
+# (2) Exactly three legs, each opening with its role at indent 2.
+if text.count("\n  - role: ") != 3:
+    raise SystemExit(
+        "the derived manifest holds %d legs, not 3"
+        % text.count("\n  - role: "))
+# (3) The nested `role:` trap survived the substitution, twice: the spec leg's
+#     naming block and the code leg's, the second of which says `spec`.
+if text.count("\n      role: spec\n") != 2:
+    raise SystemExit(
+        "the derived manifest holds %d nested `role: spec` records, not 2; "
+        "the naive-parser trap is gone"
+        % text.count("\n      role: spec\n"))
 
-topic: xf-project-fixture
-
-visibility: private
-
-tracking_branch: main
-
-shape:
-  repository: dummy/openRepoShape
-  revision_kind: commit
-  commit: "0000000000000000000000000000000000000000"
-  digest_algorithm: sha256
-  digest_definition: sorted-ls-tree-r-v1
-  digests:
-    tree_sha256: "0000000000000000000000000000000000000000000000000000000000000000"
-
-neutral_product_pins: []
-
-legs:
-  - role: assembly
-    repository: dummy/fixture-project
-    path: "."
-    naming:
-      form: project-leg
-      role: assembly
-      also_matches: []
-  - role: spec
-    repository: dummy/fixture-project-spec
-    path: spec
-    naming:
-      form: project-leg
-      role: spec
-      also_matches: []
-  - role: code
-    repository: dummy/fixture-project-code
-    path: code
-    naming:
-      form: project-leg
-      role: spec
-      also_matches: []
-YAML
+with open(destination, "w", encoding="utf-8") as stream:
+    stream.write(text)
+    if not text.endswith("\n"):
+        stream.write("\n")
+    stream.write(DECOY)
+PY
 }
 
 initialize_three_leg_fixture() {
@@ -3427,6 +3510,17 @@ test_single_repo_park_and_resume() {
         'single-repo state file'
 }
 
+# The vendored openRepoShape copies — including the manifest template this
+# suite derives its three-leg fixture from — are pinned by commit and per-file
+# sha256. Checking them HERE and not only in CI is what makes an edited copy
+# red for the developer who edited it, before the push. `check` writes nothing
+# and needs no network, which is why it can run inside the read-only mounts of
+# the Bash 3.2 and Git 2.34.1 jobs. Its own report is suppressed on success;
+# a finding goes to stderr and reaches the log.
+test_vendored_copies_match_their_pins() {
+    python3 "$UPDATE_UPSTREAM_FILE" check >/dev/null
+}
+
 failures=0
 run_scenario() {
     local name="$1"
@@ -3440,6 +3534,8 @@ run_scenario() {
     fi
 }
 
+run_scenario 'the vendored openRepoShape copies match devBenches/base-image/upstream-pin.yaml' \
+    test_vendored_copies_match_their_pins
 run_scenario 'default sequential worktree with apostrophe description' test_default_sequential_worktree
 run_scenario 'branch_template with {number}-{slug} final segment' test_branch_template
 run_scenario 'namespaced sequential numbering' test_namespaced_numbering

--- a/devBenches/devcontainer.test/test-speckit-git-feature.sh
+++ b/devBenches/devcontainer.test/test-speckit-git-feature.sh
@@ -30,7 +30,7 @@ SELECT_WORKTREE_SCRIPT="$TEMPLATE_ROOT/specify/shell/select-worktree.sh"
 # mounted names them through the environment instead, which is what this
 # directory's own docker-compose.yml does.
 SOURCE_SHAPE_TEMPLATE_ROOT="$REPO_ROOT/devBenches/base-image/files/openreposhape/templates"
-SHAPE_TEMPLATE_ROOT="${OPENREPOSHAPE_TEMPLATE_ROOT:-$SOURCE_SHAPE_TEMPLATE_ROOT}"
+SHAPE_TEMPLATE_ROOT="${WORKBENCHES_SHAPE_TEMPLATE_ROOT:-$SOURCE_SHAPE_TEMPLATE_ROOT}"
 THREE_LEG_MANIFEST_TEMPLATE="$SHAPE_TEMPLATE_ROOT/assembly-root/project.yaml"
 SOURCE_UPDATE_UPSTREAM_FILE="$REPO_ROOT/devBenches/base-image/update-upstream.py"
 UPDATE_UPSTREAM_FILE="${UPDATE_UPSTREAM_FILE:-$SOURCE_UPDATE_UPSTREAM_FILE}"
@@ -54,7 +54,7 @@ done
 for required_file in "$THREE_LEG_MANIFEST_TEMPLATE" "$UPDATE_UPSTREAM_FILE"; do
     if [ ! -f "$required_file" ]; then
         printf 'Pinned openRepoShape fixture input is missing: %s\n' "$required_file" >&2
-        printf 'Set $OPENREPOSHAPE_TEMPLATE_ROOT and $UPDATE_UPSTREAM_FILE when only\n' >&2
+        printf 'Set $WORKBENCHES_SHAPE_TEMPLATE_ROOT and $UPDATE_UPSTREAM_FILE when only\n' >&2
         printf 'devBenches/devcontainer.test/ is mounted; the image does not carry them.\n' >&2
         exit 1
     fi
@@ -1631,11 +1631,15 @@ if text.count(assembly) != 1:
     raise SystemExit(
         "the derived manifest holds %d assembly-leg repository lines, not 1; "
         "set_assembly_repository cannot work" % text.count(assembly))
-# (2) Exactly three legs, each opening with its role at indent 2.
-if text.count("\n  - role: ") != 3:
+# (2) Exactly three legs, each opening with its role at indent 2, and the
+#     roles are exactly the three load_repo_shape needs, once each — a
+#     template that renamed one would otherwise pass this and then fail three
+#     scenarios later inside the reader.
+roles = re.findall(r"^  - role: (\S+)$", text, re.MULTILINE)
+if sorted(roles) != ["assembly", "code", "spec"]:
     raise SystemExit(
-        "the derived manifest holds %d legs, not 3"
-        % text.count("\n  - role: "))
+        "the derived manifest's legs are %r, not assembly/spec/code once each"
+        % (roles,))
 # (3) The nested `role:` trap survived the substitution, twice: the spec leg's
 #     naming block and the code leg's, the second of which says `spec`.
 if text.count("\n      role: spec\n") != 2:


### PR DESCRIPTION
Lane: xfactory-2 (xFactory-2)
Claim: https://github.com/opensoft/workBenches/issues/32#issuecomment-5621452209

Part of #32 (W1 of two slices; W2 follows once opensoft/openRepoTools has a main). Design record: opensoft/openRepoShape#92.

**What lands.** This repository now holds VENDORED COPIES of another repository's commands, and their identity is a file under review. `devBenches/base-image/upstream-pin.yaml` records, per SOURCE repository, a 40-hex commit and a sha256 per file; `devBenches/base-image/update-upstream.py` is the code that says the copies still match it; `dev-bench-base` installs `openRepoShape`, `park` and `resume` into `/usr/local/bin`; and `test-speckit-git-feature.sh` stops hand-mirroring openRepoShape's assembly-root manifest and DERIVES its three-leg fixture from the pinned template.

Copies and not a build-time fetch, for the reason already written into the Dockerfile beside the Oh My Zsh plugins: the build network may route github.com through a VPN tunnel whose MTU breaks TLS mid-transfer. So the bytes live here.

**The pin.** `opensoft/openRepoShape` at `d090a7a141048b214f0420a8c7afbfff62472d1a` — `gh api repos/opensoft/openRepoShape/compare/main...d090a7a1 -q .status` says `identical`, so it is the commit `main` carries, and its tree still holds `park` and `resume`, which is why W1 precedes the carve (S2). It is deliberately post-openRepoShape#93, which rewrote `park` (+288/−90: a bare `park` with no estate now parks every estate) and touched `resume` (+9); pinning the pre-#93 tip would have shipped this image a `park` that main had already replaced. Nothing under `templates/` moved between those two commits (`git diff --stat` empty), so the derived fixture below is unaffected by the move — and that is said from a run, not from reasoning: the whole suite matrix was re-run after the re-vendor.

Four files: `openRepoShape`, `park`, `resume` and `templates/assembly-root/project.yaml`. `vendor_dir` is relative to the pin file's own directory and `path` is BOTH the upstream path and the path under it — one string, two meanings, because the vendored tree mirrors the upstream's layout. There is deliberately no `digests.tree_sha256`, unlike `shape-pin.yaml`: nothing here is mounted, so no offline run could recompute it, and a number no run checks is decoration. Multi-source from day one though W1 fills in one source, so W2 is two `apply` runs and one Dockerfile hunk and changes neither the schema nor the tool.

**The tool.** `check` / `apply` / `list`, python3 standard library only, with its own reader for the subset of YAML the pin is written in — self-contained rather than importing the upstream's `repo_shape.py`, which would give the checker the one property it must not have: breaking on exactly the refactor it exists to notice. Exit 0 ok, 1 a finding, 2 a refusal.

`check` writes NOTHING — no temporary file, no cache, no recomputed row — because it runs inside two CI containers that mount the workspace `:ro`, and it needs no network. It reports a changed byte, a missing file, a copy that stopped being a regular file, and a file under a vendor directory with NO row (every file under a vendor directory is a pinned copy by construction). It never offers to recompute a row: that records the local edit as the upstream, which is the failure `shape-pin.yaml`'s own header spends a paragraph forbidding, so the finding names the two real exits and the actual source id in both of them.

`apply` refuses, and each refusal names its fix: an `--at` that is not a full 40-character lowercase commit (a tag can be moved and a commit cannot); a `--source` the pin does not name (a new source is a new block in that file and a human's decision, not a flag); **a commit not reachable from the source repository's default branch** — openRepoShape squash-merges, so a pull-request commit is orphaned by the merge and a raw fetch of it 404s for the next person, and a pin the rest of the world cannot fetch is a pin nobody can reproduce; a fetch that failed for ANY file in the set, with nothing written, no copy replaced, and every failure named together with both forms it tried (openRepoShape #82's F10 rule); and a run without `--yes`, which prints the per-file plan (`take`/`unchanged`/`add`/`remove`/`re-pin`) and stops. The fetch order is the shims': `gh api …/contents/<path>?ref=<sha>` with `Accept: application/vnd.github.raw` first, because it is authenticated and so survives an organisation that blocks raw.githubusercontent.com, then `raw.githubusercontent.com`.

**The vendored copies came through the tool, not by hand.** `apply --source openreposhape --at d090a7a1… --yes` wrote all four, and they are byte-identical to the upstream tree at that commit: their git blob oids are `d80b6269` / `21990529` / `ee6c5a97` / `a07aeaae` and their modes `100755` / `100755` / `100755` / `100644`, which is exactly what `git ls-tree d090a7a1` reports. `diff <(git show d090a7a1:<f>) devBenches/base-image/files/openreposhape/<f>` is empty for all four, and the sha256 computed from the upstream blob, from the local file and read out of the pin row agree for all four.

**The derived fixture (D7), and it is a strengthening.** `write_three_leg_manifest` substitutes all twenty `{{…}}` placeholders of the pinned `templates/assembly-root/project.yaml` and REFUSES, naming them, if any survives — so a field the standard adds fails here, loudly, instead of leaving a fixture that quietly stops resembling the thing it stands for. Its DATA is byte-identical to the hand-mirror it replaces (diffed with comments and blanks stripped), so every scenario sees the same fields, values and key order. What is new is the template's own ~140-line comment block, which reaches `workspace_read_scalar`, `workspace_project_repository` and `load_repo_shape` for the first time, commented `role:` lines included. **All three handled it, so the risk the plan flagged (a finding in the reader rather than in the fixture) did not materialise, and nothing under `files/speckit-worktree/` is touched by this pull request.** Driven directly against the derived file, `load_repo_shape` returns `REPO_SHAPE=three-leg SHAPE_SPEC_PATH=spec SHAPE_CODE_PATH=code` — the code leg is not mounted at `spec/` — and `workspace_project_repository` returns `dummy/fixture-project`, the assembly leg and not the `shape:` block's repository.

Three properties the helpers depend on are asserted at the derivation: `    repository: dummy/fixture-project` occurs exactly once, so `set_assembly_repository` still works; exactly three legs open with a role at indent 2; and the naive-parser trap survives twice — the code leg's nested `role: spec` is the one a reader that takes the last `role:` it saw would mount at `spec/`. The commented decoy leg is the FIXTURE's own; the template carries none, so it is appended after substitution under a comment saying which lines are the fixture's and why.

**CI.** Four globs in BOTH `paths:` lists (the pin, the tool, and both vendor directories — `files/openrepotools/**` ahead of that directory existing, so W2 touches no workflow). Without them a pull request that only changes vendored bytes fires no job at all and merges green on nothing. One `regression` step runs `check` after the prerequisites and before every suite, so a drifted copy is named in seconds rather than after fifteen minutes of git fixtures. The pre-existing Layer-0 path in this Layer-1a trigger list (`base-image/files/claude/skills/speckit-clarify/SKILL.md`, missing its `devBenches/` prefix) is noticed and left exactly as it is.

**Decisions beyond the plan, for the reviewer.**

1. **`apply` rewrites the rows it owns IN PLACE; it does not re-emit the pin from a schema.** Only the target source's `commit:` line and its `files:` rows change — the header prose, every other source's block, the key order and the trailing bytes survive byte for byte, which is what makes `git diff` after an `apply` readable and is what lets W2's two `apply` runs not disturb each other. The consequence is stated in the pin's own header: a new source block is HAND-WRITTEN once with its `path:` rows and no digests, and the first `apply` fills them in; and a comment placed between two file rows does not survive. The plan's header line "Written by `update-upstream.py apply`; do not hand-edit" is therefore spelled out rather than left absolute.
2. **Modes are not pinned.** A fetched file whose first two bytes are `#!` is placed 0755; anything else 0644. That reproduced the upstream mode for each of these four — but the rule is `#!`, not the upstream bit, and it is lossy: a `.py` that upstream stores 0644 would land 0755 (NIT-3). The pin records BYTES: the Dockerfile chmods 0755 explicitly, so no image depends on the in-tree bit, and a `check` that compared filesystem modes would report a finding on any checkout made by a tool that does not carry them.
3. **The template gets TWO ways to be found, not the suite's three.** The image deliberately does not carry `files/openreposhape/templates/`, so there is no `/usr/local/share` fallback to invent. `devBenches/devcontainer.test/docker-compose.yml` therefore mounts `../base-image` read-only and sets `$WORKBENCHES_SHAPE_TEMPLATE_ROOT` and `$UPDATE_UPSTREAM_FILE` (named for the subsystem as vendored HERE, matching its sibling `$SPECKIT_WORKTREE_TEMPLATE_ROOT` rather than squatting on the upstream product's namespace — NIT-5) — one volume and two variables, which is what keeps `test.sh`'s in-container `/test/test-speckit-git-feature.sh` working when only that directory is the workspace. Without it, a hard fail-fast gate on a file the image does not have would have reddened Layer 1a's own smoke test. This file is not in the plan's file table; it is the cost of the plan's own "NOT copied into the image" decision.
4. **`check` refuses more than a changed byte.** A symlink at a pinned path, a copy that resolves outside its vendor directory (`ESCAPES`), a duplicate `path:` row, two rows where one nests inside the other, a duplicate key in a source block, two `files:` blocks, two top-level `sources:` keys, two `vendor_dir`s where one nests inside the other, an uppercase digest or commit, a row with no digest, and a pin that is not UTF-8 — each exit 2 with the file, the line and the fix. A mis-read pin in a checker is a wrong answer with a confident tone.
5. **A new source's rows are hand-written once, and both refusals say so.** `- path: <upstream path>` per file with no `sha256:` (or an empty one); the first `apply` fetches those paths and fills the digests. `check` refuses an unfilled row (`pin-row-unfilled`) naming the `apply` to run, and `pin-no-rows` names the whole sequence — it is the refusal W2's operator is most likely to meet. `apply --remove` that would empty a source is refused before the fetch, because an empty `files:` block is a pin `check` rejects.

**Verification.** Every number below is from a run on this branch's HEAD.

| Run | Result |
|---|---|
| `update-upstream.py check` | exit 0, four rows named |
| `update-upstream.py list` | exit 0, one source, four rows |
| host `test-speckit-git-feature.sh` (bash 5.2) | **56/56 GREEN**, exit 0 (55 existing + 1 new) |
| host `test-speckit-git-compat.sh` | **22/22 GREEN**, exit 0 |
| host `test-openspeckit-bootstrap.sh` | **742 GREEN**, exit 0 |
| `bash:3.2` + BusyBox, workspace `:ro` (feature + compat) | **78/78 GREEN**, exit 0 (56 + 22) |
| `ubuntu:22.04` git 2.34.1, workspace `:ro` (feature + compat) | **78/78 GREEN**, exit 0 (56 + 22) |
| `test-ct-launchers.sh` with CI's two env vars | exit 0 (silent on success); byte-unchanged by this PR |

Adversarial checks, each run rather than reasoned:

* **Drift.** One byte appended to the vendored `park` → `check` exits 1 naming `CHANGED files/openreposhape/park recorded 432f0023 computed 96a34557` and printing the two exits with the real source id; `git checkout --` → exit 0.
* **Missing.** `resume` moved away → exit 1, `MISSING files/openreposhape/resume`.
* **Unpinned.** A stray file under the vendor directory → exit 1, `UNPINNED files/openreposhape/stray.txt`, and the remediation names `--add`.
* **Malformed pins.** Twenty mutations — truncated, short digest, uppercase digest, duplicate `path:` row, `..` traversal, absolute path, wrong `kind`, wrong `schema_version`, wrong `digest_algorithm`, 39-hex commit, uppercase commit, duplicate source key, duplicate top-level key, two `files:` blocks, `materialization: mounted`, a `source_repository` that is not `owner/repo`, `revision_kind: tag`, a missing `vendor_dir`, a tab in the indentation, an empty `sources:` — each exits **2** and names the file, the line and the fix.
* **`check` writes nothing.** Run over a `chmod -R a-w` copy of the tool, the pin and the vendor directory: the `find -printf '%m %s %T@ %p'` listing digest is identical before and after, and no `__pycache__` or temporary file is left. It also runs green inside the read-only Alpine and Ubuntu mounts above.
* **`apply` is idempotent.** Re-running it at the same commit reports four `unchanged` and leaves the pin byte-identical.
* **`apply --add` / `--remove`** exercised against a scratch pin: `--add setup.sh --remove park --remove resume` took the new file 0755, deleted the two vendored copies, rewrote only the rows, and left lines 1-45 of the pin byte-identical. `--add` of an already-pinned path and `--remove` of an unpinned one both refuse by name.
* **An off-main commit is refused.** `--at 1b3b0e33…` (an openRepoShape branch head, `compare` says `diverged`) exits 2 and writes nothing.
* **A failed fetch writes nothing.** `--add no/such/file --add also-missing` exits 2, names both, prints both attempted forms, and leaves the pin and the vendor directory untouched.
* **Python floor.** `check` runs green on python 3.10 (ubuntu:22.04) and 3.12 (alpine). `flake8` is clean at 100 columns and has 16 E501s at 79 — the same file class as openRepoShape's own tools, which have 24-27 each and no flake8 config.
* **Rule 1.** `git diff origin/main | grep -E '^\+.*(/home/|/Users/|C:\\)'` is empty.
* **Nothing under `devBenches/base-image/files/speckit-worktree/` changed** (`git diff --stat origin/main --` on that path is empty), and no existing scenario in any suite was edited — the suite diff is five hunks: the two locators, the `[ -f ]` gate, the manifest derivation, the new scenario and its one registration line.

**Not proven here: the image.** `./build.sh` was attempted once and failed before reaching any `COPY`, at `resolve image config for docker-image://docker.io/docker/dockerfile:1.7` with `error getting credentials - err: exit status 1` — a registry-credential fault on this workstation, unrelated to this change (no layer of this Dockerfile had run). **The rebuild is P3's step, after W2 merges**, and this is the command that proves it:

```sh
cd devBenches/base-image && ./build.sh
docker run --rm <tag build.sh printed> sh -c \
    'for c in openRepoShape park resume; do command -v "$c" || exit 1; done
     find / -name project.yaml -path "*openreposhape*" 2>/dev/null'
```

Three `/usr/local/bin` paths, and NO `project.yaml` from the vendored templates anywhere in the image — the Dockerfile copies the three commands and not `files/openreposhape/templates/`. **NIT-6, worth writing down because the plan and this body both had it wrong:** under POSIX `sh`, `command -v a b c` proves only the FIRST name and prints one line, so the loop above (or `bash -c`) is the form that actually proves three. The adversarial review built the image from this branch and ran the strong form: three `/usr/local/bin` paths, modes 0755, the three `sha256sum`s equal to the pin rows, and `find / -path '*openreposhape*'` empty — so the criterion is met even though this PR does not build it.

**One operational consequence for P3 and for anyone running `test.sh` (NOTE-2):** an already-running `devbench-test` container must be recreated (`docker compose down && docker compose up -d`) to pick up the new `:ro` mount and the two variables, or the new fail-fast gate makes Layer 1a's smoke test lines 93/94 go red. The gate is deliberate and names the fix; the compose change supplies it. A change to `docker-compose.yml` alone fires no CI job, which is harmless because no job reads that file (`regression` runs the suites directly and the two container jobs use `docker run --volume …:ro`).

**Review comments.** The adversarial review returned **0 defects / 8 nits / READY**; the Copilot review flagged six inline findings plus eight suppressed ones. This commit fixes NIT-1, NIT-2, NIT-4, NIT-5 and NIT-7, corrects decision 2's wording (NIT-3), and takes NIT-6 into the image-proof command above. From Copilot it also fixes: a second top-level `sources:` block silently merging into the first; `rewrite_pin` dropping the `- ` marker when `commit:` opens a source item; a repeated `--add`/`--remove` value writing duplicate rows; an undecodable pin producing a traceback instead of a named exit 2; `--remove` leaving a directory or a broken link behind its deleted row; and both verbs following a symlinked `vendor_dir`, a symlinked component or a symlinked destination — `check` now reports `ESCAPES` and `apply` refuses to write through a link, proven by pointing a destination at a path outside the tree and watching nothing be created there. It also strengthens the fixture's leg assertion to name `assembly`/`spec`/`code` once each rather than count three list items, allows a legitimately empty upstream file to be vendored (the exit code is the check, not the body length), and refuses two rows or two `vendor_dir`s where one nests inside the other (NOTE-5). NIT-8 is left as the review recommended: `TOOL` is a literal, correct for every real invocation.

**The one class of comment not acted on here** is Copilot's findings inside `devBenches/base-image/files/openreposhape/resume` (`:724`, `:1190`, `:1283` and their suppressed twins about `ROOT_REFUSED`): those are openRepoShape's own bytes at the pinned commit, and editing a vendored copy is precisely the drift this pin exists to forbid — `update-upstream.py check` would go red on the next run and the recorded fix is to carry the change upstream, never to edit the copy — so they belong in opensoft/openRepoShape, not in this pull request.


**Not here.** openRepoTools' own content (T1); the removal of `park` and `resume` from openRepoShape (S2); the second source and the four-command Dockerfile hunk (W2); the base-image rebuild and the host reinstall (P3, operator). The `re-run \`make park\`` messages in `park.sh` and `resume.sh` are not wrong and are not touched — those scripts ship INTO user projects, where openRepoShape's assembly-root Makefile supplies that target.

## Summary by Sourcery

Vendor and validate pinned openRepoShape commands while deriving the three-leg test fixture from the pinned upstream manifest template.

New Features:
- Vendor the pinned openRepoShape estate commands and assembly-root manifest template for use by the base image and test fixtures.
- Add an offline upstream pin management tool with check, apply, and list workflows for validating and updating vendored copies.
- Derive the three-leg test manifest from the pinned upstream template and validate its required structure.

Bug Fixes:
- Prevent CI and read-only test environments from silently using drifted or untracked vendored upstream files.
- Ensure upstream updates refuse unreachable commits, incomplete fetches, malformed pins, and unsafe filesystem destinations without partial writes.

Enhancements:
- Install openRepoShape, park, and resume into the base image while keeping the fixture template out of the image.
- Run vendored-copy validation in the regression workflow and feature test suite.
- Expose the vendored fixture inputs to the devcontainer test environment through a read-only mount and dedicated environment variables.

CI:
- Trigger the Bash workflow when the upstream pin, updater, or vendored upstream directories change.
- Add a regression step that verifies vendored files match their recorded pins.

Tests:
- Replace the hand-maintained three-leg manifest fixture with a derived fixture based on the pinned upstream template.
- Add coverage for vendored-copy pin validation within the feature test suite.