### PR TITLE
setup.sh installs the estate commands on the host from the vendored pin: openRepoShape, openRepoTools, park, resume placed from files/openreposhape and files/openrepotools, re-placed when the pin moves (#37)

### DIFF
--- a/.github/workflows/speckit-git-bash.yml
+++ b/.github/workflows/speckit-git-bash.yml
@@ -17,6 +17,9 @@ on:
       - devBenches/base-image/update-upstream.py
       - devBenches/base-image/files/openreposhape/**
       - devBenches/base-image/files/openrepotools/**
+      - scripts/setup-estate-commands.sh
+      - devcontainer.test/test-setup-estate-commands.sh
+      - setup.sh
   pull_request:
     paths:
       - .github/workflows/speckit-git-bash.yml
@@ -33,6 +36,9 @@ on:
       - devBenches/base-image/update-upstream.py
       - devBenches/base-image/files/openreposhape/**
       - devBenches/base-image/files/openrepotools/**
+      - scripts/setup-estate-commands.sh
+      - devcontainer.test/test-setup-estate-commands.sh
+      - setup.sh
   workflow_dispatch:
 
 permissions:
@@ -66,6 +72,9 @@ jobs:
 
       - name: Check the vendored upstream copies against their pin
         run: python3 ./devBenches/base-image/update-upstream.py check
+
+      - name: Run the setup-estate-commands regression test
+        run: bash ./devcontainer.test/test-setup-estate-commands.sh
 
       - name: Run bootstrap suite
         run: bash ./devBenches/devcontainer.test/test-openspeckit-bootstrap.sh

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ setup.sh
   └── Summary + log file path
 ```
 
-Your host's `openRepoShape`, `openRepoTools`, `park` and `resume` commands come from workBenches' own pin (`devBenches/base-image/upstream-pin.yaml`). `setup.sh` places them from the vendored copies in `devBenches/base-image/files/openreposhape/` and `devBenches/base-image/files/openrepotools/`, and re-places them whenever a host copy differs from the pin, in either direction — behind, ahead, or hand-edited. To move them to a new upstream commit, move the pin with `update-upstream.py apply` and re-run `setup.sh`; do not edit the vendored files or the installed commands directly. Set `WORKBENCHES_SKIP_ESTATE_COMMANDS=1` to skip this step.
+Your host's `openRepoShape`, `openRepoTools`, `park` and `resume` commands come from workBenches' own pin (`devBenches/base-image/upstream-pin.yaml`). `setup.sh` places them from the vendored copies in `devBenches/base-image/files/openreposhape/` and `devBenches/base-image/files/openrepotools/`, and re-places them whenever a host copy differs from the pin, in either direction — behind, ahead, or hand-edited. To move them to a new upstream commit, move the pin with `update-upstream.py apply` and re-run `setup.sh`; do not edit the vendored files or the installed commands directly. The step refuses to run over a symlinked, non-regular, or read-only target, and verifies the four placed files against the vendored copies before it reports success. Set `WORKBENCHES_SKIP_ESTATE_COMMANDS=1` to skip this step.
 
 ## Wave Terminal Widgets
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ After setup, open any bench in VS Code → "Reopen in Container" to start develo
 
 ### Re-running setup.sh
 
-Safe to run repeatedly. Installed benches show `✓ up to date` and are skipped. Only new selections or missing images trigger builds.
+Safe to run repeatedly. Installed benches show `✓ up to date` and are skipped. Only new selections or missing images trigger builds. The estate commands (`openRepoShape`, `openRepoTools`, `park`, `resume`) are checked against workBenches' pin on every run and are re-placed only when a host copy differs from it.
 
 ## Docker Image Layers
 
@@ -81,6 +81,8 @@ setup.sh
   ├── Layer 1 builds (dev-bench-base, sys-bench-base, bio-bench-base)
   └── Summary + log file path
 ```
+
+Your host's `openRepoShape`, `openRepoTools`, `park` and `resume` commands come from workBenches' own pin (`devBenches/base-image/upstream-pin.yaml`). `setup.sh` places them from the vendored copies in `devBenches/base-image/files/openreposhape/` and `devBenches/base-image/files/openrepotools/`, and re-places them whenever a host copy differs from the pin, in either direction — behind, ahead, or hand-edited. To move them to a new upstream commit, move the pin with `update-upstream.py apply` and re-run `setup.sh`; do not edit the vendored files or the installed commands directly. Set `WORKBENCHES_SKIP_ESTATE_COMMANDS=1` to skip this step.
 
 ## Wave Terminal Widgets
 

--- a/devcontainer.test/test-setup-estate-commands.sh
+++ b/devcontainer.test/test-setup-estate-commands.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# Regression test for scripts/setup-estate-commands.sh (opensoft/workBenches#37):
+# the host's openRepoShape, openRepoTools, park and resume come from
+# workBenches' own vendored pin, and the script places them, re-places them
+# when they differ from the pin (either direction), and refuses to place
+# anything when the vendored copies themselves no longer match the pin.
+
+set -euo pipefail
+
+TEST_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -- "$TEST_DIR/.." && pwd -P)"
+SCRIPT_UNDER_TEST="$REPO_ROOT/scripts/setup-estate-commands.sh"
+BASE_IMAGE_DIR="$REPO_ROOT/devBenches/base-image"
+PIN_FILE="$BASE_IMAGE_DIR/upstream-pin.yaml"
+
+SHAPE_VENDOR="$BASE_IMAGE_DIR/files/openreposhape/openRepoShape"
+TOOLS_VENDOR="$BASE_IMAGE_DIR/files/openrepotools/openRepoTools"
+PARK_VENDOR="$BASE_IMAGE_DIR/files/openrepotools/park"
+RESUME_VENDOR="$BASE_IMAGE_DIR/files/openrepotools/resume"
+
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+failures=0
+
+pass() {
+    printf 'PASS: %s\n' "$1"
+}
+
+fail() {
+    printf 'FAIL: %s\n' "$1"
+    failures=$((failures + 1))
+}
+
+assert_equal() {
+    local actual="$1"
+    local expected="$2"
+    local label="$3"
+    if [ "$actual" = "$expected" ]; then
+        pass "$label"
+    else
+        fail "$label: expected [$expected], got [$actual]"
+    fi
+}
+
+assert_matches() {
+    local actual="$1"
+    local pattern="$2"
+    local label="$3"
+    if [[ "$actual" =~ $pattern ]]; then
+        pass "$label"
+    else
+        fail "$label: [$actual] does not match /$pattern/"
+    fi
+}
+
+assert_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local label="$3"
+    if grep -Fq -- "$needle" <<<"$haystack"; then
+        pass "$label"
+    else
+        fail "$label: output does not contain: $needle"
+    fi
+}
+
+assert_file_executable() {
+    local path="$1"
+    local label="$2"
+    if [ -f "$path" ] && [ -x "$path" ]; then
+        pass "$label"
+    else
+        fail "$label: $path missing or not executable"
+    fi
+}
+
+assert_identical() {
+    local a="$1"
+    local b="$2"
+    local label="$3"
+    if cmp -s "$a" "$b"; then
+        pass "$label"
+    else
+        fail "$label: $a differs from $b"
+    fi
+}
+
+assert_empty_dir() {
+    local dir="$1"
+    local label="$2"
+    if [ -z "$(find "$dir" -mindepth 1 2>/dev/null)" ]; then
+        pass "$label"
+    else
+        fail "$label: $dir is not empty"
+    fi
+}
+
+# Independent of the script under test: read the two pinned commits straight
+# out of the YAML, the same file the script itself must agree with.
+pin_commit_for() {
+    local id="$1"
+    awk -v id="$id" '
+        $0 ~ "^  - id: " id "$" { found=1; next }
+        found && /^  - id:/ { found=0 }
+        found && /^    commit:/ {
+            line = $0
+            gsub(/^    commit: *"?/, "", line)
+            gsub(/"$/, "", line)
+            print line
+            exit
+        }
+    ' "$PIN_FILE"
+}
+
+SHAPE_COMMIT="$(pin_commit_for openreposhape)"
+TOOLS_COMMIT="$(pin_commit_for openrepotools)"
+assert_matches "$SHAPE_COMMIT" '^[0-9a-f]{40}$' 'pin file yields a 40-hex openreposhape commit'
+assert_matches "$TOOLS_COMMIT" '^[0-9a-f]{40}$' 'pin file yields a 40-hex openrepotools commit'
+
+printf '%s\n' '--- Scenario (a): fresh bin dir installs all four commands from the vendored copies ---'
+BIN_A="$TMPDIR_ROOT/bin-a"
+mkdir -p "$BIN_A"
+STATUS_A=0
+OUTPUT_A="$(OPENREPOSHAPE_BIN_DIR="$BIN_A" OPENREPOTOOLS_BIN_DIR="$BIN_A" "$SCRIPT_UNDER_TEST" 2>&1)" || STATUS_A=$?
+
+assert_equal '0' "$STATUS_A" 'fresh install exit code'
+assert_file_executable "$BIN_A/openRepoShape" 'fresh install places openRepoShape, executable'
+assert_file_executable "$BIN_A/openRepoTools" 'fresh install places openRepoTools, executable'
+assert_file_executable "$BIN_A/park" 'fresh install places park, executable'
+assert_file_executable "$BIN_A/resume" 'fresh install places resume, executable'
+assert_identical "$BIN_A/openRepoShape" "$SHAPE_VENDOR" 'fresh openRepoShape is byte-identical to the vendored copy'
+assert_identical "$BIN_A/openRepoTools" "$TOOLS_VENDOR" 'fresh openRepoTools is byte-identical to the vendored copy'
+assert_identical "$BIN_A/park" "$PARK_VENDOR" 'fresh park is byte-identical to the vendored copy'
+assert_identical "$BIN_A/resume" "$RESUME_VENDOR" 'fresh resume is byte-identical to the vendored copy'
+assert_contains "$OUTPUT_A" "openRepoShape pinned at $SHAPE_COMMIT" 'fresh install prints the openRepoShape pin commit'
+assert_contains "$OUTPUT_A" "openRepoTools pinned at $TOOLS_COMMIT" 'fresh install prints the openRepoTools pin commit'
+assert_contains "$OUTPUT_A" 'openRepoShape: installed at' 'fresh install reports an installed verb for openRepoShape'
+assert_contains "$OUTPUT_A" 'openRepoTools: installed at' 'fresh install reports an installed verb for openRepoTools'
+assert_contains "$OUTPUT_A" 'park: installed at' 'fresh install reports an installed verb for park'
+assert_contains "$OUTPUT_A" 'resume: installed at' 'fresh install reports an installed verb for resume'
+# Scenario (f) folded in here: a brand-new temp dir is never on $PATH.
+assert_contains "$OUTPUT_A" "$BIN_A is not on \$PATH" 'fresh install warns that the bin dir is not on PATH, naming it'
+
+printf '%s\n' '--- Scenario (b): a second run over an already-installed bin dir reports unchanged ---'
+STATUS_B=0
+OUTPUT_B="$(OPENREPOSHAPE_BIN_DIR="$BIN_A" OPENREPOTOOLS_BIN_DIR="$BIN_A" "$SCRIPT_UNDER_TEST" 2>&1)" || STATUS_B=$?
+
+assert_equal '0' "$STATUS_B" 'second run exit code'
+assert_contains "$OUTPUT_B" 'openRepoShape: already installed at' 'second run reports openRepoShape unchanged'
+assert_contains "$OUTPUT_B" 'openRepoTools: already installed at' 'second run reports openRepoTools unchanged'
+assert_contains "$OUTPUT_B" 'park: already installed at' 'second run reports park unchanged'
+assert_contains "$OUTPUT_B" 'resume: already installed at' 'second run reports resume unchanged'
+assert_identical "$BIN_A/openRepoShape" "$SHAPE_VENDOR" 'openRepoShape still byte-identical after the second run'
+assert_identical "$BIN_A/openRepoTools" "$TOOLS_VENDOR" 'openRepoTools still byte-identical after the second run'
+assert_identical "$BIN_A/park" "$PARK_VENDOR" 'park still byte-identical after the second run'
+assert_identical "$BIN_A/resume" "$RESUME_VENDOR" 'resume still byte-identical after the second run'
+
+printf '%s\n' '--- Scenario (c): a locally-modified park is replaced and reported updated ---'
+printf '%s\n' '# a local edit, not the vendored bytes' >> "$BIN_A/park"
+STATUS_C=0
+OUTPUT_C="$(OPENREPOSHAPE_BIN_DIR="$BIN_A" OPENREPOTOOLS_BIN_DIR="$BIN_A" "$SCRIPT_UNDER_TEST" 2>&1)" || STATUS_C=$?
+
+assert_equal '0' "$STATUS_C" 'updated-park run exit code'
+assert_contains "$OUTPUT_C" 'park: updated at' 'the locally-modified park is reported updated'
+assert_identical "$BIN_A/park" "$PARK_VENDOR" 'park is byte-identical to the vendored copy again after being updated'
+# The other three were untouched, so this run still reports them unchanged.
+assert_contains "$OUTPUT_C" 'openRepoShape: already installed at' 'updated-park run still reports openRepoShape unchanged'
+assert_contains "$OUTPUT_C" 'resume: already installed at' 'updated-park run still reports resume unchanged'
+
+printf '%s\n' '--- Scenario (d): a corrupted vendor copy refuses to install anything ---'
+CORRUPT_BASE="$TMPDIR_ROOT/corrupt-base-image"
+mkdir -p "$CORRUPT_BASE"
+cp -r "$BASE_IMAGE_DIR/." "$CORRUPT_BASE/"
+python3 - "$CORRUPT_BASE/files/openrepotools/resume" <<'PYEOF'
+import sys
+path = sys.argv[1]
+data = bytearray(open(path, "rb").read())
+idx = len(data) // 2
+data[idx] ^= 0x01
+open(path, "wb").write(data)
+PYEOF
+BIN_D="$TMPDIR_ROOT/bin-d"
+mkdir -p "$BIN_D"
+STATUS_D=0
+OUTPUT_D="$(OPENREPOSHAPE_BIN_DIR="$BIN_D" OPENREPOTOOLS_BIN_DIR="$BIN_D" WORKBENCHES_BASE_IMAGE_DIR="$CORRUPT_BASE" "$SCRIPT_UNDER_TEST" 2>&1)" || STATUS_D=$?
+
+assert_equal '1' "$STATUS_D" 'corrupted vendor copy exit code'
+assert_contains "$OUTPUT_D" 'REFUSED' "the check's REFUSED finding is in the output"
+assert_contains "$OUTPUT_D" 'CHANGED' "the check's CHANGED finding is in the output"
+assert_contains "$OUTPUT_D" 'files/openrepotools/resume' 'the finding names the corrupted file'
+assert_empty_dir "$BIN_D" 'nothing was installed into the bin dir'
+
+printf '%s\n' '--- Scenario (e): WORKBENCHES_SKIP_ESTATE_COMMANDS=1 skips the step entirely ---'
+BIN_E="$TMPDIR_ROOT/bin-e"
+mkdir -p "$BIN_E"
+STATUS_E=0
+OUTPUT_E="$(WORKBENCHES_SKIP_ESTATE_COMMANDS=1 OPENREPOSHAPE_BIN_DIR="$BIN_E" OPENREPOTOOLS_BIN_DIR="$BIN_E" "$SCRIPT_UNDER_TEST" 2>&1)" || STATUS_E=$?
+
+assert_equal '0' "$STATUS_E" 'skip-var run exit code'
+assert_contains "$OUTPUT_E" 'skipped' 'skip-var run says skipped'
+assert_empty_dir "$BIN_E" 'skip-var run installs nothing'
+
+if (( failures == 0 )); then
+    printf '%s\n' 'GREEN: setup-estate-commands regression test passed'
+else
+    printf 'RED: %d assertion(s) failed\n' "$failures"
+    exit 1
+fi

--- a/devcontainer.test/test-setup-estate-commands.sh
+++ b/devcontainer.test/test-setup-estate-commands.sh
@@ -4,6 +4,12 @@
 # workBenches' own vendored pin, and the script places them, re-places them
 # when they differ from the pin (either direction), and refuses to place
 # anything when the vendored copies themselves no longer match the pin.
+#
+# Scenarios (g)-(m) guard the adversarial review round's D1-D6 findings: a
+# symlinked target (D1), a directory target (D2), unpinned bytes reaching
+# the shims from the network (D3), a partial install across two independent
+# shim transactions (D4), the pin file itself missing, and the placed
+# files' mode.
 
 set -euo pipefail
 
@@ -65,6 +71,23 @@ assert_contains() {
     fi
 }
 
+assert_not_contains() {
+    local haystack="$1"
+    local needle="$2"
+    local label="$3"
+    if grep -Fq -- "$needle" <<<"$haystack"; then
+        fail "$label: output unexpectedly contains: $needle"
+    else
+        pass "$label"
+    fi
+}
+
+count_occurrences() {
+    # A bare `grep -c` with zero matches exits 1, which would abort this
+    # test script under `set -e` if not for the `|| true` guard here.
+    grep -Fc -- "$2" <<<"$1" || true
+}
+
 assert_file_executable() {
     local path="$1"
     local label="$2"
@@ -94,6 +117,15 @@ assert_empty_dir() {
     else
         fail "$label: $dir is not empty"
     fi
+}
+
+assert_mode() {
+    local path="$1"
+    local expected="$2"
+    local label="$3"
+    local actual
+    actual="$(stat -c '%a' "$path" 2>/dev/null || stat -f '%Lp' "$path" 2>/dev/null)"
+    assert_equal "$actual" "$expected" "$label"
 }
 
 # Independent of the script under test: read the two pinned commits straight
@@ -139,8 +171,13 @@ assert_contains "$OUTPUT_A" 'openRepoShape: installed at' 'fresh install reports
 assert_contains "$OUTPUT_A" 'openRepoTools: installed at' 'fresh install reports an installed verb for openRepoTools'
 assert_contains "$OUTPUT_A" 'park: installed at' 'fresh install reports an installed verb for park'
 assert_contains "$OUTPUT_A" 'resume: installed at' 'fresh install reports an installed verb for resume'
-# Scenario (f) folded in here: a brand-new temp dir is never on $PATH.
-assert_contains "$OUTPUT_A" "$BIN_A is not on \$PATH" 'fresh install warns that the bin dir is not on PATH, naming it'
+assert_contains "$OUTPUT_A" 'Estate commands verified against the vendored pin.' 'fresh install reports success only after post-install verification'
+# Scenario (f) folded in here: a brand-new temp dir is never on $PATH. Fix 4
+# removed this script's own PATH warning (the shims already print theirs),
+# so the substring must appear exactly twice -- once per shim -- not three
+# times.
+path_warning_count="$(count_occurrences "$OUTPUT_A" 'is not on $PATH')"
+assert_equal '2' "$path_warning_count" 'exactly two PATH warnings (one per shim; this script prints no third copy)'
 
 printf '%s\n' '--- Scenario (b): a second run over an already-installed bin dir reports unchanged ---'
 STATUS_B=0
@@ -200,6 +237,123 @@ OUTPUT_E="$(WORKBENCHES_SKIP_ESTATE_COMMANDS=1 OPENREPOSHAPE_BIN_DIR="$BIN_E" OP
 assert_equal '0' "$STATUS_E" 'skip-var run exit code'
 assert_contains "$OUTPUT_E" 'skipped' 'skip-var run says skipped'
 assert_empty_dir "$BIN_E" 'skip-var run installs nothing'
+
+printf '%s\n' '--- Scenario (g) [D1]: a symlinked target refuses, the link target is untouched ---'
+BIN_G="$TMPDIR_ROOT/bin-g"
+OTHER_REPO_G="$TMPDIR_ROOT/other-repo-g"
+mkdir -p "$BIN_G" "$OTHER_REPO_G"
+printf '#!/bin/bash\necho other repo park, not workBenches'"'"'s\n' > "$OTHER_REPO_G/park"
+chmod +x "$OTHER_REPO_G/park"
+LINK_TARGET_BEFORE="$(cat "$OTHER_REPO_G/park")"
+ln -s "$OTHER_REPO_G/park" "$BIN_G/park"
+STATUS_G=0
+OUTPUT_G="$(OPENREPOSHAPE_BIN_DIR="$BIN_G" OPENREPOTOOLS_BIN_DIR="$BIN_G" "$SCRIPT_UNDER_TEST" 2>&1)" || STATUS_G=$?
+
+assert_equal '1' "$STATUS_G" 'symlinked park target exit code'
+assert_contains "$OUTPUT_G" "$BIN_G/park" 'the refusal names the symlinked path'
+assert_contains "$OUTPUT_G" 'symlink' 'the refusal says it is a symlink'
+assert_equal "$LINK_TARGET_BEFORE" "$(cat "$OTHER_REPO_G/park")" 'the symlink target file is byte-for-byte unchanged'
+assert_equal '1' "$(find "$BIN_G" -mindepth 1 | wc -l | tr -d ' ')" 'no other target was placed into the bin dir (only the pre-existing symlink remains)'
+
+printf '%s\n' '--- Scenario (h) [D2]: a directory target refuses, nothing is placed ---'
+BIN_H="$TMPDIR_ROOT/bin-h"
+mkdir -p "$BIN_H/park"
+STATUS_H=0
+OUTPUT_H="$(OPENREPOSHAPE_BIN_DIR="$BIN_H" OPENREPOTOOLS_BIN_DIR="$BIN_H" "$SCRIPT_UNDER_TEST" 2>&1)" || STATUS_H=$?
+
+assert_equal '1' "$STATUS_H" 'directory-target park exit code'
+assert_contains "$OUTPUT_H" "$BIN_H/park" 'the refusal names the directory path'
+assert_contains "$OUTPUT_H" 'not a regular file' 'the refusal says it is not a regular file'
+assert_equal '0' "$(find "$BIN_H/park" -mindepth 1 | wc -l | tr -d ' ')" 'nothing was copied into the directory standing in for park'
+
+printf '%s\n' '--- Scenario (i) [D4 regression guard]: a read-only pre-seeded park refuses before ANY placement ---'
+BIN_I="$TMPDIR_ROOT/bin-i"
+mkdir -p "$BIN_I"
+cp "$PARK_VENDOR" "$BIN_I/park"
+chmod 0444 "$BIN_I/park"
+STATUS_I=0
+OUTPUT_I="$(OPENREPOSHAPE_BIN_DIR="$BIN_I" OPENREPOTOOLS_BIN_DIR="$BIN_I" "$SCRIPT_UNDER_TEST" 2>&1)" || STATUS_I=$?
+
+assert_equal '1' "$STATUS_I" 'read-only park exit code'
+assert_contains "$OUTPUT_I" 'not writable' 'the refusal says park is not writable'
+assert_equal '0' "$([ -e "$BIN_I/openRepoShape" ] && echo 1 || echo 0)" 'openRepoShape was NOT placed (D4 regression guard)'
+assert_equal '0' "$([ -e "$BIN_I/openRepoTools" ] && echo 1 || echo 0)" 'openRepoTools was NOT placed (D4 regression guard)'
+assert_equal '0' "$([ -e "$BIN_I/resume" ] && echo 1 || echo 0)" 'resume was NOT placed (D4 regression guard)'
+chmod 0755 "$BIN_I/park"
+
+printf '%s\n' '--- Scenario (j): a base-image copy with upstream-pin.yaml deleted refuses with exit 2 ---'
+NOPIN_BASE="$TMPDIR_ROOT/nopin-base-image"
+mkdir -p "$NOPIN_BASE"
+cp -r "$BASE_IMAGE_DIR/." "$NOPIN_BASE/"
+rm -f "$NOPIN_BASE/upstream-pin.yaml"
+BIN_J="$TMPDIR_ROOT/bin-j"
+mkdir -p "$BIN_J"
+STATUS_J=0
+OUTPUT_J="$(OPENREPOSHAPE_BIN_DIR="$BIN_J" OPENREPOTOOLS_BIN_DIR="$BIN_J" WORKBENCHES_BASE_IMAGE_DIR="$NOPIN_BASE" "$SCRIPT_UNDER_TEST" 2>&1)" || STATUS_J=$?
+
+assert_equal '2' "$STATUS_J" 'missing pin file exit code'
+assert_contains "$OUTPUT_J" 'missing' 'the refusal says the pin is missing'
+assert_empty_dir "$BIN_J" 'missing-pin run installs nothing'
+
+printf '%s\n' '--- Scenario (k) [D3]: resume'"'"'s row AND vendored file both removed the documented way ---'
+NOROW_BASE="$TMPDIR_ROOT/norow-base-image"
+mkdir -p "$NOROW_BASE"
+cp -r "$BASE_IMAGE_DIR/." "$NOROW_BASE/"
+NOROW_COMMIT="$(pin_commit_for openrepotools)"
+(cd "$NOROW_BASE" && python3 update-upstream.py apply --source openrepotools --at "$NOROW_COMMIT" --remove resume --yes) >"$TMPDIR_ROOT/norow-apply.log" 2>&1
+if ! grep -Fq 'deleted   files/openrepotools/resume' "$TMPDIR_ROOT/norow-apply.log"; then
+    fail "scenario (k) setup: 'apply --remove resume' did not report deleting the file; see $TMPDIR_ROOT/norow-apply.log"
+fi
+NOROW_CHECK_STATUS=0
+python3 "$NOROW_BASE/update-upstream.py" check >"$TMPDIR_ROOT/norow-check.log" 2>&1 || NOROW_CHECK_STATUS=$?
+assert_equal '0' "$NOROW_CHECK_STATUS" "scenario (k) setup: 'check' passes on the row-and-file-removed copy (this is the D3 precondition)"
+
+BIN_K="$TMPDIR_ROOT/bin-k"
+mkdir -p "$BIN_K"
+STATUS_K=0
+OUTPUT_K="$(OPENREPOSHAPE_BIN_DIR="$BIN_K" OPENREPOTOOLS_BIN_DIR="$BIN_K" WORKBENCHES_BASE_IMAGE_DIR="$NOROW_BASE" "$SCRIPT_UNDER_TEST" 2>&1)" || STATUS_K=$?
+
+assert_equal '2' "$STATUS_K" 'row-and-file-removed resume exit code'
+assert_contains "$OUTPUT_K" 'resume' 'the pre-flight refusal names resume'
+assert_empty_dir "$BIN_K" 'nothing was installed for the row-and-file-removed copy'
+assert_not_contains "$OUTPUT_K" 'fetch' 'the output contains no attempted-fetch line'
+assert_not_contains "$OUTPUT_K" 'github' 'the output contains no github reference'
+
+printf '%s\n' '--- Scenario (l): every placed file is mode 0755 ---'
+assert_mode "$BIN_A/openRepoShape" '755' 'placed openRepoShape is mode 0755'
+assert_mode "$BIN_A/openRepoTools" '755' 'placed openRepoTools is mode 0755'
+assert_mode "$BIN_A/park" '755' 'placed park is mode 0755'
+assert_mode "$BIN_A/resume" '755' 'placed resume is mode 0755'
+
+printf '%s\n' '--- Scenario (m): the operator'"'"'s own *_REF/*_REPO are overridden by the sentinel, not used ---'
+# Dynamically: an operator's environment must not change the happy-path
+# outcome (this would also be true without the fix, since neither shim
+# fetches when every file is already present -- but it is still a real
+# regression guard: it proves the override does not itself break anything).
+BIN_M="$TMPDIR_ROOT/bin-m"
+mkdir -p "$BIN_M"
+STATUS_M=0
+OUTPUT_M="$(OPENREPOSHAPE_REF='operator-branch' OPENREPOTOOLS_REF='operator-branch' \
+    OPENREPOSHAPE_REPO='operator/fork' OPENREPOTOOLS_REPO='operator/fork' \
+    OPENREPOSHAPE_BIN_DIR="$BIN_M" OPENREPOTOOLS_BIN_DIR="$BIN_M" \
+    "$SCRIPT_UNDER_TEST" 2>&1)" || STATUS_M=$?
+assert_equal '0' "$STATUS_M" 'an operator-set REF/REPO does not change the happy-path exit code'
+assert_not_contains "$OUTPUT_M" 'operator-branch' "the operator's REF value never reaches the output"
+assert_not_contains "$OUTPUT_M" 'operator/fork' "the operator's REPO value never reaches the output"
+assert_identical "$BIN_M/resume" "$RESUME_VENDOR" 'resume is still placed correctly from the vendored copy, not fetched'
+# Statically: neither shim echoes REPO/REF on the happy path at all (only on
+# --version, or inside a fetch-failure message -- and this script's own
+# pre-flight makes a fetch unreachable through its front door once every
+# file is proven present and pinned, which is exactly what scenario (k)
+# proves for the one file that COULD have gone missing). So the only way to
+# show the override itself -- not just its harmlessness -- is to read the
+# source for the four fixed exports, which is what the reviewer's own
+# fallback clause invited ("assert instead by a method you can justify, or
+# drop (m) and say so"): this is that method.
+SCRIPT_SOURCE="$(cat "$SCRIPT_UNDER_TEST")"
+for var in OPENREPOSHAPE_REPO OPENREPOSHAPE_REF OPENREPOTOOLS_REPO OPENREPOTOOLS_REF; do
+    assert_contains "$SCRIPT_SOURCE" "export $var=\"\$ESTATE_SENTINEL\"" "the script source exports $var to the fixed sentinel before installing"
+done
 
 if (( failures == 0 )); then
     printf '%s\n' 'GREEN: setup-estate-commands regression test passed'

--- a/devcontainer.test/test-setup-estate-commands.sh
+++ b/devcontainer.test/test-setup-estate-commands.sh
@@ -296,14 +296,35 @@ assert_contains "$OUTPUT_J" 'missing' 'the refusal says the pin is missing'
 assert_empty_dir "$BIN_J" 'missing-pin run installs nothing'
 
 printf '%s\n' '--- Scenario (k) [D3]: resume'"'"'s row AND vendored file both removed the documented way ---'
+# Hand-edit the copy directly (drop resume's three-line row, delete its
+# file) rather than running `update-upstream.py apply --remove`, which
+# needs `gh api` to prove the target commit is reachable from
+# opensoft/openRepoTools' default branch -- network and auth this offline
+# suite does not assume (and does not have in every CI job). The end state
+# is the same one `apply --remove` documents producing: a row-and-file pair
+# gone together, `check` none the wiser.
 NOROW_BASE="$TMPDIR_ROOT/norow-base-image"
 mkdir -p "$NOROW_BASE"
 cp -r "$BASE_IMAGE_DIR/." "$NOROW_BASE/"
-NOROW_COMMIT="$(pin_commit_for openrepotools)"
-(cd "$NOROW_BASE" && python3 update-upstream.py apply --source openrepotools --at "$NOROW_COMMIT" --remove resume --yes) >"$TMPDIR_ROOT/norow-apply.log" 2>&1
-if ! grep -Fq 'deleted   files/openrepotools/resume' "$TMPDIR_ROOT/norow-apply.log"; then
-    fail "scenario (k) setup: 'apply --remove resume' did not report deleting the file; see $TMPDIR_ROOT/norow-apply.log"
-fi
+python3 - "$NOROW_BASE/upstream-pin.yaml" <<'PYEOF'
+import sys
+path = sys.argv[1]
+lines = open(path).readlines()
+out = []
+i = 0
+dropped = 0
+while i < len(lines):
+    if lines[i].strip() == "- path: resume":
+        i += 3  # this line, its sha256: line, its mode: line
+        dropped += 1
+        continue
+    out.append(lines[i])
+    i += 1
+if dropped != 1:
+    raise SystemExit(f"expected to drop exactly one 'resume' row, dropped {dropped}")
+open(path, "w").writelines(out)
+PYEOF
+rm -f "$NOROW_BASE/files/openrepotools/resume"
 NOROW_CHECK_STATUS=0
 python3 "$NOROW_BASE/update-upstream.py" check >"$TMPDIR_ROOT/norow-check.log" 2>&1 || NOROW_CHECK_STATUS=$?
 assert_equal '0' "$NOROW_CHECK_STATUS" "scenario (k) setup: 'check' passes on the row-and-file-removed copy (this is the D3 precondition)"

--- a/scripts/setup-estate-commands.sh
+++ b/scripts/setup-estate-commands.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# scripts/setup-estate-commands.sh
+#
+# Installs the estate commands on this host from workBenches' own vendored
+# pin: openRepoShape, openRepoTools, park and resume, placed by the vendored
+# shims' own `--install` (devBenches/base-image/files/openreposhape/openRepoShape
+# and devBenches/base-image/files/openrepotools/openRepoTools). This script
+# adds no install logic of its own: it runs `update-upstream.py check`, then
+# the two shims, and relays their own output unchanged.
+#
+# Two of the four rulings of opensoft/workBenches#37 that this script
+# embodies:
+#   - "Version" means the pin, not a number (ruling 1): the shims' own
+#     `--version` never prints the pinned commit, so this script prints the
+#     two commits devBenches/base-image/upstream-pin.yaml names, read via
+#     `update-upstream.py list`. It adds no version string to either shim.
+#   - The host follows the pin, both ways (ruling 2): a host copy that
+#     differs from the vendored one -- behind, ahead, or hand-edited -- is
+#     replaced, and the shim's own per-file line says `updated`. This step
+#     is best-effort and default-on in setup.sh, like the Wave widgets step:
+#     it never fails setup.sh.
+#
+# Set WORKBENCHES_SKIP_ESTATE_COMMANDS=1 to skip this step entirely (prints
+# one line, exits 0).
+#
+# WORKBENCHES_BASE_IMAGE_DIR overrides the base-image directory this script
+# reads the pin, the checker and the vendored shims from (default:
+# "<repo root>/devBenches/base-image"). This exists for the test suite's
+# corruption scenario only -- point it at a throwaway copy of base-image to
+# prove a corrupted vendor copy refuses to install; there is no reason to
+# set it on a real host.
+#
+# Exit codes when run directly: 0 ok; 1 refused (update-upstream.py check
+# found drift, so NOTHING was installed, or one of the two installers itself
+# failed); 2 tooling missing (no python3, or a file this script needs is
+# missing). setup.sh runs this under `log_header "ESTATE COMMANDS"` and
+# treats any non-zero exit here as best-effort, continuing either way; this
+# script is also safe to run directly, any time.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+BASE_IMAGE_DIR="${WORKBENCHES_BASE_IMAGE_DIR:-$ROOT_DIR/devBenches/base-image}"
+
+if [ "${WORKBENCHES_SKIP_ESTATE_COMMANDS:-}" = "1" ]; then
+    echo "Estate command install skipped by WORKBENCHES_SKIP_ESTATE_COMMANDS=1."
+    exit 0
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "Estate command install refused: python3 is not available, and" >&2
+    echo "$BASE_IMAGE_DIR/update-upstream.py needs it to check the vendored" >&2
+    echo "copies against their pin. Nothing was installed." >&2
+    exit 2
+fi
+
+UPDATE_UPSTREAM="$BASE_IMAGE_DIR/update-upstream.py"
+SHAPE_SHIM="$BASE_IMAGE_DIR/files/openreposhape/openRepoShape"
+TOOLS_SHIM="$BASE_IMAGE_DIR/files/openrepotools/openRepoTools"
+
+missing=""
+for f in "$UPDATE_UPSTREAM" "$SHAPE_SHIM" "$TOOLS_SHIM"; do
+    if [ ! -f "$f" ]; then
+        missing="${missing:+$missing }$f"
+    fi
+done
+if [ -n "$missing" ]; then
+    echo "Estate command install refused: missing file(s): $missing" >&2
+    echo "Nothing was installed." >&2
+    exit 2
+fi
+
+# Ruling 3 (drift refuses): the checker runs BEFORE anything is placed. A
+# non-zero exit means the vendored bytes are not the pinned bytes, and this
+# script installs NOTHING rather than spread a local edit that the pin
+# exists to forbid. Its own stdout/stderr stream through unchanged above.
+if ! python3 "$UPDATE_UPSTREAM" check; then
+    echo "" >&2
+    echo "Estate command install refused: the vendored copies do not match" >&2
+    echo "$BASE_IMAGE_DIR/upstream-pin.yaml (see the finding above). NOTHING" >&2
+    echo "was installed, because the vendored bytes are not the pinned bytes." >&2
+    exit 1
+fi
+
+# Ruling 1 ("version" means the pin): read the two pinned commits from
+# `update-upstream.py list`, which prints each source's id, then its
+# attributes (including "commit") in a stable, parseable form -- never from
+# a version string, because neither shim's `--version` carries one.
+if ! list_output="$(python3 "$UPDATE_UPSTREAM" list)"; then
+    echo "Estate command install refused: '$UPDATE_UPSTREAM list' failed" >&2
+    echo "unexpectedly, right after 'check' passed. Nothing was installed." >&2
+    exit 1
+fi
+
+shape_commit="$(printf '%s\n' "$list_output" | awk '/^openreposhape$/{f=1;next} f&&/^  commit /{print $2;exit}')"
+tools_commit="$(printf '%s\n' "$list_output" | awk '/^openrepotools$/{f=1;next} f&&/^  commit /{print $2;exit}')"
+
+if [ -z "$shape_commit" ] || [ -z "$tools_commit" ]; then
+    echo "Estate command install refused: could not read the pinned commits" >&2
+    echo "from '$UPDATE_UPSTREAM list'. Nothing was installed." >&2
+    exit 1
+fi
+
+echo "openRepoShape pinned at $shape_commit"
+echo "openRepoTools pinned at $tools_commit"
+
+# Ruling 2 (the host follows the pin, both ways): each shim, invoked as a
+# FILE, installs its own bytes (and openRepoTools copies park and resume
+# from beside itself); it reports each target `already installed ...
+# (unchanged)`, `updated`, or `installed`. That per-file report is relayed
+# unchanged below -- this script adds no version logic and no flags of its
+# own to either shim (ruling 4).
+if ! "$SHAPE_SHIM" --install; then
+    echo "openRepoShape --install failed; estate command install refused." >&2
+    exit 1
+fi
+
+if ! "$TOOLS_SHIM" --install; then
+    echo "openRepoTools --install failed; estate command install refused." >&2
+    exit 1
+fi
+
+# Each shim already warns on its own bin dir; this is a second, de-duplicated
+# pass over both effective bin dirs, in case they differ. Names the
+# directory only -- PATH and rc files are never touched here.
+shape_bin_dir="${OPENREPOSHAPE_BIN_DIR:-$HOME/.local/bin}"
+tools_bin_dir="${OPENREPOTOOLS_BIN_DIR:-$HOME/.local/bin}"
+
+seen=""
+for dir in "$shape_bin_dir" "$tools_bin_dir"; do
+    case " $seen " in
+        *" $dir "*) continue ;;
+    esac
+    seen="$seen $dir"
+    case ":${PATH:-}:" in
+        *":$dir:"*) ;;
+        *) echo "Warning: $dir is not on \$PATH. Add it, e.g.: export PATH=\"$dir:\$PATH\"" ;;
+    esac
+done
+
+exit 0

--- a/scripts/setup-estate-commands.sh
+++ b/scripts/setup-estate-commands.sh
@@ -7,7 +7,12 @@
 # shims' own `--install` (devBenches/base-image/files/openreposhape/openRepoShape
 # and devBenches/base-image/files/openrepotools/openRepoTools). This script
 # adds no install logic of its own: it runs `update-upstream.py check`, then
-# the two shims, and relays their own output unchanged.
+# the two shims, and relays their own output unchanged -- but it pre-flights
+# every install target and verifies every placed file afterward, because the
+# shims' own `cp` can write through a symlink or into a directory, and two
+# shim invocations are two independent transactions (an adversarial review of
+# this script, opensoft/workBenches#37, found and named these gaps D1-D6;
+# every guarantee below closes one).
 #
 # Two of the four rulings of opensoft/workBenches#37 that this script
 # embodies:
@@ -21,22 +26,48 @@
 #     is best-effort and default-on in setup.sh, like the Wave widgets step:
 #     it never fails setup.sh.
 #
+# Guarantees added by the adversarial review round:
+#   - Refuses (exit 1) before running either shim if any of the four install
+#     targets already exists as a symlink, as anything other than a regular
+#     file (e.g. a directory), or is not writable -- or if its bin dir exists
+#     and is not writable. Nothing is installed once any one target fails
+#     this check (closes D1, D2, most of D4).
+#   - Refuses (exit 2) if the pin file itself is missing, if a file this
+#     script or either shim needs is missing, or if a file the shims would
+#     install has no row in the pin's own `list` output -- so a row removed
+#     the documented way (`apply --remove`) is caught here, before either
+#     shim could fall back to fetching that file over the network (D3).
+#   - For the duration of both installer runs, OPENREPOSHAPE_REPO/_REF and
+#     OPENREPOTOOLS_REPO/_REF are overridden to a sentinel that cannot
+#     resolve, so that IF a fetch is ever attempted despite the checks
+#     above, it fails loudly naming the sentinel rather than silently
+#     succeeding against whatever the operator's shell happened to export
+#     (D3, defense in depth).
+#   - After both installers exit 0, every one of the four placed files is
+#     re-checked: a regular, non-symlink file, mode exactly 0755, and
+#     `cmp`-identical to its vendored copy. Only then does this script
+#     report success (D1/D2/D3/D4 residue, closed in one place).
+#
 # Set WORKBENCHES_SKIP_ESTATE_COMMANDS=1 to skip this step entirely (prints
 # one line, exits 0).
 #
 # WORKBENCHES_BASE_IMAGE_DIR overrides the base-image directory this script
 # reads the pin, the checker and the vendored shims from (default:
 # "<repo root>/devBenches/base-image"). This exists for the test suite's
-# corruption scenario only -- point it at a throwaway copy of base-image to
+# corruption scenarios only -- point it at a throwaway copy of base-image to
 # prove a corrupted vendor copy refuses to install; there is no reason to
 # set it on a real host.
 #
-# Exit codes when run directly: 0 ok; 1 refused (update-upstream.py check
-# found drift, so NOTHING was installed, or one of the two installers itself
-# failed); 2 tooling missing (no python3, or a file this script needs is
-# missing). setup.sh runs this under `log_header "ESTATE COMMANDS"` and
-# treats any non-zero exit here as best-effort, continuing either way; this
-# script is also safe to run directly, any time.
+# Exit codes when run directly: 0 ok; 1 refused (a target is a symlink, a
+# non-regular file, or not writable; update-upstream.py check found drift;
+# one of the two installers itself failed; or a placed file failed
+# verification after install); 2 tooling or configuration missing (no
+# python3; the pin file, update-upstream.py, or a file either shim needs is
+# missing; a file the shims would install has no row in the pin; or
+# update-upstream.py check itself refused structurally). setup.sh runs this
+# under `log_header "ESTATE COMMANDS"` and treats any non-zero exit here as
+# best-effort, continuing either way; this script is also safe to run
+# directly, any time.
 
 set -euo pipefail
 
@@ -57,11 +88,20 @@ if ! command -v python3 >/dev/null 2>&1; then
 fi
 
 UPDATE_UPSTREAM="$BASE_IMAGE_DIR/update-upstream.py"
+PIN_FILE="$BASE_IMAGE_DIR/upstream-pin.yaml"
 SHAPE_SHIM="$BASE_IMAGE_DIR/files/openreposhape/openRepoShape"
 TOOLS_SHIM="$BASE_IMAGE_DIR/files/openrepotools/openRepoTools"
+PARK_FILE="$BASE_IMAGE_DIR/files/openrepotools/park"
+RESUME_FILE="$BASE_IMAGE_DIR/files/openrepotools/resume"
+
+if [ ! -f "$PIN_FILE" ]; then
+    echo "Estate command install refused: the pin file is missing or" >&2
+    echo "unreadable: $PIN_FILE. Nothing was installed." >&2
+    exit 2
+fi
 
 missing=""
-for f in "$UPDATE_UPSTREAM" "$SHAPE_SHIM" "$TOOLS_SHIM"; do
+for f in "$UPDATE_UPSTREAM" "$SHAPE_SHIM" "$TOOLS_SHIM" "$PARK_FILE" "$RESUME_FILE"; do
     if [ ! -f "$f" ]; then
         missing="${missing:+$missing }$f"
     fi
@@ -72,30 +112,46 @@ if [ -n "$missing" ]; then
     exit 2
 fi
 
-# Ruling 3 (drift refuses): the checker runs BEFORE anything is placed. A
-# non-zero exit means the vendored bytes are not the pinned bytes, and this
-# script installs NOTHING rather than spread a local edit that the pin
-# exists to forbid. Its own stdout/stderr stream through unchanged above.
-if ! python3 "$UPDATE_UPSTREAM" check; then
+# Ruling 3 (drift refuses): the checker runs BEFORE anything is placed. Its
+# own stdout/stderr stream through unchanged above. Its exit code decides
+# which of two different refusals this is:
+#   1 -- a vendored copy no longer matches its pinned row (drift);
+#   anything else nonzero -- the pin itself could not be read or validated
+#   (a structural refusal, e.g. malformed YAML) -- a different failure than
+#   drift, and it gets a different exit code from this script too.
+check_status=0
+python3 "$UPDATE_UPSTREAM" check || check_status=$?
+
+if [ "$check_status" -eq 1 ]; then
     echo "" >&2
     echo "Estate command install refused: the vendored copies do not match" >&2
-    echo "$BASE_IMAGE_DIR/upstream-pin.yaml (see the finding above). NOTHING" >&2
-    echo "was installed, because the vendored bytes are not the pinned bytes." >&2
+    echo "$PIN_FILE (see the finding above). NOTHING was installed, because" >&2
+    echo "the vendored bytes are not the pinned bytes." >&2
     exit 1
+elif [ "$check_status" -ne 0 ]; then
+    echo "" >&2
+    echo "Estate command install refused: the pin is unreadable or was" >&2
+    echo "refused structurally (see '$UPDATE_UPSTREAM check' above, exit" >&2
+    echo "$check_status). Nothing was installed." >&2
+    exit 2
 fi
 
 # Ruling 1 ("version" means the pin): read the two pinned commits from
 # `update-upstream.py list`, which prints each source's id, then its
 # attributes (including "commit") in a stable, parseable form -- never from
-# a version string, because neither shim's `--version` carries one.
+# a version string, because neither shim's `--version` carries one. Read
+# once into a variable, then parsed from there with a here-string, not a
+# pipeline: a pipeline into a command that exits early (an awk `exit`) can
+# be sent SIGPIPE against a still-writing producer under `pipefail`, and a
+# here-string has no live producer process to receive one.
 if ! list_output="$(python3 "$UPDATE_UPSTREAM" list)"; then
     echo "Estate command install refused: '$UPDATE_UPSTREAM list' failed" >&2
     echo "unexpectedly, right after 'check' passed. Nothing was installed." >&2
     exit 1
 fi
 
-shape_commit="$(printf '%s\n' "$list_output" | awk '/^openreposhape$/{f=1;next} f&&/^  commit /{print $2;exit}')"
-tools_commit="$(printf '%s\n' "$list_output" | awk '/^openrepotools$/{f=1;next} f&&/^  commit /{print $2;exit}')"
+shape_commit="$(awk '/^openreposhape$/{f=1;next} f&&/^  commit /{print $2;exit}' <<<"$list_output")"
+tools_commit="$(awk '/^openrepotools$/{f=1;next} f&&/^  commit /{print $2;exit}' <<<"$list_output")"
 
 if [ -z "$shape_commit" ] || [ -z "$tools_commit" ]; then
     echo "Estate command install refused: could not read the pinned commits" >&2
@@ -103,8 +159,81 @@ if [ -z "$shape_commit" ] || [ -z "$tools_commit" ]; then
     exit 1
 fi
 
+# D3, closed a second way: a file either shim would install must also have
+# a row in the pin's own listing, not just exist on disk -- so a row
+# dropped the documented way (`apply --remove`, which deletes the row AND
+# the file together) is refused here explicitly, naming the file, rather
+# than ever reaching a shim that would fall back to fetching it over the
+# network.
+require_pin_row() {
+    local path="$1"
+    if ! grep -Eq "^    [0-9a-f]{12}  ${path}\$" <<<"$list_output"; then
+        echo "Estate command install refused: '$path' has no row in" >&2
+        echo "'$UPDATE_UPSTREAM list' output; it is not a pinned file." >&2
+        echo "Nothing was installed." >&2
+        exit 2
+    fi
+}
+require_pin_row "openRepoShape"
+require_pin_row "openRepoTools"
+require_pin_row "park"
+require_pin_row "resume"
+
 echo "openRepoShape pinned at $shape_commit"
 echo "openRepoTools pinned at $tools_commit"
+
+shape_bin_dir="${OPENREPOSHAPE_BIN_DIR:-$HOME/.local/bin}"
+tools_bin_dir="${OPENREPOTOOLS_BIN_DIR:-$HOME/.local/bin}"
+
+refuse_preflight() {
+    echo "Estate command install refused: $1" >&2
+    echo "Nothing was installed." >&2
+    exit 1
+}
+
+refuse_postverify() {
+    echo "Estate command install refused: $1" >&2
+    echo "One or more of the four commands may now be in a mixed state;" >&2
+    echo "fix the problem above and re-run this script." >&2
+    exit 1
+}
+
+# D1/D2/most of D4: every target either shim is about to write to is
+# checked BEFORE either of them runs, so a bad target refuses before
+# anything at all is placed -- never after only some of the four are done.
+check_target_preflight() {
+    local target="$1" dir="$2"
+    if [ -L "$target" ]; then
+        refuse_preflight "$target is a symlink; refusing to write through it into whatever it points at."
+    fi
+    if [ -e "$target" ] && [ ! -f "$target" ]; then
+        refuse_preflight "$target exists and is not a regular file (a directory, device, or similar)."
+    fi
+    if [ -e "$target" ] && [ ! -w "$target" ]; then
+        refuse_preflight "$target exists and is not writable."
+    fi
+    if [ -d "$dir" ] && [ ! -w "$dir" ]; then
+        refuse_preflight "$dir exists and is not writable, so $target could not be placed."
+    fi
+}
+
+check_target_preflight "$shape_bin_dir/openRepoShape" "$shape_bin_dir"
+check_target_preflight "$tools_bin_dir/openRepoTools" "$tools_bin_dir"
+check_target_preflight "$tools_bin_dir/park" "$tools_bin_dir"
+check_target_preflight "$tools_bin_dir/resume" "$tools_bin_dir"
+
+# D3, defense in depth: every file the checks above proved is present and
+# pinned is about to be installed with no fetch ever reachable, because
+# neither shim's `collect_commands` falls back to the network for a file
+# already beside it. If that ever stopped being true -- a future change, a
+# race -- these four must resolve to nothing real, so a fetch this sentinel
+# can never satisfy fails loudly, naming it, instead of quietly succeeding
+# against whichever ref/repo the operator's own shell happened to export.
+ESTATE_SENTINEL="pinned-by-workBenches-no-fetch"
+export OPENREPOSHAPE_REPO="$ESTATE_SENTINEL"
+export OPENREPOSHAPE_REF="$ESTATE_SENTINEL"
+export OPENREPOTOOLS_REPO="$ESTATE_SENTINEL"
+export OPENREPOTOOLS_REF="$ESTATE_SENTINEL"
 
 # Ruling 2 (the host follows the pin, both ways): each shim, invoked as a
 # FILE, installs its own bytes (and openRepoTools copies park and resume
@@ -122,22 +251,34 @@ if ! "$TOOLS_SHIM" --install; then
     exit 1
 fi
 
-# Each shim already warns on its own bin dir; this is a second, de-duplicated
-# pass over both effective bin dirs, in case they differ. Names the
-# directory only -- PATH and rc files are never touched here.
-shape_bin_dir="${OPENREPOSHAPE_BIN_DIR:-$HOME/.local/bin}"
-tools_bin_dir="${OPENREPOTOOLS_BIN_DIR:-$HOME/.local/bin}"
+# Post-install verification: D1/D2/D3/D4 residue, closed in one place. Both
+# shims reported success above, but `cp` can write through a symlink or into
+# a directory without either shim noticing -- so every placed file is
+# re-checked against the vendored copy it was supposed to become, and only
+# once all four pass does this script report success itself.
+file_mode_octal() {
+    stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null
+}
 
-seen=""
-for dir in "$shape_bin_dir" "$tools_bin_dir"; do
-    case " $seen " in
-        *" $dir "*) continue ;;
-    esac
-    seen="$seen $dir"
-    case ":${PATH:-}:" in
-        *":$dir:"*) ;;
-        *) echo "Warning: $dir is not on \$PATH. Add it, e.g.: export PATH=\"$dir:\$PATH\"" ;;
-    esac
-done
+verify_installed() {
+    local target="$1" vendor="$2" mode
+    if [ -L "$target" ] || [ ! -f "$target" ]; then
+        refuse_postverify "$target is not a regular file after install."
+    fi
+    mode="$(file_mode_octal "$target")"
+    if [ "$mode" != "755" ]; then
+        refuse_postverify "$target has mode ${mode:-unknown} after install, expected 755."
+    fi
+    if ! cmp -s "$target" "$vendor"; then
+        refuse_postverify "$target does not match its vendored copy ($vendor) after install."
+    fi
+}
+
+verify_installed "$shape_bin_dir/openRepoShape" "$SHAPE_SHIM"
+verify_installed "$tools_bin_dir/openRepoTools" "$TOOLS_SHIM"
+verify_installed "$tools_bin_dir/park" "$PARK_FILE"
+verify_installed "$tools_bin_dir/resume" "$RESUME_FILE"
+
+echo "Estate commands verified against the vendored pin."
 
 exit 0

--- a/setup.sh
+++ b/setup.sh
@@ -176,6 +176,16 @@ if [ -x "${SCRIPT_DIR}/scripts/setup-shell.sh" ]; then
     echo ""
 fi
 
+# Estate commands (openRepoShape, openRepoTools, park, resume) come from
+# workBenches' own vendored pin and are placed by their own installers; see
+# scripts/setup-estate-commands.sh. Best-effort, like the other host-user
+# steps here: it never fails setup.sh. WORKBENCHES_SKIP_ESTATE_COMMANDS=1 skips it.
+log_header "ESTATE COMMANDS"
+if [ -x "${SCRIPT_DIR}/scripts/setup-estate-commands.sh" ]; then
+    "${SCRIPT_DIR}/scripts/setup-estate-commands.sh" || echo "⚠ Estate command install skipped or failed; continuing workBenches setup."
+    echo ""
+fi
+
 # Claude workflow setup is host-user state. The benches bind-mount ~/.claude, so
 # seed it before any container build without overwriting existing user workflows.
 log_header "CLAUDE WORKFLOW SETUP"


### PR DESCRIPTION
Lane: xfactory-2 (xFactory-2)
Claim: https://github.com/opensoft/workBenches/issues/37#issuecomment-5625482029
Governing issue: #37

## What this does

Adds `scripts/setup-estate-commands.sh`, which installs `openRepoShape`, `openRepoTools`, `park` and `resume` on the host from workBenches' own vendored pin (`devBenches/base-image/upstream-pin.yaml`). It runs `update-upstream.py check` first; only if that passes does it print the two pinned commits and run the two vendored shims' own `--install`, invoked as files so each places its own bytes (and `openRepoTools` copies `park`/`resume` from beside itself) with no network and no version logic of this script's own. `setup.sh` calls it under a new `log_header "ESTATE COMMANDS"` block, after shell setup and before the interactive selector, best-effort like the Wave widgets step (`WORKBENCHES_SKIP_ESTATE_COMMANDS=1` skips it; any failure here is caught and setup continues). The regression test is wired into `.github/workflows/speckit-git-bash.yml` immediately after the existing pin-check step. A paragraph under `## setup.sh Flow`, plus a sentence under `### Re-running setup.sh`, documents the mechanism in the README.

**Review round:** an adversarial review found and named six reproducible defects, D1-D6; all six are fixed in `a4bdbe8`, entirely inside the script, its test, and the README — the vendored shims are untouched (ruling 4).

## The four rulings, and where each lives in the diff

1. **"Version" means the pin, not a number.** Reads the two pinned commits from `update-upstream.py list` (a stable, parseable form) and prints `openRepoShape pinned at <40hex>` / `openRepoTools pinned at <40hex>`. Neither shim gains a `--version` change.
2. **The host follows the pin, both ways.** Invokes both shims' `--install` unchanged, relaying their own per-file `already installed ... (unchanged)` / `updated` / `installed` verbs. `setup.sh`'s new block is default-on and best-effort, matching the Wave widgets pattern.
3. **Drift refuses.** `update-upstream.py check` runs before anything is placed; its exit code is now read precisely: 1 (drift) prints the existing refusal and exits 1; any other non-zero (a structural pin refusal) gets its own message and exits 2 (fix for D5).
4. **Nothing upstream changes.** No commit to openRepoShape/openRepoTools, and this diff does not touch the Dockerfile, `upstream-pin.yaml`, `files/`, or `files/speckit-worktree/`.

## Guarantees added by the review round (D1-D6)

- **D1 (symlinked target)** — the shim's `cp` wrote through a symlinked `park`, silently editing another repository. **Fixed:** pre-flight refuses (exit 1) before either shim runs if any of the four targets is a symlink, naming it.
- **D2 (directory-named target)** — `cp` copied *into* a directory standing in for a target, reporting success while installing nothing. **Fixed:** pre-flight refuses if a target exists and is not a regular file.
- **D3 (unpinned bytes reported as the pin)** — removing a pin row the documented way (`apply --remove`, which deletes the row and the file together) let `check` pass while the shim silently fetched the missing file from the network at `$*_REF`/`$*_REPO`. **Fixed two ways:** (a) pre-flight now also requires the pin file to exist, every file either shim needs to be present on disk, and every file the shims would install to have a row in `update-upstream.py list`'s own output — refusing (exit 2) and naming the file before any shim could reach for the network; (b) for defense in depth, `OPENREPOSHAPE_REPO`/`_REF` and `OPENREPOTOOLS_REPO`/`_REF` are overridden to a sentinel (`pinned-by-workBenches-no-fetch`) that cannot resolve, for the duration of both installer runs, so a fetch that ever became reachable despite (a) fails loudly naming the sentinel instead of silently succeeding against the operator's own exported environment.
- **D4 (partial installs, two independent transactions)** — a read-only pre-existing `park` let `openRepoShape`/`openRepoTools` install before the second shim failed partway through its own three-file loop, leaving a mismatched trio. **Fixed:** the same pre-flight checks all four targets (existence, symlink, regular-file, writability, and bin-dir writability) before *either* shim runs, so a bad target refuses before anything at all is placed.
- **D5 (`check` exit 2 misreported as drift)** — see ruling 3 above; the pin file's own existence is also now checked explicitly before `check` even runs.
- **D6 (hygiene)** — removed this script's own third "not on `$PATH`" line (both shims already print their own) and the `seen`-dedupe it needed; switched both `list`-output parses from a `printf | awk '{exit}'` pipeline to a here-string, so there is no live producer process an early `awk exit` could ever send SIGPIPE under `pipefail` if the output ever grew.

After both installers exit 0, all four placed files are independently re-verified — regular, non-symlink, mode exactly 0755, `cmp`-identical to the vendored copy — and only then does the script report `Estate commands verified against the vendored pin.` (closes D1-D4 residue in one place).

## Tests

`devcontainer.test/test-setup-estate-commands.sh`, **76 assertions, all green**:
```
GREEN: setup-estate-commands regression test passed
```
Original (a)-(e) unchanged in behavior (scenario (a) now also asserts exactly two PATH warnings — one per shim, not a third from this script). New:
- **(g) [D1]** `park` a symlink into another temp dir → exit 1, refusal names it, the link target's bytes and the rest of the bin dir untouched.
- **(h) [D2]** `park` a directory → exit 1, refusal, nothing copied into it.
- **(i) [D4 guard]** pre-seeded read-only `park` (0444) → exit 1 *before* `openRepoShape`/`openRepoTools`/`resume` are placed.
- **(j)** a base-image copy with `upstream-pin.yaml` deleted → exit 2, "missing", bin dir empty.
- **(k) [D3]** `resume`'s row and vendored file both removed via `apply --remove` (confirmed `check` still passes first) → our pre-flight exits 2 naming `resume`, bin dir empty, no "fetch"/"github" in the output.
- **(l)** every file placed in scenario (a) is mode 0755 (`stat -c %a`).
- **(m)** the sentinel: run with operator-style `*_REF`/`*_REPO` values set → still exit 0, unchanged install, neither operator value reaches the output. Since neither shim echoes `$REPO`/`$REF` on the happy path (only on `--version` or inside an unreachable fetch-failure message), a live grep-for-zero-occurrences can't by itself distinguish "overridden" from "never consulted" — so this scenario also asserts, by reading the script's own source, that all four `export …="$ESTATE_SENTINEL"` lines are present, per the reviewer's own fallback ("assert instead by a method you can justify, or drop (m) and say so").

`devcontainer.test/test.sh` is a Layer 0 *container* harness (registers only 3 of its 10 sibling `test-*.sh` files, as in-container helpers) — not a general runner list. `test-ai-cli-install-summary.sh`, host-side like this one, is already unregistered there, so this test follows that precedent and is not added to it; it is wired into CI directly.

Also: `bash -n` clean on both scripts and `setup.sh`; `python3 devBenches/base-image/update-upstream.py check` exits 0 on this branch; `git diff --stat origin/main...HEAD` still touches exactly the same 5 files. `shellcheck` is not on this machine's PATH.

## CI-driven follow-up (`fef6916`)

The first push of the fix round (`a4bdbe8`) failed CI's `regression` job: scenario (k)'s setup ran `update-upstream.py apply --source openrepotools --remove resume --yes`, unguarded, inside this `set -euo pipefail` test. `apply` calls `gh api` to prove the target commit is reachable from openRepoTools' default branch; that CI job has no `GH_TOKEN`, so `gh api` failed, `apply` exited 2 on its own Refusal, and the unguarded call took the whole test down with it (exit 2, no PASS/FAIL for the scenario). The reviewer's own instruction for (k) was already "edit the copied pin file by hand to drop the three `resume` lines, delete the copied file" — switched to exactly that (a small python3 edit + `rm`), which is both truer to the instruction and removes the network dependency entirely, rather than adding an unguarded network call the rest of this offline suite doesn't have. 76/76 green after, confirmed on CI (`fef6916`).

## Eagle pre-check (unchanged from the original PR; not re-run this round)

`openRepoShape` and `resume` identical to vendored; `openRepoTools` and `park` differ (a separate, already-merged PR bumped the pin since — see #39/#38). The real installer has still not been run on this branch; that is left for the acceptance pass after review, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
