### PR TITLE
claude-profile: an opt-in --lane hands the final Claude launch to lane-start

### DIFF
--- a/base-image/files/claude-profile
+++ b/base-image/files/claude-profile
@@ -150,6 +150,13 @@ start_profile_tmux() {
   local profile="$1"
   shift
   local launcher session_name command_string="" argument
+  local -a env_prefix
+  env_prefix=(env WORKBENCHES_CLAUDE_TMUX_CHILD=1)
+  # --lane/CLAUDE_LANE must survive this re-exec into a new tmux session.
+  # tmux does not reliably hand a freshly-exported variable to a new session
+  # on an already-running server, so it is threaded through explicitly here
+  # rather than relied on via inheritance — same idiom as the guard above.
+  [[ -n "${lane:-}" ]] && env_prefix+=("CLAUDE_LANE=$lane")
 
   command -v tmux >/dev/null 2>&1 || {
     echo "pclaude: tmux is required for interactive profile launches." >&2
@@ -157,7 +164,7 @@ start_profile_tmux() {
   }
   launcher="$(readlink -f "${BASH_SOURCE[0]}")"
   session_name="claude-${profile//[^a-zA-Z0-9_-]/-}-$(date +%Y%m%d%H%M%S)-$$"
-  for argument in env WORKBENCHES_CLAUDE_TMUX_CHILD=1 "$launcher" run "$profile" "$@"; do
+  for argument in "${env_prefix[@]}" "$launcher" run "$profile" "$@"; do
     printf -v argument '%q' "$argument"
     command_string+="${command_string:+ }$argument"
   done
@@ -244,6 +251,50 @@ profile_metadata() {
   return 1
 }
 
+# --lane / CLAUDE_LANE (opt-in, default off): hand the final Claude launch to
+# `lane-start` instead of exec'ing Claude directly. Recognised only as a
+# leading option, before the action/profile — the first token that is not
+# --lane/--lane=.../-h/--help ends this loop and is left for the existing
+# parsing below, so anything meant for Claude itself (e.g. `claude-profile
+# work --help`) is untouched.
+lane="${CLAUDE_LANE:-}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --lane)
+      [[ $# -ge 2 ]] || { echo "pclaude: --lane needs a value: <repo>-<n>" >&2; exit 2; }
+      lane="$2"; shift 2 ;;
+    --lane=*) lane="${1#--lane=}"; shift ;;
+    -h|--help)
+      cat <<'EOF'
+Usage: claude-profile {list|login|status|run} PROFILE [CLAUDE_ARGS...]
+       pclaude PROFILE [CLAUDE_ARGS...]
+
+Actions:
+  list                 list configured profiles
+  login PROFILE        authenticate a profile
+  status PROFILE       show Claude auth status for a profile
+  run PROFILE [ARGS]   launch Claude under the profile (the default action;
+                        "run" itself may be omitted: claude-profile PROFILE)
+
+Options:
+  --lane <repo>-<n>    opt-in: hand the final launch to
+                        `lane-start <repo>-<n> -- CLAUDE_ARGS` instead of
+                        exec'ing Claude directly (also settable as
+                        CLAUDE_LANE=<repo>-<n> in the environment).
+                        lane-start renames the tmux window to the lane,
+                        records the lane register row, and starts Claude
+                        with --resume/--name <lane> under this same profile.
+                        Requires lane-start on PATH (opensoft/brett-wip,
+                        lanes/, linked by that repo's scripts/link-estates).
+                        Without --lane/CLAUDE_LANE, behaviour is unchanged.
+  -h, --help           show this help
+EOF
+      exit 0
+      ;;
+    *) break ;;
+  esac
+done
+
 action="${1:-list}"
 if [[ "$action" == "list" || "$action" == "login" || "$action" == "status" || "$action" == "run" ]]; then
   [[ $# -eq 0 ]] || shift
@@ -282,6 +333,13 @@ case "$action" in
       login) CLAUDE_CONFIG_DIR="$config_dir" "$claude_bin" auth login --claudeai --email "$email" "$@" ;;
       status) CLAUDE_CONFIG_DIR="$config_dir" "$claude_bin" auth status "${@---text}" ;;
       run)
