### PR TITLE
upstream-pin.yaml gains a second source: park and resume are re-vendored from opensoft/openRepoTools at a commit, the openRepoShape source shrinks to the shim and the manifest template, and the image installs all four commands (#32)

### DIFF
--- a/devBenches/base-image/Dockerfile
+++ b/devBenches/base-image/Dockerfile
@@ -135,14 +135,31 @@ RUN chmod 0755 /usr/local/bin/speckit-worktree-enable && \
     find /usr/local/share/speckit-worktree/templates -type f ! \( -name '*.sh' -o -name '*.zsh' -o -name '*.ps1' \) -exec chmod 0644 {} +
 
 # ========================================
-# ESTATE COMMANDS (openRepoShape)
+# ESTATE COMMANDS (openRepoShape + openRepoTools)
 # ========================================
 # VENDORED, never fetched at build time: the build network may route github.com
 # through a VPN tunnel whose MTU breaks TLS, which is why the Oh My Zsh plugins
 # in Layer 0 come from apt rather than a clone. These copies are pinned by
-# commit and per-file sha256 in ../upstream-pin.yaml; `update-upstream.py check`
-# is what says they still are, and it runs in CI (.github/workflows/
-# speckit-git-bash.yml) and in the devcontainer suite.
+# commit and per-file sha256 in ../upstream-pin.yaml, one source block per
+# repository; `update-upstream.py check` is what says they still are, and it
+# runs in CI (.github/workflows/speckit-git-bash.yml) and in the devcontainer
+# suite.
+#
+# TWO SOURCES, ONE DIRECTION. openRepoTools pins openRepoShape (as a submodule
+# in that repository, mounted and verified against the pinned checkout's own
+# scripts/repo_shape.py) because `park` and `resume` are tested against the
+# estate standard they walk. openRepoShape pins nothing of openRepoTools' and
+# does not know it exists. This image is downstream of both pins and holds a
+# vendored COPY of each, at the commit its own source block in
+# ../upstream-pin.yaml names — that copying does not add a dependency between
+# the two repositories, only two independent commits landing beside each other
+# under /usr/local/bin.
+#
+# `park` and `resume` are vendored from files/openrepotools/
+# (opensoft/openRepoTools), not from files/openreposhape/: they moved there so
+# the estate-resolver they share is reviewed once for the whole estate rather
+# than once per standard. files/openreposhape/ now vendors only the shim
+# (`openRepoShape` itself) and the manifest template below.
 #
 # files/openreposhape/templates/ is NOT copied. It is a fixture input for
 # devBenches/devcontainer.test/test-speckit-git-feature.sh, which derives its
@@ -151,20 +168,24 @@ RUN chmod 0755 /usr/local/bin/speckit-worktree-enable && \
 #
 # PATH, said out loud: Layer 0 writes $HOME/.local/bin AHEAD of the inherited
 # PATH into /etc/skel/.zshrc and /etc/skel/.bashrc (base-image/Dockerfile:261
-# and :270), so `openRepoShape --install` run in an interactive container shell
-# SHADOWS these pinned copies with whatever the upstream main holds. A
-# non-interactive `docker exec` uses this image's own ENV PATH, where these
-# win. Accepted, not fixed: fetching at build time is what the network
+# and :270), so an `--install` of either command run in an interactive
+# container shell SHADOWS these pinned copies with whatever the upstream main
+# holds. A non-interactive `docker exec` uses this image's own ENV PATH, where
+# these win. Accepted, not fixed: fetching at build time is what the network
 # constraint above forbids.
 #
-# `openRepoShape --version` prints `(opensoft/openRepoShape @ main)`, not the
-# pinned commit: $OPENREPOSHAPE_REF defaults to `main` upstream and this image
-# does not set it. The identity of these bytes is ../upstream-pin.yaml, not
-# what the command says about itself.
+# `openRepoShape --version` prints `openRepoShape (opensoft/openRepoShape @
+# main)` and `openRepoTools --version` prints `openRepoTools
+# (opensoft/openRepoTools @ main)` — neither the pinned commit: each shim's
+# own `_REF` defaults to `main` upstream and this image sets neither override.
+# The identity of these bytes is ../upstream-pin.yaml, not what either command
+# says about itself.
 COPY files/openreposhape/openRepoShape /usr/local/bin/openRepoShape
-COPY files/openreposhape/park /usr/local/bin/park
-COPY files/openreposhape/resume /usr/local/bin/resume
-RUN chmod 0755 /usr/local/bin/openRepoShape /usr/local/bin/park /usr/local/bin/resume
+COPY files/openrepotools/openRepoTools /usr/local/bin/openRepoTools
+COPY files/openrepotools/park /usr/local/bin/park
+COPY files/openrepotools/resume /usr/local/bin/resume
+RUN chmod 0755 /usr/local/bin/openRepoShape /usr/local/bin/openRepoTools \
+    /usr/local/bin/park /usr/local/bin/resume
 
 # ========================================
 # AI META-HARNESS (OMNIGENT)

--- a/devBenches/base-image/files/openreposhape/openRepoShape
+++ b/devBenches/base-image/files/openreposhape/openRepoShape
@@ -15,11 +15,12 @@
 # passing every other argument through untouched. The README's long
 # `curl … | bash -s -- --org … --project …` line and this do the same thing.
 #
-# `--install` PLACES THREE COMMANDS, not one: this file, `park` and `resume`
-# (#82). One install line for the whole standard, so a second engineer gets
-# the estate verbs from the README's one line and nothing depends on anyone's
-# dotfiles. The two of them add no behaviour either — they find the estate and
-# run its own `make park` / `make resume`.
+# `--install` PLACES ONE COMMAND: this file. `park` and `resume` were placed
+# beside it until 2026-09-10 and are opensoft/openRepoTools' now (#92), with an
+# installer of their own — which this one PRINTS and never runs. A command that
+# reached into another repository to finish its own install would make the
+# standard depend on its tools at runtime, and that is the direction the carve
+# exists to forbid: tools depend on the shape, the shape depends on nothing.
 
 set -euo pipefail
 
@@ -56,23 +57,20 @@ argument reaches setup.sh unchanged: --visibility, --elected-by, --family,
 hands on to scaffold-project.py. `./setup.sh --help` prints setup-project.py's
 usage, which lists them all.
 
-`--install` places THREE commands, and each is one file:
+`--install` places ONE command, and it is this one file:
 
   openRepoShape <Project> --org <org>    scaffold a project
-  park [<Name>]                          commit, push and RECORD an estate's
-                                         open features, so another workstation
-                                         can take the work up
-  resume [<Name>]                        clone or fast-forward that estate here
-                                         and recreate those features
 
-`park --help` and `resume --help` say the rest. Neither implements any of the
-mechanics: they find the estate under your projects directory and run its own
-`make park` / `make resume`, which run the Speckit git extension's scripts.
+The estate verbs are not here. `park` and `resume` — commit, push and RECORD an
+estate's open features, then rebuild them on the next workstation — are
+opensoft/openRepoTools', and its own installer places them:
+
+  curl -fsSL https://raw.githubusercontent.com/opensoft/openRepoTools/main/openRepoTools | bash -s -- --install
 
   $OPENREPOSHAPE_REPO       owner/name to fetch from (default opensoft/openRepoShape)
   $OPENREPOSHAPE_REF        the ref to fetch it at   (default main)
   $OPENREPOSHAPE_ORG        the organisation, when --org is not given
-  $OPENREPOSHAPE_BIN_DIR    where --install puts them (default ~/.local/bin)
+  $OPENREPOSHAPE_BIN_DIR    where --install puts it  (default ~/.local/bin)
   $OPENREPOSHAPE_SETUP_SH   run this setup.sh on disk instead of fetching one
 USAGE
 }
