### PR TITLE
devBenches/base-image: re-vendor openRepoShape at 90e30ff — docs/cli.md landed upstream, no vendored byte changes

### DIFF
--- a/devBenches/base-image/upstream-pin.yaml
+++ b/devBenches/base-image/upstream-pin.yaml
@@ -43,7 +43,7 @@ sources:
     source_repository: opensoft/openRepoShape
     materialization: copied
     revision_kind: commit
-    commit: "3d46ab590351797f7570946aab422a940b44fded"
+    commit: "90e30ff6ae5f229a00985fe7e3f20db047230ce7"
     vendor_dir: files/openreposhape
     files:
       - path: openRepoShape


### PR DESCRIPTION
Lane: openreposhape-2 (openRepoShape-2)
Claim: https://github.com/opensoft/workBenches/issues/45#issuecomment-5628964993

Closes #45.

**What lands.** `devBenches/base-image/upstream-pin.yaml`'s `openreposhape` source moves from `3d46ab590351797f7570946aab422a940b44fded` (pinned in #41, carried by #42) to `90e30ff6ae5f229a00985fe7e3f20db047230ce7` — `gh api repos/opensoft/openRepoShape/compare/main...90e30ff6ae5f229a00985fe7e3f20db047230ce7 -q .status` says `identical`, so it is the commit `main` carries (PR opensoft/openRepoShape#98, merged as this exact sha, closing opensoft/openRepoShape#97). **The tool does not change** — one `apply` run and nothing else.

**Upstream, between the two commits (opensoft/openRepoShape#98, one commit on `main`):**

- `docs/cli.md` — every shipped tool's `--help` and every subcommand's, in one file for an agent, GENERATED by the new `scripts/render-cli-reference.py`.
- `tests/test_cli_reference.py` (8 tests) plus additions to `tests/test_repo_hygiene.py` keep the generated file honest — a drift test fails when the committed file no longer matches a fresh render.
- `AGENTS.md` (+8 lines) and `README.md` (+6/-1) point at the new reference; `docs/handbook.html` is re-cut for the README change.
- None of the changed files are `openRepoShape` or `templates/assembly-root/project.yaml` — the two files this repository vendors. Confirmed from a run, not from reasoning: `gh api repos/opensoft/openRepoShape/compare/3d46ab590351797f7570946aab422a940b44fded...90e30ff6ae5f229a00985fe7e3f20db047230ce7 -q '.files[].filename'` lists only `AGENTS.md`, `README.md`, `docs/cli.md`, `docs/handbook.html`, `scripts/render-cli-reference.py`, `tests/test_cli_reference.py`, `tests/test_repo_hygiene.py` — no vendored path among them.

**The `apply` run, verbatim:**

```
$ python3 devBenches/base-image/update-upstream.py apply --source openreposhape --at 90e30ff6ae5f229a00985fe7e3f20db047230ce7 --yes
source      openreposhape (opensoft/openRepoShape)
pinned      3d46ab590351
target      90e30ff6ae5f (on main)
vendor      files/openreposhape

  unchanged openRepoShape
  unchanged templates/assembly-root/project.yaml
  re-pin    commit 3d46ab590351 -> 90e30ff6ae5f

  wrote     files/openreposhape/openRepoShape  0755
  wrote     files/openreposhape/templates/assembly-root/project.yaml  0644
  re-pinned devBenches/base-image/upstream-pin.yaml  2 row(s) at 90e30ff6ae5f

NEXT  python3 devBenches/base-image/update-upstream.py check
```

Both vendored files come back `unchanged` — the brief's claim proven from a run. Only the pin row's `commit:` moves.

**Proofs, all run on this branch's HEAD.**

| Run | Result |
|---|---|
| `update-upstream.py check` | exit 0, **5** rows across 2 sources (`openreposhape`: `openRepoShape`, `templates/assembly-root/project.yaml`; `openrepotools`: `openRepoTools`, `park`, `resume`) |
| `update-upstream.py list` | exit 0, both sources named with their commits and vendor dirs |
| `devBenches/devcontainer.test/test-speckit-git-feature.sh` | 29/29 GREEN, exit 0 |
| `devcontainer.test/test-setup-estate-commands.sh` | 76/76 GREEN, exit 0 |
| `git diff --stat` | 1 file: `devBenches/base-image/upstream-pin.yaml`, 1 line — no vendored byte anywhere, no tool change, no Dockerfile change |

**Not proven here: the image.** `dev-bench-base` carries the new pin only after its next rebuild — not run in this PR, and moot here since no vendored byte moved. Eagle's host reinstall is unaffected (the installed shim bytes are unchanged) and was already done per Brett Heap's word (2026-09-10: "merge it when green, then re-vendor and reinstall on Eagle").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Re-pin the base image’s openRepoShape dependency to the latest upstream commit while preserving the existing vendored contents.

Enhancements:
- Update the openRepoShape upstream pin to commit 90e30ff without changing the vendored tool files.

Tests:
- Verify upstream pin consistency and existing devBench integration and setup command behavior.