### PR TITLE
devBenches/base-image: re-vendor openRepoTools at ff1f01a — park skips roots without the overlay, --help wording fix

### DIFF
--- a/devBenches/base-image/files/openrepotools/openRepoTools
+++ b/devBenches/base-image/files/openrepotools/openRepoTools
@@ -47,8 +47,8 @@ openRepoTools --install            install (or update) park, resume and this
 openRepoTools --help | --version
 
 This command installs the estate commands and does nothing else. It has no
-verb of its own: `openRepoShape` is the standard's front door, and the two
-verbs `--install` places beside this file are
+verb of its own: `openRepoShape` is the standard's front door. `--install`
+places three files beside each other — this command and the two verbs:
 
   park [<Name>]                    commit, push and RECORD an estate's open
                                    features, so another workstation can take

--- a/devBenches/base-image/files/openrepotools/park
+++ b/devBenches/base-image/files/openrepotools/park
@@ -22,10 +22,16 @@
 # discovers and PARKS EVERY ESTATE under the projects directory, in name
 # order, continuing past a refusal, instead of refusing. `park <Name>`,
 # `park --repo` and the walk-up inside an estate are unchanged either way.
+# IN THAT SWEEP ONLY, a standalone root carrying no Speckit git overlay is
+# SKIPPED and named instead of being run and counted as a refusal — Brett
+# Heap's RULING of 2026-09-10 on openRepoShape #92, "skip roots without the
+# overlay": a root nobody ever installed the overlay in is not a park that
+# FAILED. Naming that same root still relays its own `make park` refusal.
 # `resume` deliberately KEEPS ruling 3's refusal for its own bare form (see
 # its header) — rebuilding every estate on a fresh machine by accident is the
 # opposite risk from failing to park the one you meant.
-# openRepoShape #82 wrote this, its #93 last changed it, its #92 moved it here.
+# openRepoShape #82 wrote this, its #91 and #93 changed it, its #92 moved it
+# here, and this repository's #6 last changed it.
 
 set -euo pipefail
 