+        if [[ -n "${lane:-}" ]]; then
+          command -v lane-start >/dev/null 2>&1 || {
+            echo "pclaude: --lane $lane needs lane-start on PATH. Fix:" >&2
+            echo "  git clone git@github.com:opensoft/brett-wip.git ~/projects/brett-wip && ~/projects/brett-wip/scripts/link-estates" >&2
+            exit 2
+          }
+        fi
         if claude_run_is_interactive "$@"; then
           start_profile_tmux "$profile" "$@"
         fi
@@ -317,6 +375,13 @@ case "$action" in
           "$mcp_sync" remove "$family" "$3"
           "$mcp_sync" sync-claude-profile "$family" "$config_dir/.claude.json"
           exit 0
+        fi
+        if [[ -n "${lane:-}" ]]; then
+          CLAUDE_CONFIG_DIR="$config_dir" CLAUDE_BIN="$claude_bin" exec lane-start "$lane" -- \
+            --allow-dangerously-skip-permissions \
+            --dangerously-skip-permissions \
+            --permission-mode bypassPermissions \
+            "$@"
         fi
         CLAUDE_CONFIG_DIR="$config_dir" exec "$claude_bin" \
           --allow-dangerously-skip-permissions \

--- a/devcontainer.test/test-claude-profile-lane-start.sh
+++ b/devcontainer.test/test-claude-profile-lane-start.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Focused regression tests for claude-profile's opt-in --lane / CLAUDE_LANE
+# hand-off to lane-start (opensoft/brett-wip, lanes/lane-start): without a
+# lane named, the launcher's behaviour must be byte-for-byte unchanged; with
+# one named, the final Claude launch is handed to `lane-start <lane> --
+# <the same claude args>` instead of exec'd directly, with CLAUDE_BIN and
+# CLAUDE_CONFIG_DIR carried over so lane-start starts the same Claude under
+# the same profile.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LAUNCHER="${1:-$REPO_ROOT/base-image/files/claude-profile}"
+
+# This test's own scenarios (a plain terminal with no lane, and a terminal
+# already inside tmux) must not be undermined by ambient lane/tmux state
+# inherited from whatever shell runs the test — including a shell that is
+# itself a claude-profile-launched tmux child (WORKBENCHES_CLAUDE_TMUX_CHILD=1)
+# or already inside some other tmux session (TMUX set to a real socket).
+unset TMUX WORKBENCHES_CLAUDE_TMUX_CHILD WORKBENCHES_TMUX_SESSION WORKBENCHES_TMUX_PANE TMUX_PANE 2>/dev/null || true
+
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+strip_ansi() {
+    sed $'s/\033\[[0-9;]*m//g'
+}
+
+PROFILE_BASE="$TEST_ROOT/profiles-home"
+PROFILE_DIR="$PROFILE_BASE/profiles/opensoft/team/team-002"
+MANIFEST="$TEST_ROOT/claude-profiles.json"
+FAKE_BIN="$TEST_ROOT/bin"
+FAKE_CLAUDE="$FAKE_BIN/claude"
+FAKE_CLAUDE_LOG="$TEST_ROOT/claude.log"
+FAKE_TMUX_LOG="$TEST_ROOT/tmux.log"
+FAKE_LANE_START="$FAKE_BIN/lane-start"
+FAKE_LANE_START_LOG="$TEST_ROOT/lane-start.log"
+FAKE_LANE_START_ENV="$TEST_ROOT/lane-start.env"
+mkdir -p "$PROFILE_DIR" "$FAKE_BIN"
+
+printf '%s\n' \
+    '{"profiles":[{"name":"team-002","email":"test@example.invalid","family":"testing","aliases":["team002"],"profilePath":"opensoft/team/team-002"}]}' \
+    > "$MANIFEST"
+printf '%s\n' '{"name":"team-002","family":"testing","email":"test@example.invalid","aliases":["team002"]}' \
+    > "$PROFILE_DIR/.profile.json"
+
+cat > "$FAKE_CLAUDE" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > "${FAKE_CLAUDE_LOG:?}"
+EOF
+chmod +x "$FAKE_CLAUDE"
+
+cat > "$FAKE_BIN/tmux" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${FAKE_TMUX_LOG:?}"
+case "${1:-}" in
+    display-message) printf 'fake\n' ;;
+esac
+EOF
+chmod +x "$FAKE_BIN/tmux"
+
+cat > "$FAKE_LANE_START" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > "${FAKE_LANE_START_LOG:?}"
+{
+    printf 'CLAUDE_BIN=%s\n' "${CLAUDE_BIN:-}"
+    printf 'CLAUDE_CONFIG_DIR=%s\n' "${CLAUDE_CONFIG_DIR:-}"
+} > "${FAKE_LANE_START_ENV:?}"
+EOF
+chmod +x "$FAKE_LANE_START"
+
+# --lane's realistic case is a terminal already inside tmux (a lane is always
+# started from an existing tmux window; lane-start itself refuses otherwise),
+# which is also the simplest to simulate: TMUX set means claude_run_is_interactive
+# is false, so the launcher does not try to wrap a NEW tmux session around it.
+common_env=(
+    "PATH=$FAKE_BIN:$PATH"
+    "CLAUDE_BIN=$FAKE_CLAUDE"
+    "CLAUDE_PROFILES_HOME=$PROFILE_BASE"
+    "CLAUDE_PROFILES_MANIFEST=$MANIFEST"
+    "FAKE_CLAUDE_LOG=$FAKE_CLAUDE_LOG"
+    "FAKE_TMUX_LOG=$FAKE_TMUX_LOG"
+    "FAKE_LANE_START_LOG=$FAKE_LANE_START_LOG"
+    "FAKE_LANE_START_ENV=$FAKE_LANE_START_ENV"
+    "WORKBENCHES_SHARED_MCP_FAMILIES=disabled"
+    "TMUX=fake-session"
+)
+
+expected_claude_args='--allow-dangerously-skip-permissions --dangerously-skip-permissions --permission-mode bypassPermissions'
+
+# ---------------------------------------------------------------------------
+# 0. --help documents --lane / CLAUDE_LANE (the Land proof's own command).
+env "${common_env[@]}" "$LAUNCHER" --help > "$TEST_ROOT/help.out"
+grep -q -- '--lane' "$TEST_ROOT/help.out" || fail "--help does not document --lane"
+grep -q 'CLAUDE_LANE' "$TEST_ROOT/help.out" || fail "--help does not document CLAUDE_LANE"
+grep -q 'lane-start' "$TEST_ROOT/help.out" || fail "--help does not mention lane-start"
+
+# ---------------------------------------------------------------------------
+# 1. No --lane, no CLAUDE_LANE: behaviour is the plain, direct Claude exec —
+# lane-start is never invoked, and Claude receives exactly the same args.
+env "${common_env[@]}" "$LAUNCHER" run team002 --resume session-1 >/dev/null
+grep -Fxq -- "$expected_claude_args --resume session-1" "$FAKE_CLAUDE_LOG" \
+    || fail "baseline: claude args did not arrive unchanged ($(cat "$FAKE_CLAUDE_LOG" 2>/dev/null))"
+[[ ! -e "$FAKE_LANE_START_LOG" ]] \
+    || fail "baseline: lane-start was invoked with no --lane/CLAUDE_LANE named"
+rm -f "$FAKE_CLAUDE_LOG"
+
+# ---------------------------------------------------------------------------
+# 2. --lane hands the final launch to lane-start, with CLAUDE_BIN and
+# CLAUDE_CONFIG_DIR set for it, and never touches Claude directly.
+env "${common_env[@]}" "$LAUNCHER" --lane openRepoShape-2 run team002 --resume session-2 >/dev/null
+[[ ! -e "$FAKE_CLAUDE_LOG" ]] \
+    || fail "--lane: Claude was exec'd directly instead of being handed to lane-start"
+[[ -e "$FAKE_LANE_START_LOG" ]] \
+    || fail "--lane: lane-start was never invoked"
+grep -Fxq -- "openRepoShape-2 -- $expected_claude_args --resume session-2" "$FAKE_LANE_START_LOG" \
+    || fail "--lane: lane-start did not receive 'openRepoShape-2 -- <claude args>' ($(cat "$FAKE_LANE_START_LOG"))"
+grep -Fxq "CLAUDE_BIN=$FAKE_CLAUDE" "$FAKE_LANE_START_ENV" \
+    || fail "--lane: lane-start did not see CLAUDE_BIN=$FAKE_CLAUDE ($(cat "$FAKE_LANE_START_ENV"))"
+grep -Fxq "CLAUDE_CONFIG_DIR=$PROFILE_DIR" "$FAKE_LANE_START_ENV" \
+    || fail "--lane: lane-start did not see CLAUDE_CONFIG_DIR=$PROFILE_DIR ($(cat "$FAKE_LANE_START_ENV"))"
+rm -f "$FAKE_LANE_START_LOG" "$FAKE_LANE_START_ENV"
+
+# ---------------------------------------------------------------------------
+# 3. Missing lane-start refuses (exit 2, names the fix) before any tmux
+# session is created — even on the genuinely interactive path (a real pty,
+# no ambient TMUX), where claude_run_is_interactive would otherwise be true
+# and start_profile_tmux would fire.
+NO_LANE_START_BIN="$TEST_ROOT/bin-no-lane-start"
+mkdir -p "$NO_LANE_START_BIN"
+cp "$FAKE_CLAUDE" "$NO_LANE_START_BIN/claude"
+cp "$FAKE_BIN/tmux" "$NO_LANE_START_BIN/tmux"
+NO_LANE_TMUX_LOG="$TEST_ROOT/tmux-no-lane-start.log"
+
+refusal_env=(
+    # A real lane-start may already be installed (e.g. ~/.local/bin on a
+    # workstation that has run brett-wip's scripts/link-estates) — PATH must
+    # exclude it entirely to simulate it being genuinely absent, not just
+    # shadowed. /usr/bin and /bin cover every standard tool the launcher and
+    # the fakes need (jq, mktemp, date, coreutils).
+    "PATH=$NO_LANE_START_BIN:/usr/bin:/bin"
+    "CLAUDE_BIN=$NO_LANE_START_BIN/claude"
+    "CLAUDE_PROFILES_HOME=$PROFILE_BASE"
+    "CLAUDE_PROFILES_MANIFEST=$MANIFEST"
+    "FAKE_CLAUDE_LOG=$TEST_ROOT/claude-no-lane-start.log"
+    "FAKE_TMUX_LOG=$NO_LANE_TMUX_LOG"
+    "WORKBENCHES_SHARED_MCP_FAMILIES=disabled"
+    "CLAUDE_LANE=openRepoShape-2"
+)
+printf -v tty_command 'env'
+for value in "${refusal_env[@]}" "$LAUNCHER" run team002 --resume session-3; do
+    printf -v value '%q' "$value"
+    tty_command+=" $value"
+done
+set +e
+script -qefc "$tty_command" "$TEST_ROOT/typescript-refusal.log" >/dev/null
+refusal_status=$?
+set -e
+[[ "$refusal_status" -eq 2 ]] \
+    || fail "missing lane-start: exit status was $refusal_status, not 2"
+grep -q 'lane-start' "$TEST_ROOT/typescript-refusal.log" \
+    || fail "missing lane-start: refusal did not mention lane-start"
+grep -q 'opensoft/brett-wip' "$TEST_ROOT/typescript-refusal.log" \
+    || fail "missing lane-start: refusal did not name the fix (clone opensoft/brett-wip)"
+grep -q 'link-estates' "$TEST_ROOT/typescript-refusal.log" \
+    || fail "missing lane-start: refusal did not name scripts/link-estates"
+[[ ! -s "$NO_LANE_TMUX_LOG" ]] \
+    || fail "missing lane-start: a tmux command ran before the refusal ($(cat "$NO_LANE_TMUX_LOG"))"
+
+# ---------------------------------------------------------------------------
+# 4. CLAUDE_LANE (env, no --lane flag) works the same as --lane.
+env "${common_env[@]}" CLAUDE_LANE=openRepoShape-2 "$LAUNCHER" run team002 --resume session-4 >/dev/null
+[[ ! -e "$FAKE_CLAUDE_LOG" ]] \
+    || fail "CLAUDE_LANE: Claude was exec'd directly instead of being handed to lane-start"
+grep -Fxq -- "openRepoShape-2 -- $expected_claude_args --resume session-4" "$FAKE_LANE_START_LOG" \
+    || fail "CLAUDE_LANE: lane-start did not receive 'openRepoShape-2 -- <claude args>' ($(cat "$FAKE_LANE_START_LOG"))"
+
+echo "claude-profile lane-start hand-off tests passed"

