### PR TITLE
devBenches/base-image: re-vendor openRepoShape at 32450eb — shape-doctor.py's platform-aware quoter landed upstream, no vendored byte changes

### DIFF
--- a/devBenches/base-image/upstream-pin.yaml
+++ b/devBenches/base-image/upstream-pin.yaml
@@ -43,7 +43,7 @@ sources:
     source_repository: opensoft/openRepoShape
     materialization: copied
     revision_kind: commit
-    commit: "90e30ff6ae5f229a00985fe7e3f20db047230ce7"
+    commit: "32450eb5c5d18fbb0747dc5ad420cf67742cfa99"
     vendor_dir: files/openreposhape
     files:
       - path: openRepoShape


### PR DESCRIPTION
Lane: openreposhape-2 (openRepoShape-2)
Claim: https://github.com/opensoft/workBenches/issues/49#issuecomment-5634343080

Closes #49.

**What lands.** `devBenches/base-image/upstream-pin.yaml`'s `openreposhape` source moves from `90e30ff6ae5f229a00985fe7e3f20db047230ce7` (pinned in #45, carried by #46) to `32450eb5c5d18fbb0747dc5ad420cf67742cfa99` — `gh api repos/opensoft/openRepoShape/compare/main...32450eb5c5d18fbb0747dc5ad420cf67742cfa99 -q .status` says `identical`, so it is the commit `main` carries (PR opensoft/openRepoShape#102, merged as this exact sha, closing opensoft/openRepoShape#101 — Brett Heap's standing order: "merge when green, pin-only re-vendor in workBenches, reinstall on Eagle"). **The tool does not change** — one `apply` run and nothing else.

**Upstream, between the two commits (two commits on `main` since the last pin, not one — opensoft/openRepoShape#100 and #102):**

- `shape-doctor.py` / `tests/test_shape_doctor.py` — the platform-aware quoter (opensoft/openRepoShape#101/#102): every next-command string `shape-doctor.py` prints is now quoted per-platform (POSIX `sh` vs. PowerShell), so a root or a name with a space or an apostrophe in it is a line that runs.
- `adopt-project.py` / `tests/test_repo_hygiene.py` / `AGENTS.md` / `README.md` / `docs/cli.md` / `docs/handbook.html` — the placement row that landed just before it (opensoft/openRepoShape#99/#100, the `MISPLACED` verdict and `--placement-plan`) and its docs, which passed through `main` without its own re-vendor here because no vendored byte changed then either.
- None of these eight changed paths are `openRepoShape` or `templates/assembly-root/project.yaml` — the two files this repository vendors. Confirmed from a run, not from reasoning: `gh api repos/opensoft/openRepoShape/compare/90e30ff6ae5f229a00985fe7e3f20db047230ce7...32450eb5c5d18fbb0747dc5ad420cf67742cfa99 -q '.files[].filename'` lists only `AGENTS.md`, `README.md`, `adopt-project.py`, `docs/cli.md`, `docs/handbook.html`, `shape-doctor.py`, `tests/test_repo_hygiene.py`, `tests/test_shape_doctor.py` — no vendored path among them.

**The `apply` run, verbatim:**

```
$ python3 devBenches/base-image/update-upstream.py apply --source openreposhape --at 32450eb5c5d18fbb0747dc5ad420cf67742cfa99 --yes
source      openreposhape (opensoft/openRepoShape)
pinned      90e30ff6ae5f
target      32450eb5c5d1 (on main)
vendor      files/openreposhape

  unchanged openRepoShape
  unchanged templates/assembly-root/project.yaml
  re-pin    commit 90e30ff6ae5f -> 32450eb5c5d1

  wrote     files/openreposhape/openRepoShape  0755
  wrote     files/openreposhape/templates/assembly-root/project.yaml  0644
  re-pinned devBenches/base-image/upstream-pin.yaml  2 row(s) at 32450eb5c5d1

NEXT  python3 devBenches/base-image/update-upstream.py check
```

Both vendored files come back `unchanged` — the brief's claim proven from a run. Only the pin row's `commit:` moves.

**Proofs, all run on this branch's HEAD.**

| Run | Result |
|---|---|
| `update-upstream.py check` | exit 0, **5** vendored copies across 2 sources (`openreposhape`: `openRepoShape`, `templates/assembly-root/project.yaml`; `openrepotools`: `openRepoTools`, `park`, `resume`), all `ok` |
| `git diff --stat` | 1 file: `devBenches/base-image/upstream-pin.yaml`, 1 line — no vendored byte anywhere, no tool change, no Dockerfile change |
| `devBenches/devcontainer.test/test-speckit-git-feature.sh` | 19/19 GREEN, exit 0 |
| `devcontainer.test/test-setup-estate-commands.sh` | 76/76 GREEN, exit 0 |

**Not proven here: the image.** `dev-bench-base` carries the new pin only after its next rebuild — not run in this PR, and moot here since no vendored byte moved. Eagle's host reinstall is unaffected (the installed shim bytes are unchanged) and is done on Brett Heap's standing order on opensoft/openRepoShape#101 ("merge when green, pin-only re-vendor in workBenches, reinstall on Eagle").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Re-pin the openRepoShape dependency to the current upstream commit while preserving the existing vendored content.

Enhancements:
- Update the vendored openRepoShape source pin to commit 32450eb5c5d18fbb0747dc5ad420cf67742cfa99 without changing the vendored files.

Tests:
- Verify all vendored upstream copies and existing devcontainer test suites remain passing after the pin update.