@@ -65,7 +71,10 @@ estate around it either, `park` PARKS EVERY ESTATE under your projects
 directory instead of refusing (Brett Heap's RULING of 2026-09-10, #91,
 superseding ruling 3 of #82 for this one case): it lists what it found, then
 runs this same procedure on each one in name order, continuing past a
-refusal or a non-zero `make park`, and ends with a summary. `resume`
+refusal or a non-zero `make park`, and ends with a summary. A root with NO
+Speckit git overlay is SKIPPED there and counted apart rather than failed
+(the RULING of the same day on #92); naming that root still relays its own
+refusal, which names `setup-openspeckit`, exactly as it does today. `resume`
 deliberately keeps the old refusal for its own bare form: rebuilding every
 estate on a fresh machine by accident is a worse mistake than failing to park
 the one you meant. `--repo <owner/name>` names the estate by the origin of a
@@ -650,7 +659,7 @@ run_one_estate() {
     return "$one_status"
 }
 
-# --- park-everything (#91) ---------------------------------------------------
+# --- park-everything (#91), and what it SKIPS (#92) --------------------------
 #
 # Brett Heap's RULING, 2026-09-10, verbatim: "for the park-all, lets make
 # that be park with no estate option. so just park will do park-all." This
@@ -661,6 +670,17 @@ run_one_estate() {
 # `resume` deliberately keeps ruling 3's refusal for its own bare form - see
 # the note in its header - because rebuilding every estate on a fresh machine
 # by accident is the opposite risk from failing to park the one you meant.
+#
+# Brett Heap's SECOND RULING of that day, on openRepoShape #92, verbatim:
+# "rule on the #92 open item: skip roots without the overlay." The sweep on
+# a real workstation found four roots with no Speckit git overlay, whose own
+# `make park` refuses with exit 2 - so a bare `park` there could only ever
+# exit 1, and the one summary line that matters was four false failures deep.
+# A root nobody installed the overlay in is not a park that FAILED; it is a
+# park there was never anything to run. So THE SWEEP skips it, names it, and
+# counts it apart. ONLY THE SWEEP: `park <Name>` and `park --repo` named a
+# root, and a person who named one gets its refusal, which names the
+# installer.
 
 # Every estate under the projects directory, `<name><TAB><dir>` per row, in
 # NAME order rather than discovery order: `~/projects` and `~/Projects` can
@@ -684,14 +704,39 @@ all_estate_dirs() {
     done | LC_ALL=C sort -t $'\t' -k1,1
 }
 
+# Does this root carry the Speckit git overlay its own `make park` requires?
+# THE SAME TEST THE MAKEFILE MAKES, spelled the same way: `templates/
+# assembly-root/Makefile` opens the target with `test -x $(PARK) || { echo
+# 'make park $(OVERLAY_MISSING)' >&2; exit 2; }`, where `$(PARK)` is
+# `.specify/extensions/git/scripts/bash/park.sh`. Asking the question the
+# target's own way is what keeps the sweep's answer and the target's answer
+# from ever disagreeing - a probe that tested for the DIRECTORY, say, would
+# skip a root the target would have run, or run one it would refuse.
+#
+# ONLY A STANDALONE ROOT IS ASKED. A family holder's Makefile makes no such
+# test: it fans out with `scripts/siblings.py --make park`, and each member's
+# own root refuses for itself and is REPORTED BY THE HOLDER. Pre-checking a
+# holder here would skip a whole family for want of a file its own Makefile
+# never reads, and pre-checking its members would answer, worse and earlier,
+# a question the holder already answers per member.
+has_speckit_overlay() {
+    [ -x "$1/.specify/extensions/git/scripts/bash/park.sh" ]
+}
+
 # Discover every estate and run `run_one_estate` for each, in name order,
 # CONTINUING PAST A REFUSAL OR A NON-ZERO `make park`: one estate's trouble is
 # not a reason to leave the others unparked. A SKIP IS NOT A PASS (#80's
 # rule), so an estate whose own report is not clean - a non-zero `make park`,
 # or a zero one that still left something behind - counts against the
 # overall exit code exactly as a refusal does.
+#
+# A ROOT WITHOUT THE OVERLAY IS THE ONE THING THAT COUNTS NEITHER WAY (#92's
+# ruling, above): nothing ran in it, so there is no report to be clean or
+# unclean, and the exit code is computed over the estates that DID run. That
+# is not #80's rule bent - #80 is about a verb that was asked and did not
+# answer; this is a verb that was never askable.
 park_every_estate() {
-    local rows name dir estate_status total=0 bad=0
+    local rows name dir estate_status total=0 bad=0 skipped=0 skipped_clause=""
     local -a summary=()
 
     rows="$(all_estate_dirs)"
@@ -718,8 +763,29 @@ $(estates_or_none)
     while IFS=$'\t' read -r name dir; do
         [ -n "$name" ] || continue
         estate_here "$dir" || continue
-        total=$((total + 1))
         say "=== park $ESTATE_NAME ==="
+        # ONE LINE, AND NOTHING RUNS HERE (#92's ruling). The block still
+        # gets its `=== park <Name> ===` heading, because a root left out of
+        # the run silently is a root a person has to go and look for.
+        #
+        # `= standalone` AND NOT `!= family`, though `estate_here` sets only
+        # those two today: the kinds are matched POSITIVELY so that a kind
+        # nobody has invented yet is RUN and answered by its own Makefile,
+        # rather than silently skipped by a test written before it existed.
+        # Skipping is the answer for the one shape whose Makefile we have
+        # read (Copilot's review of #7).
+        if [ "$ESTATE_KIND" = "standalone" ] && ! has_speckit_overlay "$ESTATE_ROOT"; then
+            if [ "$DRY_RUN" -eq 1 ]; then
+                say "  would skip (no Speckit overlay; install it with: setup-openspeckit)"
+            else
+                say "  SKIPPED (no Speckit overlay; install it with: setup-openspeckit)"
+            fi
+            summary+=("  skipped    $ESTATE_NAME (no Speckit overlay)")
+            skipped=$((skipped + 1))
+            say ""
+            continue
+        fi
+        total=$((total + 1))
         estate_status=0
         run_one_estate || estate_status=$?
         if [ "$estate_status" -ne 0 ]; then
@@ -739,7 +805,17 @@ $(estates_or_none)
     for line in "${summary[@]}"; do
         say "$line"
     done
-    say "park: $((total - bad)) estate(s) parked, $bad refused or with findings"
+    # THE #91 LINE, UNCHANGED, when nothing was skipped - which is every
+    # workstation whose roots all carry the overlay. The clause appears only
+    # when there is something to say, and it says what was NOT run rather
+    # than padding the line with a zero.
+    [ "$skipped" -eq 0 ] || skipped_clause=", $skipped skipped (no overlay)"
+    say "park: $((total - bad)) estate(s) parked, $bad refused or with findings$skipped_clause"
+    if [ "$total" -eq 0 ] && [ "$skipped" -ne 0 ]; then
+        say "park: nothing here was park-able: every estate found is without the"
+        say "      Speckit git overlay, so nothing ran and nothing failed. Install"
+        say "      it where you want park to work: setup-openspeckit"
+    fi
     [ "$bad" -eq 0 ]
 }
 

--- a/devBenches/base-image/upstream-pin.yaml
+++ b/devBenches/base-image/upstream-pin.yaml
@@ -57,14 +57,14 @@ sources:
     source_repository: opensoft/openRepoTools
     materialization: copied
     revision_kind: commit
-    commit: "9fbf01c789c311aa7c190b238a3df48ea39473e1"
+    commit: "ff1f01aae70b8f21dce0e4654da071a1281b41a4"
     vendor_dir: files/openrepotools
     files:
       - path: openRepoTools
-        sha256: "e1996322a0fc898edf271ad8fc66837b54410e8dc93880b9c13149421ba9ffe9"
+        sha256: "15e4cb8ca6bb51ff17dd3b59223037c1f2d84c010e6238496a94514a61a915d1"
         mode: "100755"
       - path: park
-        sha256: "5048a7db16bcf68b5b976d96b9ee9c44ee6fa17a2e548c4c4fc825064bb84239"
+        sha256: "6c2dca99f2e1dc8db4c0817f28b5a31805ab096fd3e372df5e4944377fe8b60b"
         mode: "100755"
       - path: resume
         sha256: "a5a147f89cf9a1b97a0d8c1e8868d17323e41b238f96d9e59d8ddd766af387eb"


### PR DESCRIPTION
Lane: openreposhape-2 (openRepoShape-2)
Claim: https://github.com/opensoft/workBenches/issues/38#issuecomment-5625616302

Closes #38.

**What lands.** `devBenches/base-image/upstream-pin.yaml`'s `openrepotools` source moves from `9fbf01c789c311aa7c190b238a3df48ea39473e1` (pinned in #32/#34) to `ff1f01aae70b8f21dce0e4654da071a1281b41a4` — `gh api repos/opensoft/openRepoTools/compare/main...ff1f01aae70b8f21dce0e4654da071a1281b41a4 -q .status` says `identical`, so it is the commit `main` carries. **The tool and the Dockerfile do not change** — the vendored paths are identical to W2's, so this is one `apply` run and nothing else.

**Upstream, between the two commits:**

- opensoft/openRepoTools#7 (closes opensoft/openRepoTools#6): `park`'s bare no-estate sweep SKIPS a standalone root with no Speckit git overlay instead of counting it as a refusal — Brett Heap's ruling on opensoft/openRepoShape#92's open item. `park <Name>` on such a root still refuses; `resume` is untouched.
- opensoft/openRepoTools#4 (closes opensoft/openRepoTools#3): `openRepoTools --help`'s `usage()` sentence naming the two verbs `--install` places alongside it is reworded — wording only.

**The `apply` run, verbatim:**

```
$ python3 devBenches/base-image/update-upstream.py apply --source openrepotools --at ff1f01aae70b8f21dce0e4654da071a1281b41a4 --yes
source      openrepotools (opensoft/openRepoTools)
pinned      9fbf01c789c3
target      ff1f01aae70b (on main)
vendor      files/openrepotools

  take      openRepoTools  15e4cb8ca6bb
  take      park  6c2dca99f2e1
  unchanged resume
  re-pin    commit 9fbf01c789c3 -> ff1f01aae70b

  wrote     files/openrepotools/openRepoTools  0755
  wrote     files/openrepotools/park  0755
  wrote     files/openrepotools/resume  0755
  re-pinned devBenches/base-image/upstream-pin.yaml  3 row(s) at ff1f01aae70b

NEXT  python3 devBenches/base-image/update-upstream.py check
```

`resume` comes back `unchanged` — confirmed from a run, not from reasoning, that neither PR#7 nor PR#4 touched it. `openRepoTools` changed (PR#4's wording fix) and `park` changed (PR#7's skip-without-overlay logic), both `take`.

**Proofs, all run on this branch's HEAD.**

| Run | Result |
|---|---|
| `update-upstream.py check` | exit 0, **5** rows across 2 sources (`openreposhape`: `openRepoShape`, `templates/assembly-root/project.yaml`; `openrepotools`: `openRepoTools`, `park`, `resume`) |
| `update-upstream.py list` | exit 0, both sources named with their commits and vendor dirs |
| `test-speckit-git-feature.sh` | 56/56 GREEN, exit 0 |
| `test-speckit-git-compat.sh` | 22/22 GREEN, exit 0 |
| `test-openspeckit-bootstrap.sh` | 742 GREEN, exit 0 |
| `git diff --stat` | 3 files: `upstream-pin.yaml`, `files/openrepotools/openRepoTools`, `files/openrepotools/park` — no tool change, no Dockerfile change, no `resume` change |

**Each vendored file diffs clean against the source at the pinned commit** (local mirror clone `~/projects/openRepoTools` at `ff1f01a`, clean):

* `diff <(git -C ~/projects/openRepoTools show ff1f01a:openRepoTools) devBenches/base-image/files/openrepotools/openRepoTools` — empty
* `diff <(git -C ~/projects/openRepoTools show ff1f01a:park) devBenches/base-image/files/openrepotools/park` — empty
* `diff <(git -C ~/projects/openRepoTools show ff1f01a:resume) devBenches/base-image/files/openrepotools/resume` — empty (byte-unchanged, as `apply` itself reported)

**Not proven here: the image.** `dev-bench-base` carries the new bytes only after its next rebuild — not run in this PR. The command that proves it, per #34's precedent:

```sh
cd devBenches/base-image && ./build.sh
docker run --rm <tag build.sh printed> sh -c \
    'for c in openRepoShape openRepoTools park resume; do command -v "$c"; done
     park --help | head -3'
```

**Not here.** The base-image rebuild and the host reinstall on Eagle (operator step, after this merges, per Brett's word in #38).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Re-vendor openRepoTools at the current upstream main commit and update the base-image source pin.

New Features:
- Update the vendored openRepoTools utilities to the upstream main commit, including revised park behavior that skips standalone roots without a Speckit git overlay during bare no-estate sweeps.

Bug Fixes:
- Correct the openRepoTools help usage wording and ensure the vendored files match the newly pinned upstream commit.