--- a/docs/claude-multi-account-profiles.md
+++ b/docs/claude-multi-account-profiles.md
@@ -132,6 +132,17 @@ shows `[TMUX] none` instead of silently dropping the field. Set
 commands such as `mcp`, `doctor`, `--help`, `--version`, and `--print` remain
 direct, and a `pclaude` command run inside an existing tmux session reuses it.
 
+Pass `--lane <repo>-<n>` (or set `CLAUDE_LANE=<repo>-<n>` in the environment)
+to hand the launch to `lane-start` instead of exec'ing Claude directly —
+opt-in, and off by default; without it `pclaude`/`claude-profile` behave
+exactly as described above. `lane-start` (from `opensoft/brett-wip`'s
+`lanes/`, put on `PATH` by that repository's `scripts/link-estates`) renames
+the current tmux window to the lane, records the lane in the lane register,
+and starts this same Claude binary under this same profile with
+`--resume`/`--name <lane>` as appropriate. Naming a lane while `lane-start`
+is not on `PATH` refuses with the fix instead of launching an unnamed
+session. See `claude-profile --help` for the exact option.
+
 Profile launches default to
 `xhigh` effort and always start Claude with `bypassPermissions` plus
 `--dangerously-skip-permissions` (the most permissive Claude Code mode). The


### PR DESCRIPTION
Lane: openreposhape-2 (openRepoShape-2)
Claim: https://github.com/opensoft/workBenches/issues/43#issuecomment-5628726609

Closes #43.

## Summary

- `base-image/files/claude-profile` gains an opt-in `--lane <repo>-<n>` (and
  `CLAUDE_LANE` fallback): when named, the `run` action's final
  `exec "$claude_bin" …` becomes `exec lane-start "$lane" -- <the same claude
  args>`, with `CLAUDE_BIN`/`CLAUDE_CONFIG_DIR` exported so `lane-start`
  starts the same Claude under the same profile.
- With no `--lane`/`CLAUDE_LANE`, behaviour is unchanged — verified
  byte-for-byte (Claude's argv and every tmux call identical to the
  pre-change script under matched inputs).
- A named lane whose `lane-start` is not on `PATH` refuses (exit 2, names the
  `opensoft/brett-wip` clone + `scripts/link-estates` fix) before
  `claude_run_is_interactive`/`start_profile_tmux` ever run, so no tmux
  session is created first.
- The interactive auto-tmux path re-invokes the launcher inside a new
  detached tmux session; `CLAUDE_LANE` is threaded through that
  re-invocation explicitly (not relied on via tmux's environment
  inheritance, which does not reliably hand a freshly-exported variable to a
  new session on an already-running server).
- `--lane`/`-h`/`--help` are recognised only as leading options, before the
  action/profile, so anything after the profile name still reaches Claude
  untouched (e.g. `claude-profile work --help` still shows Claude's help).

## Test plan

- [x] New `devcontainer.test/test-claude-profile-lane-start.sh` (fake tmux,
      `lane-start`, `claude` on `PATH`): `--help` documents `--lane`/
      `CLAUDE_LANE`; no lane leaves `lane-start` uninvoked and Claude's args
      unchanged; `--lane` hands off with `CLAUDE_BIN`/`CLAUDE_CONFIG_DIR`
      set; a missing `lane-start` refuses before any tmux command runs;
      `CLAUDE_LANE` (env, no flag) behaves the same as `--lane`.
- [x] Existing launcher regression tests re-run against the patched script:
      `test-claude-tmux-statusline.sh`, `test-claude-profile-preserves-model.sh`,
      `test-shared-mcp-profiles.sh` — all pass.
- [x] `devBenches/devcontainer.test/test-openspeckit-bootstrap.sh` (742
      pass), `test-speckit-git-feature.sh` (56 pass), `test-speckit-git-compat.sh`
      (22 pass), `test-ct-launchers.sh` (exit 0) — unaffected, all green.
- [x] `bash base-image/files/claude-profile --help | grep -n lane` shows the
      new option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable optional Claude profile launches to hand off named sessions to lane-start without changing the default launch behavior.

New Features:
- Add opt-in lane handoff support to claude-profile through --lane and CLAUDE_LANE, delegating named launches to lane-start while preserving the selected Claude profile and arguments.

Bug Fixes:
- Prevent named lane launches from creating tmux sessions when lane-start is unavailable, and provide guidance for installing it.

Enhancements:
- Preserve existing launcher behavior when no lane is specified and explicitly propagate lane configuration through interactive tmux re-invocations.

Documentation:
- Document lane-based Claude launches, prerequisites, fallback configuration, and behavior when lane-start is unavailable.

Tests:
- Add regression coverage for help output, unchanged no-lane launches, flag and environment-based handoff, argument and profile preservation, and early failure without lane-start.