@@ -132,27 +130,31 @@ shape_clone_url() {
 	esac
 }
 
-# THE THREE COMMANDS `--install` PLACES (#82). One list, so the installer, the
-# fetch fallback and the tests cannot disagree about what a complete install
-# is. `openRepoShape` is first because it is the one a person types to get the
-# other two.
-INSTALLABLES=(openRepoShape park resume)
+# WHAT `--install` PLACES. One list, so the installer, the fetch fallback and
+# the tests cannot disagree about what a complete install is. It held three
+# names from #82 until 2026-09-10 and holds one again (#92): `park` and
+# `resume` are opensoft/openRepoTools'.
+INSTALLABLES=(openRepoShape)
 
-# ALL THREE IN HAND BEFORE ANY OF THEM IS PLACED (#82, F10 of the review on
+# EVERY ONE IN HAND BEFORE ANY OF THEM IS PLACED (#82, F10 of the review on
 # #83). One file at a time, dying on the first fetch that failed, left a
 # person with a NEW `openRepoShape` and no `park` — a half-install that says
 # `installed at` and is not one — and there was nothing on screen to say which
-# of the three were missing. Now every one is collected into the temporary
-# directory first: a failure there replaces NOTHING, names what was not
-# fetched, and exits.
+# files were missing. Now every one is collected into the temporary directory
+# first: a failure there replaces NOTHING, names what was not fetched, and
+# exits.
+#
+# KEPT WHOLE AT ONE INSTALLABLE (#92). The guarantee is a property of the
+# STRUCTURE and not of the count, and an installer that holds it only while
+# the list is long is an installer that loses it the next time somebody
+# shortens the list — which is this commit.
 collect_commands() {
 	local name selfdir="" missing=""
 	# Run from a file, install THOSE bytes: `--install` then needs no network
-	# and no `gh` at all — and `park` and `resume` sit BESIDE this file, in the
-	# checkout and in the repository alike, so the siblings that are there are
-	# copied and only a missing one is fetched. Run from stdin (`curl … | bash
-	# -s -- --install`) there is no file to copy from at all, so each of the
-	# three is fetched at this same ref.
+	# and no `gh` at all, and a name in $INSTALLABLES that is not beside this
+	# file is fetched instead. Run from stdin (`curl … | bash -s -- --install`)
+	# there is no file to copy from at all, so every one of them is fetched at
+	# this same ref.
 	if [ -f "$SELF" ]; then
 		selfdir="$(cd -- "$(dirname -- "$SELF")" && pwd)"
 	fi
@@ -168,9 +170,9 @@ collect_commands() {
 			missing="${missing:+$missing }$name"
 	done
 	[ -z "$missing" ] || die "could not fetch $missing from $REPO at $REF, so NOTHING was installed
-    and nothing already installed was replaced. \`--install\` places all
-    ${#INSTALLABLES[@]} commands or none: a new openRepoShape beside a missing park is
-    a half-install that reads like a whole one. Both ways were tried:
+    and nothing already installed was replaced. \`--install\` places every one
+    of the ${#INSTALLABLES[@]} it collects or none of them: a new command beside a missing
+    one is a half-install that reads like a whole one. Both ways were tried:
     gh api repos/$REPO/contents/<file>?ref=$REF
     curl -fsSL https://raw.githubusercontent.com/$REPO/$REF/<file>"
 }
@@ -194,11 +196,23 @@ install_commands() {
 		placed=$((placed + 1))
 		say "$name: $verb"
 	done
-	# THE COUNT, out loud: a person reading three lines cannot tell whether a
-	# fourth was meant to be there, and this object is the one that made
-	# `--install` plural.
+	# THE COUNT, out loud, and kept at one installable (#92): it costs a line
+	# and is what keeps $INSTALLABLES honest — a person reading N lines cannot
+	# tell whether an N+1th was meant to be there. The sentence that made
+	# `--install` plural is the pointer's job now.
 	say "openRepoShape: $placed of ${#INSTALLABLES[@]} placed in $dir"
-	# ONE PATH NOTE for the three of them: the directory is the same one.
+	# THE POINTER, unconditional and TEXT ONLY (#92). Nothing here is fetched
+	# from opensoft/openRepoTools and nothing checks whether its installer has
+	# been run: this command reports where the estate verbs come from and stops
+	# there. The `curl` line is byte-identical to the one README.md carries,
+	# and `tests/test_repo_hygiene.py` is what holds the copies together.
+	say "  park and resume are installed by openRepoTools, not by this command:"
+	say "    curl -fsSL https://raw.githubusercontent.com/opensoft/openRepoTools/main/openRepoTools | bash -s -- --install"
+	# THE PATH NOTE, last, and it is about the directory THIS command just
+	# wrote to — `$OPENREPOSHAPE_BIN_DIR`, nothing else. openRepoTools reads
+	# its own `$OPENREPOTOOLS_BIN_DIR` and defaults to the same
+	# `~/.local/bin`, so the two land together on a machine that sets
+	# neither and in two places on a machine that sets one.
 	case ":${PATH:-}:" in
 	*":$dir:"*) ;;
 	*)

--- a/devBenches/base-image/files/openrepotools/openRepoTools
+++ b/devBenches/base-image/files/openrepotools/openRepoTools
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# openRepoTools — the short way to put the estate commands on your PATH.
+#
+# Install them once, from anywhere, with no checkout and no clone:
+#
+#   gh api repos/opensoft/openRepoTools/contents/openRepoTools \
+#       -H 'Accept: application/vnd.github.raw' | bash -s -- --install
+#
+# (or the raw-URL twin, `curl -fsSL …/main/openRepoTools | bash -s -- --install`).
+#
+# IT INSTALLS AND IT DOES NOTHING ELSE. There is no verb here and no scaffold
+# role: `openRepoShape` is the standard's front door and stays there, and the
+# two verbs are `park` and `resume`, which add no mechanics of their own — they
+# find the estate under your projects directory and run its own `make park` /
+# `make resume`.
+#
+# `--install` PLACES THREE COMMANDS, not one: this file, `park` and `resume`
+# (openRepoShape #82). One install line for the whole toolset, so a second
+# engineer gets the estate verbs from the README's one line and nothing depends
+# on anyone's dotfiles.
+#
+# openRepoShape #82 wrote the two verbs and these install semantics; its #92
+# carved them out into this repository.
+
+set -euo pipefail
+
+# $OPENREPOTOOLS_REPO is an owner/name slug: it is an API path and a raw-URL
+# path, and nothing here clones. Name a fork or a mirror once and both fetch
+# forms follow it.
+REPO="${OPENREPOTOOLS_REPO:-opensoft/openRepoTools}"
+REF="${OPENREPOTOOLS_REF:-main}"
+SELF="${BASH_SOURCE[0]:-$0}"
+
+MODE=""
+WORKDIR=""
+STAGED=""
+
+say() { printf '%s\n' "$*"; }
+die() { printf '\nREFUSED: %s\n' "$1" >&2; exit "${2:-2}"; }
+
+usage() {
+	cat <<'USAGE'
+openRepoTools --install            install (or update) park, resume and this
+                                   command into ~/.local/bin
+openRepoTools --help | --version
+
+This command installs the estate commands and does nothing else. It has no
+verb of its own: `openRepoShape` is the standard's front door, and the two
+verbs `--install` places beside this file are
+
+  park [<Name>]                    commit, push and RECORD an estate's open
+                                   features, so another workstation can take
+                                   the work up
+  resume [<Name>]                  clone or fast-forward that estate here and
+                                   recreate those features
+
+`park --help` and `resume --help` say the rest. Neither implements any of the
+mechanics: they find the estate under your projects directory and run its own
+`make park` / `make resume`, which run the Speckit git extension's scripts.
+
+  $OPENREPOTOOLS_REPO       owner/name to fetch from (default opensoft/openRepoTools)
+  $OPENREPOTOOLS_REF        the ref to fetch it at   (default main)
+  $OPENREPOTOOLS_BIN_DIR    where --install puts them (default ~/.local/bin)
+USAGE
+}
+
+# THE TRAP BELONGS TO THE SHELL THAT DOES THE WRITING, so this makes the
+# directory and takes no output. A `$(workdir)` would be a COMMAND
+# SUBSTITUTION — a subshell, whose `trap … EXIT` fires the instant the
+# substitution closes, so `rm -rf` would run before a single fetched byte had
+# landed and $WORKDIR out here would still be empty (openRepoShape #74). A trap
+# only ever fires in the shell that set it. Callers read $WORKDIR.
+workdir() {
+	if [ -z "$WORKDIR" ]; then
+		WORKDIR="$(mktemp -d)"
+		trap 'rm -rf -- "$WORKDIR"' EXIT
+	fi
+}
+
+# THE API FIRST, the raw URL second. `gh api` is authenticated, so it still
+# works inside an organisation whose policy blocks raw.githubusercontent.com;
+# curl is the fallback for a machine with no `gh`. Each attempt writes to a
+# file and is checked before its bytes are used, so a half-written first
+# attempt is never mistaken for a fetch.
+#
+# THESE FORTY LINES ARE A DELIBERATE COPY of openRepoShape's own shim, and the
+# duplication is the cheaper of the two mistakes: a shared `orp-fetch.sh` would
+# be a FOURTH FILE for `--install` to place, and a broken installer the first
+# time somebody copied only three of them. It is the same argument the estate
+# resolver inside `park` and `resume` already carries, for the same reason —
+# each of these files is one file a person has on PATH. Two installers that
+# fetch the same way is a claim `tests/test_openrepotools_command.py` and
+# openRepoShape's own suite each assert against their own script's text.
+fetch_from_repo() {
+	local path="$1" dest="$2"
+	if command -v gh >/dev/null 2>&1 &&
+		gh api "repos/$REPO/contents/$path?ref=$REF" \
+			-H 'Accept: application/vnd.github.raw' >"$dest" 2>/dev/null &&
+		[ -s "$dest" ]; then
+		return 0
+	fi
+	if command -v curl >/dev/null 2>&1 &&
+		curl -fsSL "https://raw.githubusercontent.com/$REPO/$REF/$path" \
+			>"$dest" 2>/dev/null && [ -s "$dest" ]; then
+		return 0
+	fi
+	# RETURNS rather than dying, so a caller fetching SEVERAL files can report
+	# the whole set instead of stopping mid-way through an install
+	# (openRepoShape #82, F10 of the review on its #83).
+	return 1
+}
+
+# THE THREE COMMANDS `--install` PLACES. One list, so the installer, the fetch
+# fallback and the tests cannot disagree about what a complete install is.
+# `openRepoTools` is first because it is the one a person types to get the
+# other two.
+INSTALLABLES=(openRepoTools park resume)
+
+# ALL THREE IN HAND BEFORE ANY OF THEM IS PLACED (openRepoShape #82, F10 of the
+# review on its #83). One file at a time, dying on the first fetch that failed,
+# leaves a person with a NEW `openRepoTools` and no `park` — a half-install that
+# says `installed at` and is not one — and nothing on screen to say which of the
+# three were missing. Every one is collected into the temporary directory first:
+# a failure there replaces NOTHING, names what was not fetched, and exits.
+collect_commands() {
+	local name selfdir="" missing=""
+	# Run from a file, install THOSE bytes: `--install` then needs no network
+	# and no `gh` at all — and `park` and `resume` sit BESIDE this file, in the
+	# checkout and in the repository alike, so the siblings that are there are
+	# copied and only a missing one is fetched. Run from stdin (`curl … | bash
+	# -s -- --install`) there is no file to copy from at all, so each of the
+	# three is fetched at this same ref.
+	if [ -f "$SELF" ]; then
+		selfdir="$(cd -- "$(dirname -- "$SELF")" && pwd)"
+	fi
+	workdir
+	STAGED="$WORKDIR/staged"
+	mkdir -p "$STAGED"
+	for name in "${INSTALLABLES[@]}"; do
+		if [ -n "$selfdir" ] && [ -f "$selfdir/$name" ]; then
+			cp -- "$selfdir/$name" "$STAGED/$name"
+			continue
+		fi
+		fetch_from_repo "$name" "$STAGED/$name" ||
+			missing="${missing:+$missing }$name"
+	done
+	[ -z "$missing" ] || die "could not fetch $missing from $REPO at $REF, so NOTHING was installed
+    and nothing already installed was replaced. \`--install\` places all
+    ${#INSTALLABLES[@]} commands or none: a new openRepoTools beside a missing park is
+    a half-install that reads like a whole one. Both ways were tried:
+    gh api repos/$REPO/contents/<file>?ref=$REF
+    curl -fsSL https://raw.githubusercontent.com/$REPO/$REF/<file>"
+}
+
+install_commands() {
+	local dir="${OPENREPOTOOLS_BIN_DIR:-$HOME/.local/bin}"
+	local name target source verb placed=0
+	collect_commands
+	mkdir -p "$dir"
+	for name in "${INSTALLABLES[@]}"; do
+		source="$STAGED/$name"
+		target="$dir/$name"
+		if [ -e "$target" ] && cmp -s "$source" "$target"; then
+			verb="already installed at $target (unchanged)"
+		else
+			if [ -e "$target" ]; then verb="updated at $target"; else verb="installed at $target"; fi
+			cp -- "$source" "$target"
+		fi
+		# Stamped every time: a copy that is not executable is not a command.
+		chmod 755 "$target"
+		placed=$((placed + 1))
+		say "$name: $verb"
+	done
+	# THE COUNT, out loud: a person reading three lines cannot tell whether a
+	# fourth was meant to be there.
+	say "openRepoTools: $placed of ${#INSTALLABLES[@]} placed in $dir"
+	# ONE PATH NOTE for the three of them: the directory is the same one.
+	case ":${PATH:-}:" in
+	*":$dir:"*) ;;
+	*)
+		say "  $dir is not on \$PATH. Add it:"
+		say "    export PATH=\"$dir:\$PATH\""
+		;;
+	esac
+}
+
+# --- arguments ------------------------------------------------------------
+#
+# THREE ARGUMENTS AND NO OTHERS, and the refusal names the verbs rather than
+# repeating the usage: somebody typing `openRepoTools park` wants `park`, and
+# the shortest true answer is where it is.
+while [ $# -gt 0 ]; do
+	case "$1" in
+	-h | --help) usage; exit 0 ;;
+	--version) say "openRepoTools ($REPO @ $REF)"; exit 0 ;;
+	--install) MODE="install"; shift ;;
+	*)
+		die "openRepoTools installs the estate commands and does nothing else. It takes --install,
+    --help or --version. The verbs themselves: \`park --help\`, \`resume --help\`."
+		;;
+	esac
+done
+
+if [ "$MODE" = "install" ]; then
+	install_commands
+	exit 0
+fi
+
+# NO ARGUMENT AT ALL is the usage, on stdout and exit 0: a person who typed the
+# name to see what it is has asked a question, not made a mistake.
+usage
+exit 0

--- a/devBenches/base-image/files/openrepotools/park
+++ b/devBenches/base-image/files/openrepotools/park
@@ -4,7 +4,7 @@
 # park — leave this workstation with your half-finished work carried, from any
 # folder: `park InkRouter`, or just `park` from inside the estate.
 #
-# Installed with the other two by `openRepoShape --install`.
+# Installed with the other two by `openRepoTools --install`.
 #
 # IT ADDS NO MECHANICS, exactly as the `openRepoShape` command adds none. It
 # FINDS THE ESTATE and runs the estate's own `make park` — the family holder's,
@@ -25,6 +25,7 @@
 # `resume` deliberately KEEPS ruling 3's refusal for its own bare form (see
 # its header) — rebuilding every estate on a fresh machine by accident is the
 # opposite risk from failing to park the one you meant.
+# openRepoShape #82 wrote this, its #93 last changed it, its #92 moved it here.
 
 set -euo pipefail
 

--- a/devBenches/base-image/files/openrepotools/resume
+++ b/devBenches/base-image/files/openrepotools/resume
@@ -3,7 +3,7 @@
 #
 # resume — arrive at a workstation and get the estate back: `resume InkRouter`.
 #
-# Installed with the other two by `openRepoShape --install`.
+# Installed with the other two by `openRepoTools --install`.
 #
 # IT ADDS NO MECHANICS, exactly as the `openRepoShape` command adds none. It
 # REBUILDS OR REFRESHES the estate with the tools that already exist — `git
@@ -27,6 +27,7 @@
 # estate you meant: a clone or a fast-forward per estate is real network and
 # real disk, and undoing an accidental one is not as simple as re-running the
 # command. Ruling #91 names `park` only; this refusal stands.
+# openRepoShape #82 wrote this, its #93 last changed it, its #92 moved it here.
 #
 # THE ONLY FILE THIS STANDARD EVER WRITES OUTSIDE A REPOSITORY is the two-line
 # user config, and only when `--workspace <owner/name>` asks for it by name on
@@ -76,7 +77,7 @@ With no <Name> the estate around the current directory is refreshed.
   $PROJECTS_DIR             your projects directory (default: ~/projects, then
                             ~/Projects - people spell it both ways)
   $AGENT_PROTOCOL_ROOT      where workspace.yaml lives (default: ~/.agents)
-  $OPENREPOSHAPE_REMOTE_BASE
+  $OPENREPOTOOLS_REMOTE_BASE
                             TEST PATH: clone from bare repositories in this
                             directory (<name>.git) instead of from GitHub, so
                             the whole flow runs offline
@@ -541,7 +542,7 @@ is_checkout() {
 
 # `https://github.com/<owner>/<name>.git` by default.
 #
-# `$OPENREPOSHAPE_REMOTE_BASE` IS THE OFFLINE TEST PATH, and it is the same
+# `$OPENREPOTOOLS_REMOTE_BASE` IS THE OFFLINE TEST PATH, and it is the same
 # concession `setup-project.py --local-remote-dir` and `family.py
 # --local-remote-dir` make: a directory of BARE repositories named
 # `<name>.git`, used as origins, so this whole flow — clone the workspace,
@@ -551,7 +552,7 @@ is_checkout() {
 # permission of its own: a test that needs `protocol.file.allow` sets it in
 # git's own environment, which is how it stays a test's decision.
 clone_url_for() {
-    local slug="$1" base="${OPENREPOSHAPE_REMOTE_BASE:-}"
+    local slug="$1" base="${OPENREPOTOOLS_REMOTE_BASE:-}"
     if [ -n "$base" ]; then
         printf '%s/%s.git\n' "${base%/}" "${slug##*/}"
         return 0

--- a/devBenches/base-image/upstream-pin.yaml
+++ b/devBenches/base-image/upstream-pin.yaml
@@ -43,14 +43,24 @@ sources:
     source_repository: opensoft/openRepoShape
     materialization: copied
     revision_kind: commit
-    commit: "d090a7a141048b214f0420a8c7afbfff62472d1a"
+    commit: "0fa73b7df704266589dcc27afca020c0127fa36f"
     vendor_dir: files/openreposhape
     files:
       - path: openRepoShape
-        sha256: "dd273fc39e6771a87450bb1b71fda6f8b728a2ddba3f1c0e44106e7f865b6e3a"
-      - path: park
-        sha256: "432f00236053d3648a061d12c02d9f449982f8a17f100f39de78f41f9013ad13"
-      - path: resume
-        sha256: "3953174297b30a41eb0ae8a57dc59fdb25d2afc3248192dda679501e503566fa"
+        sha256: "32ca582b7990c9ca29e5dcf142d51661bf3543f7bda4bfdb890ba9ee34e18bbb"
       - path: templates/assembly-root/project.yaml
         sha256: "45a0fb89f7f7f873665d24c0d26a79dab5113364808bd61e914eb07f46eab0c7"
+
+  - id: openrepotools
+    source_repository: opensoft/openRepoTools
+    materialization: copied
+    revision_kind: commit
+    commit: "9fbf01c789c311aa7c190b238a3df48ea39473e1"
+    vendor_dir: files/openrepotools
+    files:
+      - path: openRepoTools
+        sha256: "e1996322a0fc898edf271ad8fc66837b54410e8dc93880b9c13149421ba9ffe9"
+      - path: park
+        sha256: "5048a7db16bcf68b5b976d96b9ee9c44ee6fa17a2e548c4c4fc825064bb84239"
+      - path: resume
+        sha256: "a5a147f89cf9a1b97a0d8c1e8868d17323e41b238f96d9e59d8ddd766af387eb"


### PR DESCRIPTION
Lane: xfactory-2 (xFactory-2)
Claim: https://github.com/opensoft/workBenches/issues/32#issuecomment-5621452209

Closes #32 (W2, the second of two slices; W1 is #33). Design record: opensoft/openRepoShape#92.

**What lands.** `devBenches/base-image/upstream-pin.yaml` gains a second `sources:` block, `openrepotools`; `park` and `resume` move out of the `openreposhape` source and into it, re-vendored from `opensoft/openRepoTools` rather than from `opensoft/openRepoShape`; the `openreposhape` source shrinks to the shim (`openRepoShape` itself) and the manifest template it was already vendoring for the derived fixture; and the Dockerfile's estate-commands block becomes four `COPY`s from two vendor directories under one `chmod`. **The tool and the schema do not change** — multi-source was built in W1 for exactly this move, so this slice is two `apply` runs and one Dockerfile hunk, nothing else: `git diff a2d4b55 -- devBenches/base-image/update-upstream.py` is empty.

**The two pins.**

* `opensoft/openRepoTools` at `9fbf01c789c311aa7c190b238a3df48ea39473e1` — `gh api repos/opensoft/openRepoTools/compare/main...9fbf01c789c311aa7c190b238a3df48ea39473e1 -q .status` says `identical`, so it is the commit `main` carries, and its tree holds `openRepoTools`, `park` and `resume` at the root.
* `opensoft/openRepoShape` moves from W1's `d090a7a1` to `0fa73b7df704266589dcc27afca020c0127fa36f` — `gh api repos/opensoft/openRepoShape/compare/main...0fa73b7df704266589dcc27afca020c0127fa36f -q .status` also says `identical`, and this commit is post-carve (opensoft/openRepoShape#92's S2): its tree no longer holds `park` or `resume` at the root, only `openRepoShape` and `templates/`.

**A new source's rows are hand-written once, per the pin's own header and the tool's `pin-no-rows`/`pin-row-unfilled` refusals.** The `openrepotools` block was added by hand — `id`, `source_repository: opensoft/openRepoTools`, `materialization: copied`, `revision_kind: commit`, `vendor_dir: files/openrepotools`, and three `- path:` rows (`openRepoTools`, `park`, `resume`) with no `sha256:`. One thing the plan did not spell out: `validate_pin` checks every source's `commit:` against `COMMIT_RE` unconditionally, even for `apply`'s `digests_required=False` pass over the OTHER source, so the hand-written block needs a syntactically-valid placeholder commit before either `apply` call will run at all — not an empty string. This branch uses forty `0`s (`0000000000000000000000000000000000000000`), the conventional null commit, and confirmed it is exactly what `apply --at <real sha> --yes` overwrites on the first run (see below); nothing downstream ever reads that placeholder as a real commit.

**The two `apply` runs, verbatim.**

```
$ python3 devBenches/base-image/update-upstream.py apply --source openrepotools --at 9fbf01c789c311aa7c190b238a3df48ea39473e1 --yes
source      openrepotools (opensoft/openRepoTools)
pinned      000000000000
target      9fbf01c789c3 (on main)
vendor      files/openrepotools

  take      openRepoTools  e1996322a0fc
  take      park  5048a7db16bc
  take      resume  a5a147f89cf9
  re-pin    commit 000000000000 -> 9fbf01c789c3

  wrote     files/openrepotools/openRepoTools  0755
  wrote     files/openrepotools/park  0755
  wrote     files/openrepotools/resume  0755
  re-pinned devBenches/base-image/upstream-pin.yaml  3 row(s) at 9fbf01c789c3

NEXT  python3 devBenches/base-image/update-upstream.py check
```

```
$ python3 devBenches/base-image/update-upstream.py apply --source openreposhape --at 0fa73b7df704266589dcc27afca020c0127fa36f --remove park --remove resume --yes
source      openreposhape (opensoft/openRepoShape)
pinned      d090a7a14104
target      0fa73b7df704 (on main)
vendor      files/openreposhape

  take      openRepoShape  32ca582b7990
  unchanged templates/assembly-root/project.yaml
  remove    park
  remove    resume
  re-pin    commit d090a7a14104 -> 0fa73b7df704

  wrote     files/openreposhape/openRepoShape  0755
  wrote     files/openreposhape/templates/assembly-root/project.yaml  0644
  deleted   files/openreposhape/park
  deleted   files/openreposhape/resume
  re-pinned devBenches/base-image/upstream-pin.yaml  2 row(s) at 0fa73b7df704

NEXT  python3 devBenches/base-image/update-upstream.py check
```

`templates/assembly-root/project.yaml` comes back `unchanged` — confirming from a run, not from reasoning, that nothing under `templates/` moved between W1's pin and this one, so the derived three-leg fixture from D7 is unaffected. `openRepoShape` itself comes back `take`: S2 rewrote its `INSTALLABLES` and `usage()` to point at `openRepoTools`, so the byte content differs from W1's pin at `d090a7a1` even though the path is the same.

**The deletions.** `files/openreposhape/park` and `files/openreposhape/resume` are deleted from the tree, not merely unpinned — `apply --remove` unlinks the file behind a dropped row (`git status` shows `D`, and git's own similarity index reports the pair as renames into `files/openrepotools/{park,resume}`, which is an accurate read of what the bytes are but not how the tool did it: two independent vendor operations, a delete under one source and a take under another).

**The Dockerfile hunk.** The estate-commands block becomes four `COPY`s from two directories:

```dockerfile
COPY files/openreposhape/openRepoShape /usr/local/bin/openRepoShape
COPY files/openrepotools/openRepoTools /usr/local/bin/openRepoTools
COPY files/openrepotools/park /usr/local/bin/park
COPY files/openrepotools/resume /usr/local/bin/resume
RUN chmod 0755 /usr/local/bin/openRepoShape /usr/local/bin/openRepoTools \
    /usr/local/bin/park /usr/local/bin/resume
```

one `chmod` naming all four. The section banner gains openRepoTools (`ESTATE COMMANDS (openRepoShape + openRepoTools)`) and the comment now states the dependency direction in both directions at once: **openRepoTools pins openRepoShape** (a submodule there, mounted and verified against the pinned checkout's own `scripts/repo_shape.py`, because `park`/`resume` are tested against the estate standard they walk) and **openRepoShape pins nothing of openRepoTools' and does not know it exists**; this image is downstream of both pins and holds an independent vendored copy of each at the commit its own source block names, which is not itself a dependency between the two repositories. The PATH-shadowing paragraph and the `--version` paragraph are both updated to speak of either shim rather than only `openRepoShape`'s.

**Proofs, all run on this branch's HEAD.**

| Run | Result |
|---|---|
| `update-upstream.py check` | exit 0, **5** rows named across 2 sources (`openreposhape`: `openRepoShape`, `templates/assembly-root/project.yaml`; `openrepotools`: `openRepoTools`, `park`, `resume`) |
| `update-upstream.py list` | exit 0, both sources named with their commits and vendor dirs |
| `test-speckit-git-feature.sh` | **56/56 GREEN**, exit 0, including `the vendored openRepoShape copies match devBenches/base-image/upstream-pin.yaml` |
| `test-speckit-git-compat.sh` | **22/22 GREEN**, exit 0 |
| `test-openspeckit-bootstrap.sh` | **742 GREEN**, exit 0 |
| `git diff --stat a2d4b55 -- devBenches/base-image/files/speckit-worktree/` | empty |
| `git grep -n 5777ca8` | empty |
| Rule 1 (`git diff a2d4b55 \| grep -E '^\+.*(/home/\|/Users/\|C:\\\\)'`) | empty |

*A note on "5" rather than a round number:* the openreposhape source genuinely shrinks to two rows (the shim and the manifest template, per this issue's own description of the slice) and the openrepotools source opens with three, so `check`/`list` name five rows total, not six — verified by the `list` output itself, not asserted.

**Each of the five vendored files diffs clean against its source at the pinned commit**, both via the local mirror clones and via `gh api …/contents/<path>?ref=<sha> -H 'Accept: application/vnd.github.raw'` directly:

* `diff <(git -C ~/projects/openRepoShape show 0fa73b7df704266589dcc27afca020c0127fa36f:openRepoShape) devBenches/base-image/files/openreposhape/openRepoShape` — empty
* `diff <(git -C ~/projects/openRepoShape show 0fa73b7df704266589dcc27afca020c0127fa36f:templates/assembly-root/project.yaml) devBenches/base-image/files/openreposhape/templates/assembly-root/project.yaml` — empty
* `diff <(git -C ~/projects/openRepoTools show 9fbf01c789c311aa7c190b238a3df48ea39473e1:openRepoTools) devBenches/base-image/files/openrepotools/openRepoTools` — empty
* `diff <(git -C ~/projects/openRepoTools show 9fbf01c789c311aa7c190b238a3df48ea39473e1:park) devBenches/base-image/files/openrepotools/park` — empty (cross-checked against `gh api repos/opensoft/openRepoTools/contents/park?ref=9fbf01c7… -H 'Accept: application/vnd.github.raw'` too)
* `diff <(git -C ~/projects/openRepoTools show 9fbf01c789c311aa7c190b238a3df48ea39473e1:resume) devBenches/base-image/files/openrepotools/resume` — empty (same cross-check)

**`park`/`resume` against openRepoShape's last copy before the carve** (`d090a7a1`, W1's pin), to show the re-vendor changed nothing beyond what T1 already changed: `diff` is **6 lines** for `park` (the `Installed with the other two by` line moving from `openRepoShape --install` to `openRepoTools --install`, plus one added provenance line naming #82/#93/#92) and **18 lines** for `resume` (the same two lines, plus the three `$OPENREPOSHAPE_REMOTE_BASE` → `$OPENREPOTOOLS_REMOTE_BASE` renames T1's design called for at `:70`/`:535`/`:541`/`:545` and its own header/comment lines for that variable).

**The tool did not change.** `git diff a2d4b55 -- devBenches/base-image/update-upstream.py` is empty — confirmed after both `apply` runs and after both commits, not just before them.

**Not proven here: the image.** P3 rebuilds it after this merges. The command that proves it:

```sh
cd devBenches/base-image && ./build.sh
docker run --rm <tag build.sh printed> sh -c \
    'for c in openRepoShape openRepoTools park resume; do command -v "$c"; done
     park --help | head -3'
```
four `/usr/local/bin` paths, and `park --help` exiting 0 from the image's own copy.

**Not here.** openRepoTools' own content (T1, merged); the removal of `park`/`resume` from openRepoShape (S2, merged, verified above by commit); the base-image rebuild and the host reinstall (P3, operator, after this merges). The `re-run `make park`` messages inside `files/speckit-worktree/` are untouched and correct — `git diff --stat` on that directory against W1's head is empty; those scripts ship into projects whose own Makefile supplies that target, and workBenches is not one of those projects.

## Summary by Sourcery

Re-vendor the estate commands from their owning repositories and install the complete command set in the base image.

New Features:
- Vendor openRepoTools, park, and resume from a dedicated pinned openRepoTools source alongside openRepoShape.

Enhancements:
- Separate the openRepoShape and openRepoTools vendored commands while keeping the manifest template with openRepoShape.
- Install all four estate commands in the base image from their respective vendor sources.

Build:
- Update the base image Dockerfile to copy and set permissions for openRepoShape, openRepoTools, park, and resume.