### PR TITLE
devBenches/base-image: re-vendor openRepoTools at f519f31 — `status`, the fourth command, joins park and resume; bare `park` asks before sweeping, `park --all`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ After setup, open any bench in VS Code → "Reopen in Container" to start develo
 
 ### Re-running setup.sh
 
-Safe to run repeatedly. Installed benches show `✓ up to date` and are skipped. Only new selections or missing images trigger builds. The estate commands (`openRepoShape`, `openRepoTools`, `park`, `resume`) are checked against workBenches' pin on every run and are re-placed only when a host copy differs from it.
+Safe to run repeatedly. Installed benches show `✓ up to date` and are skipped. Only new selections or missing images trigger builds. The estate commands (`openRepoShape`, `openRepoTools`, `park`, `resume`, `status`) are checked against workBenches' pin on every run and are re-placed only when a host copy differs from it.
 
 ## Docker Image Layers
 
@@ -82,7 +82,7 @@ setup.sh
   └── Summary + log file path
 ```
 
-Your host's `openRepoShape`, `openRepoTools`, `park` and `resume` commands come from workBenches' own pin (`devBenches/base-image/upstream-pin.yaml`). `setup.sh` places them from the vendored copies in `devBenches/base-image/files/openreposhape/` and `devBenches/base-image/files/openrepotools/`, and re-places them whenever a host copy differs from the pin, in either direction — behind, ahead, or hand-edited. To move them to a new upstream commit, move the pin with `update-upstream.py apply` and re-run `setup.sh`; do not edit the vendored files or the installed commands directly. The step refuses to run over a symlinked, non-regular, or read-only target, and verifies the four placed files against the vendored copies before it reports success. Set `WORKBENCHES_SKIP_ESTATE_COMMANDS=1` to skip this step.
+Your host's `openRepoShape`, `openRepoTools`, `park`, `resume` and `status` commands come from workBenches' own pin (`devBenches/base-image/upstream-pin.yaml`). `setup.sh` places them from the vendored copies in `devBenches/base-image/files/openreposhape/` and `devBenches/base-image/files/openrepotools/`, and re-places them whenever a host copy differs from the pin, in either direction — behind, ahead, or hand-edited. To move them to a new upstream commit, move the pin with `update-upstream.py apply` and re-run `setup.sh`; do not edit the vendored files or the installed commands directly. The step refuses to run over a symlinked, non-regular, or read-only target, and verifies the five placed files against the vendored copies before it reports success. Set `WORKBENCHES_SKIP_ESTATE_COMMANDS=1` to skip this step.
 
 ## Wave Terminal Widgets
 

--- a/devBenches/base-image/Dockerfile
+++ b/devBenches/base-image/Dockerfile
@@ -147,19 +147,21 @@ RUN chmod 0755 /usr/local/bin/speckit-worktree-enable && \
 #
 # TWO SOURCES, ONE DIRECTION. openRepoTools pins openRepoShape (as a submodule
 # in that repository, mounted and verified against the pinned checkout's own
-# scripts/repo_shape.py) because `park` and `resume` are tested against the
-# estate standard they walk. openRepoShape pins nothing of openRepoTools' and
+# scripts/repo_shape.py) because `park`, `resume` and `status` are tested against
+# the estate standard they walk. openRepoShape pins nothing of openRepoTools' and
 # does not know it exists. This image is downstream of both pins and holds a
 # vendored COPY of each, at the commit its own source block in
 # ../upstream-pin.yaml names — that copying does not add a dependency between
 # the two repositories, only two independent commits landing beside each other
 # under /usr/local/bin.
 #
-# `park` and `resume` are vendored from files/openrepotools/
-# (opensoft/openRepoTools), not from files/openreposhape/: they moved there so
-# the estate-resolver they share is reviewed once for the whole estate rather
-# than once per standard. files/openreposhape/ now vendors only the shim
-# (`openRepoShape` itself) and the manifest template below.
+# `park`, `resume` and `status` are vendored from files/openrepotools/
+# (opensoft/openRepoTools), not from files/openreposhape/: the two verbs moved
+# there so the estate-resolver they share is reviewed once for the whole estate
+# rather than once per standard, and `status` — the read-only view of the same
+# estate, which runs nothing — was added there on the same resolver.
+# files/openreposhape/ now vendors only the shim (`openRepoShape` itself) and
+# the manifest template below.
 #
 # files/openreposhape/templates/ is NOT copied. It is a fixture input for
 # devBenches/devcontainer.test/test-speckit-git-feature.sh, which derives its
@@ -184,8 +186,9 @@ COPY files/openreposhape/openRepoShape /usr/local/bin/openRepoShape
 COPY files/openrepotools/openRepoTools /usr/local/bin/openRepoTools
 COPY files/openrepotools/park /usr/local/bin/park
 COPY files/openrepotools/resume /usr/local/bin/resume
+COPY files/openrepotools/status /usr/local/bin/status
 RUN chmod 0755 /usr/local/bin/openRepoShape /usr/local/bin/openRepoTools \
-    /usr/local/bin/park /usr/local/bin/resume
+    /usr/local/bin/park /usr/local/bin/resume /usr/local/bin/status
 
 # ========================================
 # AI META-HARNESS (OMNIGENT)

--- a/devBenches/base-image/files/openrepotools/openRepoTools
+++ b/devBenches/base-image/files/openrepotools/openRepoTools
@@ -11,18 +11,19 @@
 # (or the raw-URL twin, `curl -fsSL …/main/openRepoTools | bash -s -- --install`).
 #
 # IT INSTALLS AND IT DOES NOTHING ELSE. There is no verb here and no scaffold
-# role: `openRepoShape` is the standard's front door and stays there, and the
-# two verbs are `park` and `resume`, which add no mechanics of their own — they
+# role: `openRepoShape` is the standard's front door and stays there. The two
+# verbs are `park` and `resume`, which add no mechanics of their own — they
 # find the estate under your projects directory and run its own `make park` /
-# `make resume`.
+# `make resume` — and `status` is the read-only view of the same estate.
 #
-# `--install` PLACES THREE COMMANDS, not one: this file, `park` and `resume`
-# (openRepoShape #82). One install line for the whole toolset, so a second
-# engineer gets the estate verbs from the README's one line and nothing depends
-# on anyone's dotfiles.
+# `--install` PLACES FOUR COMMANDS, not one: this file, `park`, `resume` and
+# `status` (openRepoShape #82; the fourth under Brett Heap's RULING of
+# 2026-09-10 in this repository, "lets go with a fourth file"). One install
+# line for the whole toolset, so a second engineer gets the estate commands
+# from the README's one line and nothing depends on anyone's dotfiles.
 #
 # openRepoShape #82 wrote the two verbs and these install semantics; its #92
-# carved them out into this repository.
+# carved them out into this repository, which added `status`.
 
 set -euo pipefail
 
@@ -42,23 +43,27 @@ die() { printf '\nREFUSED: %s\n' "$1" >&2; exit "${2:-2}"; }
 
 usage() {
 	cat <<'USAGE'
-openRepoTools --install            install (or update) park, resume and this
-                                   command into ~/.local/bin
+openRepoTools --install            install (or update) park, resume, status and
+                                   this command into ~/.local/bin
 openRepoTools --help | --version
 
 This command installs the estate commands and does nothing else. It has no
 verb of its own: `openRepoShape` is the standard's front door. `--install`
-places three files beside each other — this command and the two verbs:
+places four files beside each other — this command, the two verbs, and the
+read-only view:
 
   park [<Name>]                    commit, push and RECORD an estate's open
                                    features, so another workstation can take
                                    the work up
   resume [<Name>]                  clone or fast-forward that estate here and
                                    recreate those features
+  status [<Name>]                  what is in and out of sync across that
+                                   estate, as of the last fetch; changes nothing
 
-`park --help` and `resume --help` say the rest. Neither implements any of the
-mechanics: they find the estate under your projects directory and run its own
-`make park` / `make resume`, which run the Speckit git extension's scripts.
+`park --help`, `resume --help` and `status --help` say the rest. The verbs
+implement none of the mechanics: they find the estate under your projects
+directory and run its own `make park` / `make resume`, which run the Speckit
+git extension's scripts. `status` only reads.
 
   $OPENREPOTOOLS_REPO       owner/name to fetch from (default opensoft/openRepoTools)
   $OPENREPOTOOLS_REF        the ref to fetch it at   (default main)
@@ -87,10 +92,10 @@ workdir() {
 #
 # THESE FORTY LINES ARE A DELIBERATE COPY of openRepoShape's own shim, and the
 # duplication is the cheaper of the two mistakes: a shared `orp-fetch.sh` would
-# be a FOURTH FILE for `--install` to place, and a broken installer the first
-# time somebody copied only three of them. It is the same argument the estate
-# resolver inside `park` and `resume` already carries, for the same reason —
-# each of these files is one file a person has on PATH. Two installers that
+# be a FIFTH FILE for `--install` to place, and a broken installer the first
+# time somebody copied only some of them. It is the same argument the estate
+# resolver inside `park`, `resume` and `status` already carries, for the same
+# reason — each of these files is one file a person has on PATH. Two installers that
 # fetch the same way is a claim `tests/test_openrepotools_command.py` and
 # openRepoShape's own suite each assert against their own script's text.
 fetch_from_repo() {
@@ -112,26 +117,26 @@ fetch_from_repo() {
 	return 1
 }
 
-# THE THREE COMMANDS `--install` PLACES. One list, so the installer, the fetch
+# THE FOUR COMMANDS `--install` PLACES. One list, so the installer, the fetch
 # fallback and the tests cannot disagree about what a complete install is.
 # `openRepoTools` is first because it is the one a person types to get the
-# other two.
-INSTALLABLES=(openRepoTools park resume)
+# other three.
+INSTALLABLES=(openRepoTools park resume status)
 
-# ALL THREE IN HAND BEFORE ANY OF THEM IS PLACED (openRepoShape #82, F10 of the
+# ALL FOUR IN HAND BEFORE ANY OF THEM IS PLACED (openRepoShape #82, F10 of the
 # review on its #83). One file at a time, dying on the first fetch that failed,
 # leaves a person with a NEW `openRepoTools` and no `park` — a half-install that
 # says `installed at` and is not one — and nothing on screen to say which of the
-# three were missing. Every one is collected into the temporary directory first:
+# four were missing. Every one is collected into the temporary directory first:
 # a failure there replaces NOTHING, names what was not fetched, and exits.
 collect_commands() {
 	local name selfdir="" missing=""
 	# Run from a file, install THOSE bytes: `--install` then needs no network
-	# and no `gh` at all — and `park` and `resume` sit BESIDE this file, in the
-	# checkout and in the repository alike, so the siblings that are there are
-	# copied and only a missing one is fetched. Run from stdin (`curl … | bash
-	# -s -- --install`) there is no file to copy from at all, so each of the
-	# three is fetched at this same ref.
+	# and no `gh` at all — and `park`, `resume` and `status` sit BESIDE this
+	# file, in the checkout and in the repository alike, so the siblings that
+	# are there are copied and only a missing one is fetched. Run from stdin
+	# (`curl … | bash -s -- --install`) there is no file to copy from at all,
+	# so each of the four is fetched at this same ref.
 	if [ -f "$SELF" ]; then
 		selfdir="$(cd -- "$(dirname -- "$SELF")" && pwd)"
 	fi
@@ -173,10 +178,10 @@ install_commands() {
 		placed=$((placed + 1))
 		say "$name: $verb"
 	done
-	# THE COUNT, out loud: a person reading three lines cannot tell whether a
-	# fourth was meant to be there.
+	# THE COUNT, out loud: a person reading four lines cannot tell whether a
+	# fifth was meant to be there.
 	say "openRepoTools: $placed of ${#INSTALLABLES[@]} placed in $dir"
-	# ONE PATH NOTE for the three of them: the directory is the same one.
+	# ONE PATH NOTE for the four of them: the directory is the same one.
 	case ":${PATH:-}:" in
 	*":$dir:"*) ;;
 	*)
@@ -198,7 +203,8 @@ while [ $# -gt 0 ]; do
 	--install) MODE="install"; shift ;;
 	*)
 		die "openRepoTools installs the estate commands and does nothing else. It takes --install,
-    --help or --version. The verbs themselves: \`park --help\`, \`resume --help\`."
+    --help or --version. The commands themselves: \`park --help\`, \`resume --help\`,
+    \`status --help\`."
 		;;
 	esac
 done

--- a/devBenches/base-image/files/openrepotools/park
+++ b/devBenches/base-image/files/openrepotools/park
@@ -4,7 +4,7 @@
 # park — leave this workstation with your half-finished work carried, from any
 # folder: `park InkRouter`, or just `park` from inside the estate.
 #
-# Installed with the other two by `openRepoTools --install`.
+# Installed with the other three by `openRepoTools --install`.
 #
 # IT ADDS NO MECHANICS, exactly as the `openRepoShape` command adds none. It
 # FINDS THE ESTATE and runs the estate's own `make park` — the family holder's,
@@ -15,23 +15,30 @@
 # creates nothing, commits nothing and pushes nothing of its own.
 #
 # openRepoShape #82, under Brett Heap's RULING of 2026-09-09: `--repo` matches
-# a LOCAL clone (ruling 1); the command is `park` (ruling 4). Ruling 3 of #82
-# ("with no <Name> and no estate around the cwd this REFUSES and lists what
-# it found") is SUPERSEDED for that one case by Brett Heap's RULING of
-# 2026-09-10 (#91): with no <Name> and no estate around the cwd, `park` now
-# discovers and PARKS EVERY ESTATE under the projects directory, in name
-# order, continuing past a refusal, instead of refusing. `park <Name>`,
-# `park --repo` and the walk-up inside an estate are unchanged either way.
-# IN THAT SWEEP ONLY, a standalone root carrying no Speckit git overlay is
-# SKIPPED and named instead of being run and counted as a refusal — Brett
-# Heap's RULING of 2026-09-10 on openRepoShape #92, "skip roots without the
-# overlay": a root nobody ever installed the overlay in is not a park that
-# FAILED. Naming that same root still relays its own `make park` refusal.
-# `resume` deliberately KEEPS ruling 3's refusal for its own bare form (see
-# its header) — rebuilding every estate on a fresh machine by accident is the
+# a LOCAL clone (ruling 1); the command is `park` (ruling 4). WITH NO <Name>
+# the estate around the current directory is parked — the walk-up, unchanged
+# since #82. WITH NO ESTATE AROUND IT EITHER, `park` lists every estate under
+# the projects directory and ASKS whether to park them all; `park --all` (or
+# `-a`) is the same sweep without the question, from anywhere. That is Brett
+# Heap's RULING of 2026-09-10 in this repository, verbatim: "lets change that
+# so it parks the current repo. if not in a repo, then asks if want to park
+# all. and park all should be park -a or park --all" — and it supersedes his
+# #91 ruling of the same day ("so just park will do park-all"), under which
+# the bare form PARKED EVERY ESTATE unasked, which had itself superseded
+# ruling 3 of #82 (the bare form REFUSES and lists what it found). With no
+# terminal on stdin nothing can be asked, so the bare form refuses and names
+# `--all`: a script that wants the sweep says so. THE SWEEP ITSELF is #91's —
+# every estate in name order, continuing past a refusal, one summary. IN THAT
+# SWEEP ONLY, a standalone root carrying no Speckit git overlay is SKIPPED and
+# named instead of being run and counted as a refusal — Brett Heap's RULING
+# of 2026-09-10 on openRepoShape #92, "skip roots without the overlay": a
+# root nobody ever installed the overlay in is not a park that FAILED. Naming
+# that same root still relays its own `make park` refusal. `resume` has no
+# sweep and no `--all`: its bare form KEEPS ruling 3's refusal (see its
+# header) — rebuilding every estate on a fresh machine by accident is the
 # opposite risk from failing to park the one you meant.
 # openRepoShape #82 wrote this, its #91 and #93 changed it, its #92 moved it
-# here, and this repository's #6 last changed it.
+# here, and this repository's #6 and then its #8 last changed it.
 
 set -euo pipefail
 
@@ -43,10 +50,14 @@ REPO_ARG=""
 DRY_RUN=0
 LANE=""
 PASSTHROUGH=()
-#: Set only in the bare, no-<Name>, no-estate-around-the-cwd case (#91): the
-#: walk-up found nothing, so every estate under the projects directory gets
-#: parked instead of one refusal. Every other path leaves this 0.
+#: 1 when EVERY estate under the projects directory is to be parked: set by
+#: `--all` / `-a` on the command line, or by a YES to the question the bare
+#: form asks when the walk-up found no estate around the cwd. Every other
+#: path leaves this 0. `ALL_ROWS` is what the sweep will run, `<name><TAB>
+#: <dir>` per estate, discovered ONCE by whichever of the two set it — so what
+#: was listed, or asked about, is exactly what runs.
 PARK_ALL=0
+ALL_ROWS=""
 
 say() { printf '%s\n' "$*"; }
 # THE SAME STDERR SHAPE AS `die`, BUT IT RETURNS: a park-everything run (#91)
@@ -59,6 +70,7 @@ die() { refuse "$1"; exit "${2:-2}"; }
 usage() {
     cat <<'USAGE'
 park [<Name>] [--repo <owner/name>] [--dry-run] [--lane <name>] [-- ARGS...]
+park --all | -a [--dry-run] [--lane <name>] [-- ARGS...]
 park --help
 
 Commit, push and RECORD every open feature of one estate, so another
@@ -66,22 +78,25 @@ workstation can take the work up with `resume <Name>`.
 
 <Name> is the estate's folder under your projects directory: a FAMILY folder
 (<Name>/<Name>/family.yaml) or a standalone project root (<Name>/project.yaml).
-With no <Name> the estate around the current directory is used. With NO
-estate around it either, `park` PARKS EVERY ESTATE under your projects
-directory instead of refusing (Brett Heap's RULING of 2026-09-10, #91,
-superseding ruling 3 of #82 for this one case): it lists what it found, then
-runs this same procedure on each one in name order, continuing past a
-refusal or a non-zero `make park`, and ends with a summary. A root with NO
-Speckit git overlay is SKIPPED there and counted apart rather than failed
-(the RULING of the same day on #92); naming that root still relays its own
-refusal, which names `setup-openspeckit`, exactly as it does today. `resume`
-deliberately keeps the old refusal for its own bare form: rebuilding every
-estate on a fresh machine by accident is a worse mistake than failing to park
-the one you meant. `--repo <owner/name>` names the estate by the origin of a
-clone you ALREADY HAVE - in any spelling: the slug, the slug with `.git`, or
-the whole https or ssh url. It never clones (`resume` is the command that
-clones).
+With no <Name> the estate around the current directory is parked. With NO
+estate around it either, `park` lists every estate under your projects
+directory and ASKS whether to park them all; anything but `y` parks nothing.
+`park --all` (or `-a`) is that same sweep WITHOUT the question, from anywhere:
+every estate in name order, continuing past a refusal or a non-zero `make
+park`, then one summary. Where stdin is not a terminal the bare form cannot
+ask, so it refuses and names `--all` - a script that wants the sweep says so.
+(Brett Heap's RULING of 2026-09-10, superseding his #91 ruling of the same
+day, under which the bare form swept unasked.) In the sweep a root with NO
+Speckit git overlay is SKIPPED and counted apart rather than failed (his
+RULING of the same day on #92); naming that root still relays its own
+refusal, which names `setup-openspeckit`. `resume` has no `--all`: rebuilding
+every estate on a fresh machine by accident is a worse mistake than failing
+to park the one you meant. `--repo <owner/name>` names the estate by the
+origin of a clone you ALREADY HAVE - in any spelling: the slug, the slug with
+`.git`, or the whole https or ssh url. It never clones (`resume` is the
+command that clones).
 
+  --all, -a           park EVERY estate under your projects directory, unasked
   --project <Name>    the positional under a flag (also --name)
   --dry-run           rehearse: `make park ARGS=--dry-run`, which writes nothing
   --lane <name>       the lane recorded in the WIP commit subject
@@ -96,12 +111,12 @@ local files (.env, credentials) are REPORTED and left exactly where they are.
 USAGE
 }
 
-# --- BEGIN shared estate resolver (park and resume carry it byte for byte) --
+# --- BEGIN shared estate resolver (park, resume, status: byte for byte) -----
 #
-# THIS BLOCK IS DUPLICATED IN THE OTHER COMMAND, DELIBERATELY, and
-# `tests/test_park_resume_commands.py` asserts the two copies are IDENTICAL.
+# THIS BLOCK IS DUPLICATED IN THE OTHER COMMANDS, DELIBERATELY, and
+# `tests/test_park_resume_commands.py` asserts the three copies are IDENTICAL.
 # Each of these is one file a person has on PATH: a shared `orp-estate.sh`
-# would be a fourth file for `--install` to place and a broken command the
+# would be a fifth file for `--install` to place and a broken command the
 # first time somebody copied only one of them. The rules themselves are NOT
 # new: `<dir>/<Name>/family.yaml` carrying `kind: family-manifest` and naming
 # `<Name>` is `setup-project.py`'s `family_folder_here`, doubled-name layout
@@ -129,9 +144,9 @@ fi
 # Where a NEW clone would go: the first spelling that already exists, else the
 # first named.
 #
-# shellcheck disable=SC2329  # `park` creates nothing and never calls this. The
-# block is byte-identical in both commands BY DESIGN, so each carries a couple
-# of functions only the other one asks.
+# shellcheck disable=SC2329  # `park` and `status` create nothing and never
+# call this. The block is byte-identical in all three commands BY DESIGN, so
+# each carries a couple of functions only another one asks.
 projects_dir_for_new() {
     local dir
     for dir in "${PROJECTS_DIRS[@]}"; do
@@ -469,16 +484,23 @@ legs_of() {
 # commit, so a leg mounted somewhere unusual, or one whose manifest row was
 # hand-edited away, still has to be asked. `git config --get-regexp` prints
 # `key value`, so the value is everything after the first space.
+# `-z`, so the key and the value cannot be confused: a submodule NAME may
+# carry a space (`[submodule "sp ace"]`), and splitting the plain output at
+# its first space would hand back `ace.path spec` and miss the leg; with `-z`
+# each entry is `key<LF>value<NUL>`, and a key with no value has no LF at all
+# and is not a path.
 submodule_paths() {
-    local root="$1" line path
+    local root="$1" record path
     [ -f "$root/.gitmodules" ] || return 0
-    while IFS= read -r line; do
-        [ -n "$line" ] || continue
-        path="${line#* }"
+    while IFS= read -r -d '' record; do
+        case "$record" in
+        *$'\n'*) path="${record#*$'\n'}" ;;
+        *) continue ;;
+        esac
         [ -n "$path" ] || continue
         [ -e "$root/$path/.git" ] || continue
         printf '%s\n' "$path"
-    done < <(git -C "$root" config --file .gitmodules \
+    done < <(git -C "$root" config --file .gitmodules -z \
         --get-regexp '^submodule\..*\.path$' 2>/dev/null || true)
 }
 
@@ -659,17 +681,26 @@ run_one_estate() {
     return "$one_status"
 }
 
-# --- park-everything (#91), and what it SKIPS (#92) --------------------------
+# --- park-everything (#91): asked for with --all, or asked about; and what it
+# --- SKIPS (#92) -------------------------------------------------------------
 #
-# Brett Heap's RULING, 2026-09-10, verbatim: "for the park-all, lets make
-# that be park with no estate option. so just park will do park-all." This
-# SUPERSEDES ruling 3 of #82 for THIS CASE ONLY: bare `park`, with no <Name>
-# and no estate around the cwd, no longer refuses. `park <Name>`, `park
-# --repo` and the walk-up above (NEAREST STILL WINS - standing inside an
-# estate parks THAT estate, never the workstation) are exactly as they were.
-# `resume` deliberately keeps ruling 3's refusal for its own bare form - see
-# the note in its header - because rebuilding every estate on a fresh machine
-# by accident is the opposite risk from failing to park the one you meant.
+# THE SWEEP is #91's - Brett Heap's RULING of 2026-09-10, verbatim: "for the
+# park-all, lets make that be park with no estate option. so just park will
+# do park-all." HOW IT IS REACHED changed the same day, under his later
+# RULING in this repository, verbatim: "lets change that so it parks the
+# current repo. if not in a repo, then asks if want to park all. and park all
+# should be park -a or park --all." So: `park --all` / `park -a` runs the
+# sweep from anywhere, unasked. Bare `park` with no <Name> and no estate
+# around the cwd LISTS the estates and ASKS (`ask_before_parking_every_estate`,
+# below); a YES runs the same sweep, anything else parks nothing, and with no
+# terminal on stdin nothing is asked - the bare form refuses and names
+# `--all`, because a sweep a script did not spell out is a sweep nobody
+# chose. `park <Name>`, `park --repo` and the walk-up above (NEAREST STILL
+# WINS - standing inside an estate parks THAT estate, never the workstation)
+# are exactly as they were under #82. `resume` has no sweep and no `--all`:
+# its bare form keeps ruling 3 of #82's refusal - see the note in its header
+# - because rebuilding every estate on a fresh machine by accident is the
+# opposite risk from failing to park the one you meant.
 #
 # Brett Heap's SECOND RULING of that day, on openRepoShape #92, verbatim:
 # "rule on the #92 open item: skip roots without the overlay." The sweep on
@@ -723,12 +754,17 @@ has_speckit_overlay() {
     [ -x "$1/.specify/extensions/git/scripts/bash/park.sh" ]
 }
 
-# Discover every estate and run `run_one_estate` for each, in name order,
-# CONTINUING PAST A REFUSAL OR A NON-ZERO `make park`: one estate's trouble is
-# not a reason to leave the others unparked. A SKIP IS NOT A PASS (#80's
-# rule), so an estate whose own report is not clean - a non-zero `make park`,
-# or a zero one that still left something behind - counts against the
-# overall exit code exactly as a refusal does.
+# Run `run_one_estate` for every estate in `$1` (`all_estate_dirs`'s rows),
+# in name order, CONTINUING PAST A REFUSAL OR A NON-ZERO `make park`: one
+# estate's trouble is not a reason to leave the others unparked. A SKIP IS
+# NOT A PASS (#80's rule), so an estate whose own report is not clean - a
+# non-zero `make park`, or a zero one that still left something behind -
+# counts against the overall exit code exactly as a refusal does.
+#
+# THE CALLER HAS ALREADY LISTED THE ROWS - `--all` under its own heading, the
+# bare form above its question - so nothing prints here before the first
+# `=== park <Name> ===`, and the rows are passed in rather than discovered
+# again: what was listed is exactly what runs.
 #
 # A ROOT WITHOUT THE OVERLAY IS THE ONE THING THAT COUNTS NEITHER WAY (#92's
 # ruling, above): nothing ran in it, so there is no report to be clean or
@@ -736,29 +772,8 @@ has_speckit_overlay() {
 # is not #80's rule bent - #80 is about a verb that was asked and did not
 # answer; this is a verb that was never askable.
 park_every_estate() {
-    local rows name dir estate_status total=0 bad=0 skipped=0 skipped_clause=""
+    local rows="$1" name dir estate_status total=0 bad=0 skipped=0 skipped_clause=""
     local -a summary=()
-
-    rows="$(all_estate_dirs)"
-    if [ -z "$rows" ]; then
-        # NO ESTATES ANYWHERE ON THIS MACHINE: there is no "every estate" to
-        # park, so this is not park-everything's case to change - the
-        # refusal ruling 3 always printed here stands untouched.
-        die "no estate around $PWD, and no <Name> was given, so nothing was parked.
-    \`park\` never guesses which estate you meant, and it never parks all of
-    them. Name one of these:
-
-$(estates_or_none)
-    ...or \`park --repo <owner/name>\`, for the clone whose origin is that
-    repository."
-    fi
-
-    require_make
-
-    say "park: no estate around $PWD; parking every estate under ${PROJECTS_DIRS[*]}:"
-    say ""
-    say "$(estates_or_none)"
-    say ""
 
     while IFS=$'\t' read -r name dir; do
         [ -n "$name" ] || continue
@@ -819,19 +834,80 @@ $(estates_or_none)
     [ "$bad" -eq 0 ]
 }
 
+# The bare form, standing outside every estate: LIST, then ASK. Brett Heap's
+# RULING of 2026-09-10 in this repository (quoted at the section head): "if
+# not in a repo, then asks if want to park all." ONLY A TERMINAL CAN ANSWER,
+# so with anything else on stdin - a pipe, /dev/null, a cron job, an
+# assistant's tool call - nothing is asked and nothing is parked: the refusal
+# names `--all`, which is how a script says it meant the sweep. Anything but
+# y/yes is a no, in either case: parking every estate on a workstation is an
+# answer a person has to give, not one they get by pressing Enter. Sets
+# PARK_ALL and ALL_ROWS on a yes; every other way out is a `die`.
+ask_before_parking_every_estate() {
+    local answer
+    ALL_ROWS="$(all_estate_dirs)"
+    [ -n "$ALL_ROWS" ] ||
+        die "no estate around $PWD, no <Name> was given, and there is no estate under
+    ${PROJECTS_DIRS[*]} at all, so there is nothing to park. An estate is a
+    FAMILY folder (<Name>/<Name>/family.yaml) or a standalone project root
+    (<Name>/project.yaml), one level under your projects directory;
+    \`resume <Name>\` brings one back."
+    [ -t 0 ] ||
+        die "no estate around $PWD, and no <Name> was given. Outside every estate
+    \`$SELF_NAME\` ASKS before parking them all, and stdin is not a terminal
+    here, so nobody could answer: nothing was parked. \`$SELF_NAME --all\`
+    parks every estate below without asking; \`$SELF_NAME <Name>\` parks one:
+
+$(estates_or_none)"
+    require_make
+    say "park: no estate around $PWD, and no <Name> was given. Every estate under ${PROJECTS_DIRS[*]}:"
+    say ""
+    say "$(estates_or_none)"
+    say ""
+    # THE QUESTION GOES TO STDERR, where a prompt belongs: with stdout sent to
+    # a file the question still reaches the terminal rather than the file,
+    # and a run hung on a question nobody can see is the one shape this must
+    # never take. `read` fails on end-of-file (Ctrl-D), which is a no.
+    printf 'park every estate above? [y/N] ' >&2
+    IFS= read -r answer || answer=""
+    case "$answer" in
+    [Yy] | [Yy][Ee][Ss]) PARK_ALL=1 ;;
+    *)
+        die "nothing was parked: the answer was not yes. \`$SELF_NAME <Name>\` parks one of
+    the estates above, \`$SELF_NAME --all\` parks every one of them without
+    asking, and \`$SELF_NAME\` from inside an estate parks that one."
+        ;;
+    esac
+}
+
 # --- arguments -------------------------------------------------------------
 while [ $# -gt 0 ]; do
     case "$1" in
     -h | --help) usage; exit 0 ;;
     --dry-run) DRY_RUN=1; shift ;;
-    --lane) LANE="${2:?--lane needs a value}"; shift 2 ;;
-    --repo) REPO_SLUG="${2:?--repo needs a value}"; REPO_ARG="$REPO_SLUG"; shift 2 ;;
+    # THE SWEEP, ASKED FOR: every estate under the projects directory, from
+    # anywhere, with no question (the RULING of 2026-09-10 at the sweep's
+    # section head: "park all should be park -a or park --all").
+    -a | --all) PARK_ALL=1; shift ;;
+    # A MISSING VALUE IS THIS COMMAND'S REFUSAL, exit 2, in its own words:
+    # `${2:?…}` would be bash's message and bash's exit 1, which is not a
+    # status this command means anything by (`status` gave the reason first:
+    # its 1 is "findings"; here, a typo must not read like `make park`'s own
+    # exit).
+    --lane)
+        [ $# -ge 2 ] || die "--lane needs a value: the lane recorded in the WIP commit subject."
+        LANE="$2"; shift 2 ;;
+    --repo)
+        [ $# -ge 2 ] || die "--repo needs a value: <owner>/<name>, or any url spelling of one."
+        REPO_SLUG="$2"; REPO_ARG="$REPO_SLUG"; shift 2 ;;
     # `--project <Name>` and `--name <Name>` are the positional under a flag,
     # because the issue's own words are "park --project <project> or park
     # --repo <repo> and it defaults to project" (Brett Heap, 2026-09-09). The
     # value is never mistaken for the positional this way, which is the same
     # reason `openRepoShape` names its value-taking flags.
-    --name | --project) NAME="${2:?$1 needs a value}"; shift 2 ;;
+    --name | --project)
+        [ $# -ge 2 ] || die "$1 needs a value: one estate folder name under your projects directory."
+        NAME="$2"; shift 2 ;;
     # EVERYTHING AFTER `--` IS THE EXTENSION'S, verbatim. `park.sh` has flags
     # this command has no opinion about (--feature, --message, --no-push,
     # --retire-parked-wip) and a command that ate them would be a command
@@ -854,9 +930,33 @@ done
 [ -z "$NAME" ] || [ -z "$REPO_SLUG" ] ||
     die "both <Name> ('$NAME') and --repo '$REPO_SLUG'. One estate per run: name it
     either way, not both."
+if [ "$PARK_ALL" -eq 1 ]; then
+    [ -z "$NAME" ] ||
+        die "both <Name> ('$NAME') and --all. \`--all\` parks EVERY estate under your
+    projects directory; <Name> parks one. Drop one of them."
+    [ -z "$REPO_SLUG" ] ||
+        die "both --repo '$REPO_ARG' and --all. \`--all\` parks EVERY estate under your
+    projects directory; \`--repo\` parks the one that clone belongs to. Drop one
+    of them."
+fi
 
 # --- resolve ---------------------------------------------------------------
-if [ -n "$REPO_SLUG" ]; then
+if [ "$PARK_ALL" -eq 1 ]; then
+    # `--all`: nothing to resolve, and nothing to ask. The sweep discovers for
+    # itself, and it runs from ANYWHERE - standing inside an estate does not
+    # narrow a flag that says every one of them.
+    ALL_ROWS="$(all_estate_dirs)"
+    [ -n "$ALL_ROWS" ] ||
+        die "--all found no estate under ${PROJECTS_DIRS[*]}, so nothing was parked.
+    An estate is a FAMILY folder (<Name>/<Name>/family.yaml) or a standalone
+    project root (<Name>/project.yaml), one level under your projects
+    directory; \`resume <Name>\` brings one back."
+    require_make
+    say "park --all: parking every estate under ${PROJECTS_DIRS[*]}:"
+    say ""
+    say "$(estates_or_none)"
+    say ""
+elif [ -n "$REPO_SLUG" ]; then
     # ANY SPELLING A PERSON MIGHT PASTE, through the same reader that reads a
     # clone's `origin`: `TestOrg/Atlas`, `TestOrg/Atlas.git`, a trailing
     # slash, or the whole https url they copied out of the browser. Both
@@ -898,17 +998,17 @@ elif [ -n "$NAME" ]; then
 
 $(estates_or_none)"
 else
-    # RULING #91 (Brett Heap, 2026-09-10) SUPERSEDES ruling 3 of #82 for THIS
-    # CASE ONLY: with no <Name> and no estate around the cwd, `park` no
-    # longer refuses — it parks every estate it can find (park_every_estate,
-    # above). The walk-up still wins first: standing inside an estate parks
-    # THAT estate, never the whole workstation.
-    estate_walk_up "$PWD" || PARK_ALL=1
+    # THE WALK-UP WINS FIRST: standing inside an estate parks THAT estate,
+    # never the whole workstation — "it parks the current repo" (the RULING
+    # of 2026-09-10 quoted at the sweep's section head). With no estate
+    # around the cwd the estates are listed and the question is asked;
+    # `--all` is the way past the question, not a folder to stand in.
+    estate_walk_up "$PWD" || ask_before_parking_every_estate
 fi
 
 if [ "$PARK_ALL" -eq 1 ]; then
     STATUS=0
-    park_every_estate || STATUS=$?
+    park_every_estate "$ALL_ROWS" || STATUS=$?
     exit "$STATUS"
 fi
 

--- a/devBenches/base-image/files/openrepotools/resume
+++ b/devBenches/base-image/files/openrepotools/resume
@@ -3,7 +3,7 @@
 #
 # resume — arrive at a workstation and get the estate back: `resume InkRouter`.
 #
-# Installed with the other two by `openRepoTools --install`.
+# Installed with the other three by `openRepoTools --install`.
 #
 # IT ADDS NO MECHANICS, exactly as the `openRepoShape` command adds none. It
 # REBUILDS OR REFRESHES the estate with the tools that already exist — `git
@@ -21,12 +21,15 @@
 #
 # BARE `resume`, WITH NO <Name> AND NO ESTATE AROUND THE CWD, STILL REFUSES —
 # deliberately NOT changed by Brett Heap's RULING of 2026-09-10 (#91), which
-# supersedes ruling 3 of #82 for `park`'s own bare form only. Rebuilding every
-# estate this machine has a record of, by accident, from one bare `resume` in
-# the wrong folder, is the opposite risk from `park` failing to park the one
-# estate you meant: a clone or a fast-forward per estate is real network and
-# real disk, and undoing an accidental one is not as simple as re-running the
-# command. Ruling #91 names `park` only; this refusal stands.
+# supersedes ruling 3 of #82 for `park`'s own bare form only, nor by his later
+# RULING of the same day in openRepoTools, under which `park` ASKS there and
+# sweeps on a yes or a `--all`. `resume` has no `--all` and asks nothing:
+# rebuilding every estate this machine has a record of, by accident, from one
+# bare `resume` in the wrong folder, is the opposite risk from `park` failing
+# to park the one estate you meant — a clone or a fast-forward per estate is
+# real network and real disk, and undoing an accidental one is not as simple
+# as re-running the command. Both rulings name `park` only; this refusal
+# stands.
 # openRepoShape #82 wrote this, its #93 last changed it, its #92 moved it here.
 #
 # THE ONLY FILE THIS STANDARD EVER WRITES OUTSIDE A REPOSITORY is the two-line
@@ -91,12 +94,12 @@ estate still comes back.
 USAGE
 }
 
-# --- BEGIN shared estate resolver (park and resume carry it byte for byte) --
+# --- BEGIN shared estate resolver (park, resume, status: byte for byte) -----
 #
-# THIS BLOCK IS DUPLICATED IN THE OTHER COMMAND, DELIBERATELY, and
-# `tests/test_park_resume_commands.py` asserts the two copies are IDENTICAL.
+# THIS BLOCK IS DUPLICATED IN THE OTHER COMMANDS, DELIBERATELY, and
+# `tests/test_park_resume_commands.py` asserts the three copies are IDENTICAL.
 # Each of these is one file a person has on PATH: a shared `orp-estate.sh`
-# would be a fourth file for `--install` to place and a broken command the
+# would be a fifth file for `--install` to place and a broken command the
 # first time somebody copied only one of them. The rules themselves are NOT
 # new: `<dir>/<Name>/family.yaml` carrying `kind: family-manifest` and naming
 # `<Name>` is `setup-project.py`'s `family_folder_here`, doubled-name layout
@@ -124,9 +127,9 @@ fi
 # Where a NEW clone would go: the first spelling that already exists, else the
 # first named.
 #
-# shellcheck disable=SC2329  # `park` creates nothing and never calls this. The
-# block is byte-identical in both commands BY DESIGN, so each carries a couple
-# of functions only the other one asks.
+# shellcheck disable=SC2329  # `park` and `status` create nothing and never
+# call this. The block is byte-identical in all three commands BY DESIGN, so
+# each carries a couple of functions only another one asks.
 projects_dir_for_new() {
     local dir
     for dir in "${PROJECTS_DIRS[@]}"; do
@@ -755,10 +758,29 @@ while [ $# -gt 0 ]; do
     case "$1" in
     -h | --help) usage; exit 0 ;;
     --dry-run) DRY_RUN=1; shift ;;
-    --repo) REPO_SLUG="${2:?--repo needs a value}"; REPO_ARG="$REPO_SLUG"; shift 2 ;;
-    --workspace) WORKSPACE_SLUG="${2:?--workspace needs a value}"; shift 2 ;;
-    --org) ORG_WANTED="${2:?--org needs a value}"; shift 2 ;;
-    --name | --project) NAME="${2:?$1 needs a value}"; shift 2 ;;
+    # A MISSING VALUE IS THIS COMMAND'S REFUSAL, exit 2, in its own words:
+    # `${2:?…}` would be bash's message and bash's exit 1 — and a `resume`
+    # that exits non-zero is read as "something was refused", so the refusal
+    # has to be one this command wrote and a person can act on.
+    --repo)
+        [ $# -ge 2 ] || die "--repo needs a value: <owner>/<name>, or any url spelling of one."
+        REPO_SLUG="$2"; REPO_ARG="$REPO_SLUG"; shift 2 ;;
+    --workspace)
+        [ $# -ge 2 ] || die "--workspace needs a value: <owner>/<name> of your private workspace repository."
+        WORKSPACE_SLUG="$2"; shift 2 ;;
+    --org)
+        [ $# -ge 2 ] || die "--org needs a value: the organisation whose manifest to read."
+        ORG_WANTED="$2"; shift 2 ;;
+    --name | --project)
+        [ $# -ge 2 ] || die "$1 needs a value: one estate folder name under your projects directory."
+        NAME="$2"; shift 2 ;;
+    # `park --all` exists; `resume --all` deliberately does not (see the
+    # header). Said here in so many words, because the generic answer below
+    # - "put it after `--`" - would hand the extension a flag it does not
+    # have and nobody meant.
+    -a | --all) die "\`$SELF_NAME\` has no \`--all\`, deliberately: rebuilding every estate on this
+    machine from one command is the accident its own bare-form refusal exists
+    to prevent. Name the one you want: \`$SELF_NAME <Name>\`." ;;
     # EVERYTHING AFTER `--` IS THE EXTENSION'S, verbatim: `resume.sh` has
     # flags this command has no opinion about (--feature, --keep-staged), and
     # a command that ate them would be a command people stop using the moment

--- a/devBenches/base-image/files/openrepotools/status
+++ b/devBenches/base-image/files/openrepotools/status
@@ -1,0 +1,2082 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# status — what is in and out of sync across an estate, READ-ONLY: `status
+# InkRouter`, or just `status` from inside the estate, or `status --all`.
+#
+# Installed with the other three by `openRepoTools --install`.
+#
+# IT CHANGES NOTHING. It finds the estate exactly as `park` and `resume` do,
+# and then only READS — git's refs, index and working tree — for the family
+# holder or the assembly root, each member's working clone beside the holder,
+# and every mounted leg. It fetches nothing unless told to (`--fetch`), so
+# every ahead/behind answer is AS OF THE LAST FETCH — the one it just made,
+# or the one before — and it says which on every run. `make validate` and
+# `make pins` say whether an estate is CONSISTENT with itself (naming,
+# manifests, lockstep pins); this is the view neither gives — whether it is
+# CURRENT with its remotes, and whether anything here has moved and not
+# travelled.
+#
+# THE FOURTH FILE, under Brett Heap's RULING of 2026-09-10 in this repository
+# (its #9), verbatim: "lets go with a fourth file. start with the local status
+# layer."
+# A flag on `park` would have put a read-only report under a verb whose name
+# means commit-and-push; a fourth file costs the shared estate resolver a
+# third copy, which the suite holds byte-identical, and the install story one
+# more line.
+#
+# THIS IS THE LOCAL LAYER PLUS `--fetch`: what this machine already knows,
+# and — only when asked — what origin knows right now. `--fetch` is the
+# second layer, under Brett Heap's RULING of 2026-09-11 (this repository's
+# #10), verbatim: "next layer: --fetch". It runs `git fetch --prune origin`
+# in every repository
+# about to be read, so the ahead/behind answers are current and a remote
+# branch deleted under a feature reads as gone; that fetch is THE ONE WRITE
+# this command ever makes — remote-tracking refs (`refs/remotes/<remote>/*`:
+# origin, and upstream where a fork has one),
+# the objects behind them and `FETCH_HEAD`, and nothing else: no branch, no
+# tag, no HEAD, no index, no working tree, because the refspec is pinned on
+# the command line rather than trusted from config (see `fetch_remote`).
+# What it cannot do is answer a prompt: `GIT_TERMINAL_PROMPT=0` makes an
+# https credential prompt FAIL and be reported, but an ssh host-key or
+# passphrase prompt is ssh's own and blocks exactly as `git fetch` would —
+# so run `--fetch` where ssh is already non-interactive (an agent, a
+# known_hosts entry). Without the flag it fetches nothing, as before.
+#
+# THE THIRD LAYER is the FORK against what it was forked from, under Brett
+# Heap's RULING of 2026-09-11 (this repository's #11), verbatim: "next layer:
+# fork against upstream".
+# A remote named `upstream` is read from local refs — `origin/<branch>`
+# against `upstream/<branch>`, as of the last fetch — and `--fetch` fetches
+# it too, under the same pinned refspec. With no such remote, and only under
+# `--fetch`, an origin on github.com is asked about with `gh api`, once: a
+# fork is a finding that names the parent and the `git remote add upstream …`
+# that makes the drift readable here. See "the fork against its upstream",
+# below.
+#
+# THE FOURTH LAYER is the SHAPE PIN, under Brett Heap's RULING of 2026-09-11
+# (this repository's #12), verbatim: "next layer: shape-pin drift". Every
+# assembly root and family
+# holder carries `contracts/shape-pin.yaml`: the openRepoShape commit its
+# copied shape files were cut from, and a sha256 per copy. The copies are
+# re-hashed here and one that differs is DRIFT — a copy edited in place, whose
+# exit is upstream, never a re-digest; a `shape:` mirror in `project.yaml` /
+# `family.yaml` that names another commit, or is missing, is out of step; and
+# the pin is read against the source's default branch (`main` for
+# openRepoShape, read from the clone's `origin/HEAD` or from GitHub) — from a
+# clone of the source under the projects directory when there is one, found
+# by its origin's slug the way `--repo` finds an estate, as of its last fetch;
+# else under `--fetch` from GitHub, once per pin per run — so a pin that has
+# fallen behind, or sits on a commit the branch never had, is named with
+# `update-shape.py check` as the exit.
+# See "the shape pin", below.
+#
+# THE FIFTH LAYER, the last of the five named when this file landed, is THE
+# PARKED RECORD AGAINST DISK, under Brett Heap's RULING of 2026-09-11 (this
+# repository's #13), verbatim: "next layer: parked record against disk".
+# `park` records every
+# open feature in the person's private workspace repository — the one
+# `~/.agents/workspace.yaml` names — and `resume` rebuilds the worktrees from
+# it; between the two, record and disk drift apart in exactly the ways
+# `resume` later refuses, and this reads them beforehand: a recorded feature
+# with no worktree here (parked, not resumed — `resume <Name>` is the exit), a
+# worktree whose branch tip is not the parked commit (moved on, or BEHIND a
+# newer record by more than the WIP commits `resume` itself un-committed, or
+# diverged), a leg parked with `--no-push`, and a worktree on disk the record
+# does not know (never parked). See "the parked record against disk", below.
+# Nothing is left on the list.
+#
+# READ THE LINES, NOT THE EXIT CODE — the rule `park` and `resume` carry.
+# Exit 0: every repository read is in sync and clean, as of the last fetch.
+# Exit 1: at least one finding was printed. Exit 2: refused, and nothing was
+# read. A finding is a fact to look at, not a fault — an unpushed commit on a
+# feature branch is exactly what `park` exists to carry.
+
+set -euo pipefail
+
+SELF_NAME="status"
+
+NAME=""
+REPO_SLUG=""
+REPO_ARG=""
+#: 1 when EVERY estate under the projects directory is to be read: `--all` /
+#: `-a`, or the bare form standing outside every estate — which SWEEPS WITHOUT
+#: ASKING, unlike `park`'s, because nothing here writes and a question before
+#: a read is only friction. `ALL_ROWS` is what the sweep reads, `<name><TAB>
+#: <dir>` per estate.
+STATUS_ALL=0
+ALL_ROWS=""
+#: 1 with `--fetch`: `git fetch --prune origin` in every repository before it
+#: is read — the one write this command makes. See `fetch_remote`.
+FETCH=0
+
+say() { printf '%s\n' "$*"; }
+refuse() { printf '\nREFUSED: %s\n' "$1" >&2; }
+die() { refuse "$1"; exit "${2:-2}"; }
+
+usage() {
+    cat <<'USAGE'
+status [<Name>] [--repo <owner/name>] [--fetch]
+status --all | -a [--fetch]
+status --help
+
+What is in and out of sync across ONE estate, read-only. For the family
+holder or the assembly root, each member's working clone, and every mounted
+leg: whether the tracking branch is ahead of or behind its origin; what is
+dirty or stashed; which feature branches carry commits origin has not seen,
+or point at a remote branch that is gone; whether a feature worktree is
+dirty; and whether a leg is checked out away from its pin, or its pin has
+fallen behind its origin. It FETCHES NOTHING unless you say `--fetch`, so
+every answer is AS OF THE LAST FETCH — the one it just made, or the one
+before — and the report says which. A FORK is read against what it was
+forked from: with a remote named `upstream`, `origin/<branch>` against
+`upstream/<branch>` from local refs, and `--fetch` fetches upstream too; with
+none, and only under `--fetch`, an origin on github.com is asked about once
+with `gh api`, and a fork is a finding naming the parent and the `git remote
+add upstream …` to run. Not a fork: nothing to say. THE SHAPE PIN
+(`contracts/shape-pin.yaml`) is read too: a copied shape file whose sha256 is
+not the one recorded is drift, a `shape:` mirror naming another commit is out
+of step, and the pinned commit is compared with the source's default branch
+— from a clone of the source under your projects directory, found by its
+origin like `--repo` finds an estate, or under `--fetch` from GitHub — so a
+pin that has fallen behind is named with the exit, `update-shape.py check
+--root <root>`. THE PARKED RECORD (`~/.agents/workspace.yaml` names the
+workspace repository; `workspaces/<org>/<id>.yaml` in it) is read against the
+worktrees on disk: a recorded feature with no worktree here (`resume <Name>`
+brings it back), a worktree whose tip is not the parked commit, a leg parked
+with `--no-push`, and a worktree the record does not know (never parked).
+
+<Name> is the estate's folder under your projects directory: a FAMILY folder
+(<Name>/<Name>/family.yaml) or a standalone project root (<Name>/project.yaml).
+With no <Name> the estate around the current directory is read. With no
+estate around it either, EVERY estate under your projects directory is read,
+without asking, because nothing here writes; `--all` (or `-a`) says the same
+thing from anywhere. `--repo <owner/name>` names the estate by the origin of
+a clone you ALREADY HAVE, in any spelling git accepts.
+
+  --fetch             `git fetch --prune` of origin — and of upstream, where a
+                      fork has one — in every repository first, so the answers
+                      are current: THE ONE WRITE this command makes, to
+                      remote-tracking refs, the objects behind them and
+                      FETCH_HEAD; never a local branch, tag, HEAD, index or
+                      working tree, because the refspec is pinned. A fetch that
+                      fails is a finding on that row, read as of the last fetch
+                      that worked. An ssh prompt is ssh's own and still blocks.
+  --all, -a           read EVERY estate under your projects directory
+  --project <Name>    the positional under a flag (also --name)
+
+  $PROJECTS_DIR       your projects directory (default: ~/projects, then
+                      ~/Projects - people spell it both ways)
+
+EXIT 0: every repository read is in sync and clean, as of the last fetch.
+EXIT 1: at least one finding was printed. EXIT 2: refused; nothing was read.
+WHAT STATUS NEVER DOES: pull, commit, push, reset, or move anything — and it
+fetches only with `--fetch`. It takes no lock while it reads (`git
+--no-optional-locks`); `--fetch` takes the ref locks a fetch takes.
+USAGE
+}
+
+# --- BEGIN shared estate resolver (park, resume, status: byte for byte) -----
+#
+# THIS BLOCK IS DUPLICATED IN THE OTHER COMMANDS, DELIBERATELY, and
+# `tests/test_park_resume_commands.py` asserts the three copies are IDENTICAL.
+# Each of these is one file a person has on PATH: a shared `orp-estate.sh`
+# would be a fifth file for `--install` to place and a broken command the
+# first time somebody copied only one of them. The rules themselves are NOT
+# new: `<dir>/<Name>/family.yaml` carrying `kind: family-manifest` and naming
+# `<Name>` is `setup-project.py`'s `family_folder_here`, doubled-name layout
+# and all (#76, RULING ruling 3).
+
+# `$PROJECTS_DIR` names ONE directory when it is set. Otherwise both
+# spellings, in that order, because people really do use both - and DEDUPED by
+# inode, because on a case-insensitive filesystem (a stock Mac) `~/projects`
+# and `~/Projects` are the same directory, and listing every estate twice
+# would read as two estates.
+PROJECTS_DIRS=()
+if [ -n "${PROJECTS_DIR:-}" ]; then
+    PROJECTS_DIRS=("$PROJECTS_DIR")
+else
+    PROJECTS_DIRS=("$HOME/projects")
+    if [ -d "$HOME/Projects" ]; then
+        if [ -d "$HOME/projects" ] && [ "$HOME/Projects" -ef "$HOME/projects" ]; then
+            : # one directory under two spellings; name it once
+        else
+            PROJECTS_DIRS+=("$HOME/Projects")
+        fi
+    fi
+fi
+
+# Where a NEW clone would go: the first spelling that already exists, else the
+# first named.
+#
+# shellcheck disable=SC2329  # `park` and `status` create nothing and never
+# call this. The block is byte-identical in all three commands BY DESIGN, so
+# each carries a couple of functions only another one asks.
+projects_dir_for_new() {
+    local dir
+    for dir in "${PROJECTS_DIRS[@]}"; do
+        if [ -d "$dir" ]; then
+            printf '%s\n' "$dir"
+            return 0
+        fi
+    done
+    printf '%s\n' "${PROJECTS_DIRS[0]}"
+}
+
+trim_unquote() {
+    local value="$1"
+    value="${value%$'\r'}"
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
+    case "$value" in
+    '"'*'"') value="${value#\"}"; value="${value%\"}" ;;
+    "'"*"'") value="${value#\'}"; value="${value%\'}" ;;
+    esac
+    printf '%s' "$value"
+}
+
+# ONE FOLDER NAME, and never a path. A `<Name>` off the command line and a
+# `root:` out of somebody's workspace manifest both end up joined to the
+# projects directory, so both are held to this: no empty string, no `/`, and
+# no leading `.` — which is what stops `resume ../../elsewhere/X` from cloning
+# outside the projects directory at all, rather than noticing afterwards.
+is_safe_folder_name() {
+    local name="$1"
+    case "$name" in
+    "" | .* | */*) return 1 ;;
+    esac
+    case "$name" in
+    *[!A-Za-z0-9_.+@-]*) return 1 ;;
+    esac
+    return 0
+}
+
+# One indent-zero scalar out of a small YAML file, with parameter expansion
+# only: no YAML library, no python per line, no forks per line. This is the
+# reader the Speckit extension's `workspace_read_scalar` is, narrowed to the
+# keys these two commands read (`kind`, `name`, `family`, `tracking_branch`).
+YAML_VALUE=""
+yaml_scalar() {
+    local file="$1" key="$2" line
+    YAML_VALUE=""
+    [ -f "$file" ] || return 1
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+        "$key":*) ;;
+        *) continue ;;
+        esac
+        YAML_VALUE="$(trim_unquote "${line#"$key":}")"
+        return 0
+    done <"$file"
+    return 1
+}
+
+# A LINKED WORKTREE, not a checkout of its own: `.git` is a FILE holding a
+# `gitdir:` line, and `--git-dir` and `--git-common-dir` disagree. A
+# single-repository project's FEATURE worktree is a whole `project.yaml` root
+# by construction, so without this the walk-up would answer `<worktree_root>/
+# 001-my-feature` as an estate named after the branch — and `park` would run
+# the write verb inside the very worktree the extension is about to park.
+# GIT'S OWN ANSWER, and not the `.git`-is-a-file shortcut, because that shape
+# is shared with a SUBMODULE and a leg must not be mistaken for a worktree:
+# in a linked worktree `--git-dir` is `<common>/worktrees/<name>` and the two
+# differ; in a submodule both are `<super>/.git/modules/<name>`; in an
+# ordinary checkout both are `.git`. Verified against all three.
+is_linked_worktree() {
+    local dir="$1" gitdir common
+    [ -e "$dir/.git" ] || return 1
+    gitdir="$(git -C "$dir" rev-parse --git-dir 2>/dev/null || true)"
+    common="$(git -C "$dir" rev-parse --git-common-dir 2>/dev/null || true)"
+    [ -n "$gitdir" ] && [ -n "$common" ] && [ "$gitdir" != "$common" ]
+}
+
+# The PINNED copy inside a family holder: `<Family>/<Family>/members/<X>`, so
+# the grandparent carries the `family.yaml`. It is detached, it is what
+# `bootstrap` and `validate` read, and nobody's in-flight work is in it — a
+# walk-up that answered it would run a WRITE verb on a detached HEAD. The
+# working clone BESIDE the holder is the one a person works in, which is the
+# same rule #80's holder dispatch follows.
+is_pinned_member() {
+    local dir="$1" parent grandparent
+    parent="${dir%/*}"
+    [ -n "$parent" ] && [ "$parent" != "$dir" ] || return 1
+    grandparent="${parent%/*}"
+    [ -n "$grandparent" ] && [ "$grandparent" != "$parent" ] || return 1
+    yaml_scalar "$grandparent/family.yaml" kind || return 1
+    [ "$YAML_VALUE" = "family-manifest" ]
+}
+
+# Is `<dir>` a FAMILY FOLDER? All three facts have to agree, exactly as
+# `family_folder_here` requires them to: the holder clone sits at
+# `<dir>/<basename>`, its `family.yaml` says `kind: family-manifest`, and it
+# names that same family. A directory called Northwind is a directory called
+# Northwind; what makes it a family folder is read, never guessed from a name.
+is_family_folder() {
+    local dir="$1" name manifest
+    name="${dir##*/}"
+    [ -n "$name" ] || return 1
+    manifest="$dir/$name/family.yaml"
+    yaml_scalar "$manifest" kind || return 1
+    [ "$YAML_VALUE" = "family-manifest" ] || return 1
+    yaml_scalar "$manifest" name || return 1
+    [ "$YAML_VALUE" = "$name" ]
+}
+
+is_project_root() {
+    local dir="$1"
+    yaml_scalar "$dir/project.yaml" kind || return 1
+    [ "$YAML_VALUE" = "project-manifest" ] || return 1
+    is_pinned_member "$dir" && return 1
+    is_linked_worktree "$dir" && return 1
+    return 0
+}
+
+ESTATE_KIND=""
+ESTATE_DIR=""
+ESTATE_ROOT=""
+ESTATE_NAME=""
+
+# Is THIS directory an estate? A FAMILY FOLDER WINS over a standalone root of
+# the same name: the holder is what drives the members, so a family answered as
+# one of its own members would act on one project and report the estate done.
+estate_here() {
+    local dir="$1"
+    if is_family_folder "$dir"; then
+        ESTATE_KIND="family"
+        ESTATE_DIR="$dir"
+        ESTATE_NAME="${dir##*/}"
+        ESTATE_ROOT="$dir/$ESTATE_NAME"
+        return 0
+    fi
+    if is_project_root "$dir"; then
+        ESTATE_KIND="standalone"
+        ESTATE_DIR="$dir"
+        ESTATE_NAME="${dir##*/}"
+        ESTATE_ROOT="$dir"
+        return 0
+    fi
+    return 1
+}
+
+# The NEAREST estate at or above `<dir>`: the holder beside you, or the project
+# root you are standing in. NEAREST WINS, so standing inside a member of a
+# family acts on that member - the estate the person is standing in. A pinned
+# copy and a linked worktree are WALKED PAST rather than answered, so
+# `<Family>/<Family>/members/<X>` reaches the family folder and a feature
+# worktree reaches the root that owns it.
+estate_walk_up() {
+    local dir="$1"
+    while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+        estate_here "$dir" && return 0
+        dir="${dir%/*}"
+    done
+    return 1
+}
+
+estate_by_name() {
+    local want="$1" dir
+    is_safe_folder_name "$want" || return 1
+    for dir in "${PROJECTS_DIRS[@]}"; do
+        estate_here "$dir/$want" && return 0
+    done
+    return 1
+}
+
+# Every estate under the projects directory, one row each. What ruling 3 asks
+# a refusal to print: a person who typed the command in the wrong folder needs
+# the names, not an instruction to go and look for them.
+list_estates() {
+    local dir child
+    for dir in "${PROJECTS_DIRS[@]}"; do
+        [ -d "$dir" ] || continue
+        for child in "$dir"/*; do
+            [ -d "$child" ] || continue
+            if is_family_folder "$child"; then
+                printf '  family   %-20s %s\n' "${child##*/}" "$child"
+            elif is_project_root "$child"; then
+                printf '  project  %-20s %s\n' "${child##*/}" "$child"
+            fi
+        done
+    done
+}
+
+estates_or_none() {
+    local rows
+    rows="$(list_estates)"
+    if [ -n "$rows" ]; then
+        printf '%s\n' "$rows"
+    else
+        printf '  (none)\n'
+    fi
+}
+
+lower() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+
+# `owner/name` — CASE PRESERVED, so a refusal prints back what a person can
+# type — out of any spelling git accepts: owner/name, owner/name.git,
+# https://host/owner/name(.git), git@host:owner/name.git,
+# ssh://git@host/owner/name.git, and a token-bearing https url. Callers
+# compare with `lower` on both sides, because GitHub owners and names are
+# case-insensitive.
+#
+# A FILESYSTEM PATH IS REFUSED rather than parsed, for the reason the
+# extension's own `workspace_org_from_url` refuses one: `/srv/remotes/Name.git`
+# has a name but no owner, and inventing `remotes` as the owner would let
+# `--repo remotes/Name` match a bare repository on disk. Such a clone answers
+# `<Name>` and the walk-up; it does not answer `--repo`.
+repo_slug_of() {
+    local url="$1" rest owner name
+    rest="$url"
+    case "$rest" in
+    /* | ./* | ../* | [A-Za-z]:[/\\]* | file://*) return 1 ;;
+    esac
+    rest="${rest%/}"
+    rest="${rest%.git}"
+    case "$rest" in
+    *://*)
+        rest="${rest#*://}"
+        rest="${rest#*@}"
+        rest="${rest#*/}"
+        ;;
+    *@*:*)
+        rest="${rest#*@}"
+        rest="${rest#*:}"
+        ;;
+    esac
+    case "$rest" in
+    */*) ;;
+    *) return 1 ;;
+    esac
+    name="${rest##*/}"
+    owner="${rest%/*}"
+    owner="${owner##*/}"
+    [ -n "$owner" ] && [ -n "$name" ] || return 1
+    case "$owner$name" in
+    *[!A-Za-z0-9_.-]*) return 1 ;;
+    esac
+    printf '%s/%s\n' "$owner" "$name"
+}
+
+# The clone under the projects directory whose `origin` IS that repository -
+# ruling 1. Two levels deep, because the estates this standard places are
+# `<projects>/<Project>` and `<projects>/<Family>/<Project>`.
+clone_with_origin() {
+    local want dir candidate origin found
+    want="$(lower "$1")"
+    for dir in "${PROJECTS_DIRS[@]}"; do
+        [ -d "$dir" ] || continue
+        for candidate in "$dir"/*/ "$dir"/*/*/; do
+            candidate="${candidate%/}"
+            [ -e "$candidate/.git" ] || continue
+            origin="$(git -C "$candidate" remote get-url origin 2>/dev/null || true)"
+            [ -n "$origin" ] || continue
+            found="$(repo_slug_of "$origin" || true)"
+            [ -n "$found" ] || continue
+            if [ "$(lower "$found")" = "$want" ]; then
+                printf '%s\n' "$candidate"
+                return 0
+            fi
+        done
+    done
+    return 1
+}
+
+# The family's members, by the same `  - project: <Project>` row `family.py`
+# writes and `siblings.py` reads. The working clone is `<family folder>/
+# <Project>`, beside the holder.
+family_members() {
+    local manifest="$1" line
+    [ -f "$manifest" ] || return 0
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+        "  - project: "*) printf '%s\n' "$(trim_unquote "${line#  - project: }")" ;;
+        esac
+    done <"$manifest"
+}
+
+# The branch a checkout belongs on: its OWN manifest's `tracking_branch:` —
+# the field `scripts/bootstrap.py` already reads to place the legs — falling
+# back to `main`. The workspace manifest records a `tracking_branch` too, but
+# that is PROVENANCE from the machine that parked; the local declaration is
+# what this machine's clone actually tracks, and the extension takes the same
+# line about `worktree_root`.
+tracking_branch_of() {
+    local root="$1"
+    if yaml_scalar "$root/family.yaml" tracking_branch && [ -n "$YAML_VALUE" ]; then
+        printf '%s\n' "$YAML_VALUE"
+        return 0
+    fi
+    if yaml_scalar "$root/project.yaml" tracking_branch && [ -n "$YAML_VALUE" ]; then
+        printf '%s\n' "$YAML_VALUE"
+        return 0
+    fi
+    printf 'main\n'
+}
+
+# The legs a root declares, by path, out of `project.yaml`'s `legs:` block —
+# the same rows `scripts/bootstrap.py` reads, and in the order it reads them,
+# `role:` before `path:`. The assembly leg is `path: "."` and is the root
+# itself, so it is not one of these.
+#
+# shellcheck disable=SC2329  # only `resume` bootstraps a root, so only
+# `resume` has to ask where its legs are; see the note above.
+legs_of() {
+    local root="$1" line role="" path=""
+    [ -f "$root/project.yaml" ] || return 0
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
+        case "$line" in
+        '  - role:'*)
+            role="$(trim_unquote "${line#*:}")"
+            path=""
+            ;;
+        '    path:'*)
+            path="$(trim_unquote "${line#*:}")"
+            [ -n "$role" ] || continue
+            [ "$role" != "assembly" ] || continue
+            [ "$path" != "." ] || continue
+            [ -n "$path" ] && printf '%s\n' "$path"
+            ;;
+        [![:space:]]*) role=""; path="" ;;
+        esac
+    done <"$root/project.yaml"
+}
+# --- END shared estate resolver ---------------------------------------------
+
+# --- reading one repository -------------------------------------------------
+
+# `git` FOR READING, and every git call in this file goes through it.
+# `--no-optional-locks` (git 2.15, 2017) keeps `status --porcelain` from
+# refreshing the index under a lock, so a `status` running beside an editor
+# or a `git commit` is never the thing that says `index.lock exists`. `-C` is
+# first so the call reads exactly as `git -C <repo> …` does.
+g() { git --no-optional-locks -C "$@"; }
+
+short() { printf '%s' "${1:0:7}"; }
+
+has_ref() { g "$1" rev-parse --verify -q "$2" >/dev/null 2>&1; }
+
+# The legs a root DECLARES in `.gitmodules` — the same file `make bootstrap`
+# mounts them from — each marked `mounted` or `unmounted` by whether `.git`
+# is there. Not the shared `legs_of`, which reads what `project.yaml` says:
+# this report is about what is on disk, and a leg that is declared and not
+# mounted is itself one of its findings. `git config --get-regexp` prints
+# `key value`, so the value is everything after the first space.
+declared_legs() {
+    local root="$1" record path
+    [ -f "$root/.gitmodules" ] || return 0
+    # `-z`, so the key and the value cannot be confused: a submodule NAME may
+    # carry a space (`[submodule "sp ace"]`), and splitting the plain output
+    # at its first space would hand back `ace.path spec` and miss the leg;
+    # with `-z` each entry is `key<LF>value<NUL>`, and a key with NO value has
+    # no LF at all and is not a path — not a phantom leg declared and never
+    # mounted. `park`'s `submodule_paths` reads the same way.
+    while IFS= read -r -d '' record; do
+        case "$record" in
+        *$'\n'*) path="${record#*$'\n'}" ;;
+        *) continue ;;
+        esac
+        [ -n "$path" ] || continue
+        if [ -e "$root/$path/.git" ]; then
+            printf 'mounted\t%s\n' "$path"
+        else
+            printf 'unmounted\t%s\n' "$path"
+        fi
+    done < <(g "$root" config --file .gitmodules -z \
+        --get-regexp '^submodule\..*\.path$' 2>/dev/null || true)
+}
+
+# `label<TAB>branch<TAB>path` per repository this estate reads — THE SAME
+# ENUMERATION `park`'s not-carried report makes, with two rows it does not
+# need: `missing`, for a member with no working clone beside the holder, and
+# `unmounted`, for a leg declared and not there. Both are things out of sync
+# with the estate as recorded, which is what this command is for.
+#
+# `members/<Project>` INSIDE A FAMILY HOLDER IS DELIBERATELY NOT HERE, for
+# park's reason: that copy is pinned and DETACHED, for `bootstrap` and
+# `validate`; nobody works in it. The working clone BESIDE the holder is
+# where a person works, so it is what is read.
+estate_repos() {
+    local member branch state leg
+    if [ "$ESTATE_KIND" = "family" ]; then
+        printf 'holder\t%s\t%s\n' "$(tracking_branch_of "$ESTATE_ROOT")" \
+            "$ESTATE_ROOT"
+        while IFS= read -r member; do
+            [ -n "$member" ] || continue
+            if [ ! -e "$ESTATE_DIR/$member/.git" ]; then
+                printf 'missing\t%s\t%s\n' \
+                    "$(tracking_branch_of "$ESTATE_ROOT")" "$ESTATE_DIR/$member"
+                continue
+            fi
+            branch="$(tracking_branch_of "$ESTATE_DIR/$member")"
+            printf 'root\t%s\t%s\n' "$branch" "$ESTATE_DIR/$member"
+            while IFS=$'\t' read -r state leg; do
+                [ -n "$leg" ] || continue
+                # A LEG'S branch is the ROOT's `tracking_branch:` — the one
+                # value `scripts/bootstrap.py` places every leg on.
+                printf '%s\t%s\t%s\n' "$state" "$branch" "$ESTATE_DIR/$member/$leg"
+            done < <(declared_legs "$ESTATE_DIR/$member")
+        done < <(family_members "$ESTATE_ROOT/family.yaml")
+        return 0
+    fi
+    branch="$(tracking_branch_of "$ESTATE_ROOT")"
+    printf 'root\t%s\t%s\n' "$branch" "$ESTATE_ROOT"
+    while IFS=$'\t' read -r state leg; do
+        [ -n "$leg" ] || continue
+        printf '%s\t%s\t%s\n' "$state" "$branch" "$ESTATE_ROOT/$leg"
+    done < <(declared_legs "$ESTATE_ROOT")
+}
+
+# The findings for the repository being read, one line each, in the order
+# they were found. Printed by `read_one_estate` under the repository's own
+# row, or replaced by one `in sync` line when there are none. EXPANDED ONLY
+# WHEN NON-EMPTY: `"${arr[@]}"` on an empty array is an unbound-variable
+# error under `set -u` in every bash before 4.4, and a Mac's is 3.2.
+FINDINGS=()
+finding() { FINDINGS+=("$1"); }
+
+# Where HEAD is: `branch<TAB><name>`, `detached<TAB><sha>`, or `unborn`.
+# `symbolic-ref -q` prints the branch when HEAD is symbolic and exits 1,
+# silently, when it is not — which is the whole test.
+head_of() {
+    local repo="$1" name sha
+    name="$(g "$repo" symbolic-ref -q --short HEAD 2>/dev/null || true)"
+    if [ -n "$name" ]; then
+        printf 'branch\t%s\n' "$name"
+        return 0
+    fi
+    sha="$(g "$repo" rev-parse -q --verify HEAD 2>/dev/null || true)"
+    if [ -n "$sha" ]; then
+        printf 'detached\t%s\n' "$sha"
+    else
+        printf 'unborn\t\n'
+    fi
+}
+
+# A ROOT OR A HOLDER belongs on its tracking branch: `resume` refuses one on a
+# feature branch, and a detached root is one `make bootstrap` never ran in.
+read_head() {
+    local repo="$1" branch="$2" kind ref
+    IFS=$'\t' read -r kind ref < <(head_of "$repo")
+    case "$kind" in
+    branch)
+        [ "$ref" = "$branch" ] ||
+            finding "on branch $ref, not $branch (\`resume\` refuses a root on a feature branch)"
+        ;;
+    detached) finding "detached HEAD at $(short "$ref"); expected to be on $branch" ;;
+    unborn) finding "no commits at all" ;;
+    esac
+}
+
+# No `origin/<branch>` locally. Without a fetch that is "never fetched, or no
+# remote named origin"; right after one that WORKED it means origin has no
+# such branch — deleted or renamed there — and saying "never fetched" would
+# contradict the `fetched origin:` line printed just above it.
+no_origin_branch_finding() {
+    if [ "$FETCHED_OK" -eq 1 ]; then
+        finding "no origin/$1 after the fetch: origin has no branch $1 (deleted or renamed there)"
+    else
+        finding "no origin/$1 here: never fetched, or no remote named origin"
+    fi
+}
+
+# The tracking branch against origin's copy of it, AS OF THE LAST FETCH: park
+# fetches nothing and neither does this. BOTH refs must exist locally or there
+# is no question to ask, and each absence is its own finding, because a clone
+# with no `origin/<branch>` is one that was never fetched or has no remote
+# named origin — either way, "in sync" would be a fiction. `rev-list
+# --left-right --count a...b` prints `<only in a> <only in b>`, so with origin
+# on the left the first number is BEHIND and the second AHEAD.
+read_tracking() {
+    local repo="$1" branch="$2" counts behind ahead
+    if ! has_ref "$repo" "refs/heads/$branch"; then
+        finding "no local branch $branch"
+        return 0
+    fi
+    if ! has_ref "$repo" "refs/remotes/origin/$branch"; then
+        no_origin_branch_finding "$branch"
+        return 0
+    fi
+    counts="$(g "$repo" rev-list --left-right --count \
+        "origin/$branch...$branch" 2>/dev/null || true)"
+    [ -n "$counts" ] || return 0
+    behind="${counts%%[[:space:]]*}"
+    ahead="${counts##*[[:space:]]}"
+    [ "$ahead" = 0 ] ||
+        finding "ahead of origin/$branch by $ahead commit(s): unpushed"
+    [ "$behind" = 0 ] ||
+        finding "behind origin/$branch by $behind commit(s), as of the last fetch"
+}
+
+# Dirty and stashed. `--ignore-submodules=all` at a root, because a leg whose
+# checkout has moved shows up in the ROOT's porcelain as ` M <leg>`, and the
+# leg's own row below reports that once, in its own words.
+read_worktree_state() {
+    local repo="$1" out n
+    out="$(g "$repo" status --porcelain --ignore-submodules=all 2>/dev/null || true)"
+    if [ -n "$out" ]; then
+        n="$(printf '%s\n' "$out" | wc -l | tr -d ' ')"
+        finding "dirty: $n path(s)"
+    fi
+    n="$(g "$repo" stash list 2>/dev/null | wc -l | tr -d ' ' || true)"
+    [ "$n" = 0 ] || finding "$n stash(es)"
+}
+
+# Every local branch OTHER than the tracking branch — the feature branches —
+# by what `for-each-ref` knows without a fetch: no upstream at all means
+# never pushed; `[gone]` means the remote branch was deleted under it, which
+# is what a merged pull request leaves behind; `[ahead N]` is unpushed work.
+# `%(upstream:track)` prints `[ahead 1]`, `[behind 2]`, `[ahead 1, behind 2]`,
+# `[gone]` or nothing, so the count is what follows `ahead ` up to the next
+# `]` or `,`. THE FIELDS ARE SEPARATED BY 0x1F, NOT TAB: a tab is IFS
+# whitespace, so a run of tabs collapses and an EMPTY middle field shifts the
+# ones after it left — `name<TAB><TAB>[gone]` would read as upstream=`[gone]`
+# and the finding would vanish. 0x1F (`%1f` to for-each-ref, `$'\037'` to
+# bash 3.2) is not whitespace, so every field stays where it was printed.
+read_branches() {
+    local repo="$1" tracking="$2" name upstream track n base
+    while IFS=$'\037' read -r name upstream track; do
+        [ -n "$name" ] || continue
+        [ "$name" != "$tracking" ] || continue
+        if [ -z "$upstream" ]; then
+            base="origin/$tracking"
+            has_ref "$repo" "refs/remotes/$base" || base="$tracking"
+            n="$(g "$repo" rev-list --count "$base..$name" 2>/dev/null || printf '?')"
+            if [ "$n" = 0 ]; then
+                finding "branch $name: never pushed; no commit of its own yet (no upstream branch)"
+            else
+                finding "branch $name: $n commit(s) never pushed (no upstream branch)"
+            fi
+            continue
+        fi
+        case "$track" in
+        *gone*)
+            finding "branch $name: its remote branch $upstream is gone (merged, or deleted)"
+            ;;
+        *ahead*)
+            n="${track#*ahead }"
+            n="${n%%[],]*}"
+            finding "branch $name: $n commit(s) unpushed to $upstream"
+            ;;
+        esac
+    done < <(g "$repo" for-each-ref refs/heads \
+        --format='%(refname:short)%1f%(upstream:short)%1f%(upstream:track)' \
+        2>/dev/null || true)
+}
+
+# The LINKED worktrees of a root — the Speckit extension's feature worktrees
+# — and whether each is dirty. Their branches are already read above; what a
+# branch cannot say is that the worktree holds uncommitted work, which is
+# exactly the work `park` would refuse to guess about. `worktree list
+# --porcelain` prints blank-line-separated blocks, the main worktree first,
+# so the first block is skipped rather than compared by path (a Mac's
+# `/tmp` is `/private/tmp`, and two spellings of one path would compare
+# unequal).
+read_worktrees() {
+    local repo="$1" line path="" branch="" first=1 out n
+    while IFS= read -r line; do
+        case "$line" in
+        "worktree "*) path="${line#worktree }"; branch="" ;;
+        "branch "*) branch="${line#branch refs/heads/}" ;;
+        "")
+            if [ "$first" -eq 1 ]; then
+                first=0
+            elif [ -n "$path" ] && [ -d "$path" ]; then
+                out="$(g "$path" status --porcelain --ignore-submodules=all 2>/dev/null || true)"
+                if [ -n "$out" ]; then
+                    n="$(printf '%s\n' "$out" | wc -l | tr -d ' ')"
+                    finding "worktree ${path#"$ESTATE_DIR"/} on ${branch:-a detached HEAD}: dirty, $n path(s)"
+                fi
+            fi
+            path=""; branch=""
+            ;;
+        esac
+    done < <(g "$repo" worktree list --porcelain 2>/dev/null; printf '\n')
+}
+
+# A LEG is read against its PIN, not against a branch of its own: the root's
+# HEAD records a gitlink for it, `make bootstrap` places it there, and
+# `scripts/bump-leg.py` is the one way the pin moves. So: a checkout that is
+# not the gitlink has moved without being pinned; a gitlink with commits on
+# `origin/<branch>` after it is a pin that has fallen behind; and a gitlink
+# that `origin/<branch>` does not contain is a pin on work the leg never
+# pushed. A leg detached AT its pin is the normal state of a submodule and
+# is not a finding. The counts are read in the LEG's repository, where the
+# commits live; if the leg has never fetched, the answer is "unknown" rather
+# than "fine", and says so.
+read_leg() {
+    local root="$1" rel="$2" branch="$3" leg gitlink head n kind ref
+    leg="$root/$rel"
+    gitlink="$(g "$root" rev-parse -q --verify "HEAD:$rel" 2>/dev/null || true)"
+    head="$(g "$leg" rev-parse -q --verify HEAD 2>/dev/null || true)"
+    # A LEG ON A FEATURE BRANCH is the state `resume` refuses a whole root
+    # for — that root's own `make bootstrap` would walk the leg back onto
+    # its tracking branch — and the superproject looks clean in it, which is
+    # why the leg's own row has to say so, pin or no pin. A leg DETACHED at
+    # its pin is a submodule's normal state and is not a finding; one on its
+    # tracking branch is where `make bootstrap` leaves it.
+    IFS=$'\t' read -r kind ref < <(head_of "$leg")
+    if [ "$kind" = "branch" ] && [ "$ref" != "$branch" ]; then
+        finding "on branch $ref, not $branch (\`resume\` refuses a root whose leg sits on a feature branch)"
+    fi
+    if [ -z "$gitlink" ]; then
+        finding "not pinned: the root's HEAD records no gitlink at $rel"
+    elif [ -n "$head" ] && [ "$gitlink" != "$head" ]; then
+        finding "checked out at $(short "$head"), pinned at $(short "$gitlink"): moved but not pinned (scripts/bump-leg.py)"
+    fi
+    if [ -n "$gitlink" ]; then
+        if has_ref "$leg" "refs/remotes/origin/$branch"; then
+            n="$(g "$leg" rev-list --count "$gitlink..origin/$branch" 2>/dev/null || true)"
+            if [ -z "$n" ]; then
+                finding "pin $(short "$gitlink") is not in this leg's history: never fetched?"
+            else
+                [ "$n" = 0 ] ||
+                    finding "pin $(short "$gitlink") is $n commit(s) behind origin/$branch, as of the last fetch"
+                n="$(g "$leg" rev-list --count "origin/$branch..$gitlink" 2>/dev/null || printf 0)"
+                [ "$n" = 0 ] ||
+                    finding "pin $(short "$gitlink") is not on origin/$branch: $n commit(s) unpushed in the leg"
+            fi
+        else
+            no_origin_branch_finding "$branch"
+        fi
+    fi
+    read_worktree_state "$leg"
+    read_branches "$leg" "$branch"
+}
+
+# --- `--fetch`: ask origin first ---------------------------------------------
+#
+# THE ONE WRITE THIS COMMAND MAKES, and only when asked: `git fetch --prune
+# origin` in the repository about to be read. A fetch moves remote-tracking
+# refs (`refs/remotes/origin/*`) and writes objects; it touches no branch, no
+# HEAD, no index and no working tree, which is why it is the one write a
+# read-only report can make and still be one. `--prune` is part of it because
+# a remote branch deleted under a feature is exactly the `[gone]` this report
+# looks for, and a fetch without prune would keep the stale ref that hides
+# it. `--recurse-submodules=no`, because the legs are rows of their own and
+# are fetched as such; git's on-demand default would fetch them again from
+# the root. `GIT_TERMINAL_PROMPT=0` so a fetch that wants an https password
+# FAILS and is reported, rather than stopping the whole report at a prompt
+# nobody is watching; an ssh host-key or passphrase prompt is ssh's own and
+# is NOT stopped by it — that blocks exactly as `git fetch` would. The
+# outcome is one line under the repository's row — not a finding when it
+# worked, a finding when it did not, in which case what follows is as of the
+# last fetch that did work. `FETCHED_OK` tells the reads below whether a
+# missing `origin/<branch>` means "never fetched" or "origin has no such
+# branch".
+#
+# THE REFSPEC IS PINNED ON THE COMMAND LINE, and that is what bounds the
+# write. `--prune` deletes whatever the refspec's destination side no longer
+# has a source for — and a repository whose `remote.origin.fetch` was
+# hand-edited, or made with `--mirror`, maps heads onto LOCAL branches, so a
+# configured refspec plus `--prune` would delete a local branch and this
+# report would then call the repository clean; `fetch.pruneTags` set
+# globally would prune local tags the same way. Naming
+# `+refs/heads/*:refs/remotes/origin/*` here means the only refs that can
+# move or go are under `refs/remotes/origin/`, whatever the config says (the
+# review of this layer deleted a local branch through the configured form to
+# prove it). AND `--refmap`, WITH THE SAME REFSPEC: a refspec on the command
+# line bounds what is fetched and pruned, but git still maps every ref it
+# fetched through the CONFIGURED refspecs as well — "opportunistic
+# remote-tracking updates" — so under a mirror-style config the pinned fetch
+# alone would still move `refs/heads/main` in a detached leg, and refuse
+# outright in a checked-out root. `--refmap` (git 2.1) replaces the
+# configured mapping for this one fetch, so nothing outside
+# `refs/remotes/<remote>/` is written by either route.
+# ONE FUNCTION FOR BOTH REMOTES: `origin` always, `upstream` when a fork has
+# one (the third layer, below). The remote's name is in every line it prints,
+# and in the refspec, so `--prune` on the upstream fetch can only touch
+# `refs/remotes/upstream/*`.
+FETCHED_OK=0
+UPSTREAM_FETCHED_OK=0
+fetch_remote() {
+    local repo="$1" branch="$2" remote="$3" before after err what="fetch"
+    [ "$remote" = origin ] || what="fetch $remote"
+    if [ "$remote" = origin ]; then FETCHED_OK=0; else UPSTREAM_FETCHED_OK=0; fi
+    if ! g "$repo" rev-parse --git-dir >/dev/null 2>&1; then
+        finding "fetch: not a readable git repository (a gitfile whose gitdir is gone?), so nothing could be fetched"
+        return 0
+    fi
+    if ! g "$repo" remote get-url "$remote" >/dev/null 2>&1; then
+        finding "fetch: no remote named $remote, so nothing could be fetched"
+        return 0
+    fi
+    before="$(g "$repo" rev-parse -q --verify "refs/remotes/$remote/$branch" 2>/dev/null || true)"
+    if err="$(GIT_TERMINAL_PROMPT=0 git --no-optional-locks -C "$repo" fetch --quiet \
+            --prune --recurse-submodules=no \
+            --refmap="+refs/heads/*:refs/remotes/$remote/*" "$remote" \
+            "+refs/heads/*:refs/remotes/$remote/*" 2>&1)"; then
+        if [ "$remote" = origin ]; then FETCHED_OK=1; else UPSTREAM_FETCHED_OK=1; fi
+        after="$(g "$repo" rev-parse -q --verify "refs/remotes/$remote/$branch" 2>/dev/null || true)"
+        if [ -n "$before" ] && [ -z "$after" ]; then
+            say "    fetched $remote: $remote/$branch is GONE (was $(short "$before")): deleted or renamed on $remote"
+        elif [ -n "$after" ] && [ "$before" != "$after" ]; then
+            if [ -n "$before" ]; then
+                say "    fetched $remote: $remote/$branch moved $(short "$before") -> $(short "$after")"
+            else
+                say "    fetched $remote: $remote/$branch is here now, at $(short "$after")"
+            fi
+        elif [ -z "$after" ]; then
+            say "    fetched $remote: there is no $remote/$branch"
+        else
+            say "    fetched $remote: nothing new on $remote/$branch"
+        fi
+    else
+        err="${err%%$'\n'*}"
+        finding "$what failed: ${err:-git said nothing}; what follows is as of the last fetch that worked"
+    fi
+}
+
+# --- the fork against its upstream --------------------------------------------
+#
+# THE THIRD LAYER, under Brett Heap's RULING of 2026-09-11, verbatim: "next
+# layer: fork against upstream". When origin is a FORK, the one question a
+# clone cannot answer about itself is whether the fork has kept up with what
+# it was forked from: a fork's `main` falls behind quietly, and a feature cut
+# from it is a feature cut from stale ground. Two ways to know, in order:
+#
+# 1. A REMOTE NAMED `upstream` — the convention every fork guide teaches — is
+#    read from LOCAL refs: `origin/<branch>` against `upstream/<branch>`, as
+#    of the last fetch. With `--fetch` the upstream remote is fetched too,
+#    under the pinned refspec, so the write stays under `refs/remotes/`.
+# 2. WITH NO SUCH REMOTE, and only under `--fetch` — the one flag that
+#    reaches the network — an origin on github.com is asked about with
+#    `gh api repos/<owner>/<name>`. If GitHub says it is a fork, that is a
+#    finding naming the parent and the `git remote add upstream …` that makes
+#    the drift readable locally from then on, and GitHub's compare endpoint
+#    gives the counts once. `gh` is READ ONLY here, and every call goes
+#    through `gh_api_line`, which pins the host, clears `GH_DEBUG`, and
+#    decides whether the run keeps asking: not on PATH, or not logged in
+#    (gh exit 4), is true of every repository and is said once; a failure on
+#    one repository — a 404 the token cannot see past — is said on its row
+#    and the others are still asked, three in a row settling the run so an
+#    offline machine does not pay a timeout per row. Without `--fetch`
+#    nothing is asked, and a fork with no upstream remote reads exactly as it
+#    did before this layer.
+#
+# An origin that is NOT a fork says nothing here: most estates are the
+# organisation's own repositories, and "not a fork" is not a finding. The
+# origin URL is read from config, not `remote get-url`, because a
+# `url.<base>.insteadOf` rewrite must not hide whose repository it is.
+GH_STATE=""
+GH_FAILS=0
+GH_LINE=""
+
+# Is `gh` there to ask? Settled ONCE per run and shared by every question this
+# command puts to GitHub (the fork check, the shape pin): absent is said once,
+# under the first row that wanted it; `failed` is set by `gh_api_line` when a
+# failure was true of every repository, after which nobody asks again.
+gh_ready() {
+    local what="$1"
+    if [ -z "$GH_STATE" ]; then
+        if command -v gh >/dev/null 2>&1; then
+            GH_STATE=ok
+        else
+            GH_STATE=none
+            say "    $what: no \`gh\` on PATH, so GitHub was not asked (said once per run)"
+        fi
+    fi
+    [ "$GH_STATE" = ok ]
+}
+
+# THE ONE PLACE `gh` IS RUN: `gh api <endpoint> --jq <filter>`, a GET, and the
+# LAST line of its output lands in `GH_LINE` (the jq payload is always last;
+# a `GH_DEBUG` trace would come first, and is cleared anyway, because a stray
+# stderr line read as the payload turns a fork into "clean"). `--hostname
+# github.com`, because that is the host `is_github_origin` admitted and a
+# `GH_HOST` in somebody's environment must not send the question elsewhere.
+# ON FAILURE the run's state is decided here, and said on the row: gh exit 4
+# is "not logged in", true of every repository, so it settles the run; a 404
+# on one repository is true of that one only, so the others are still asked
+# — three failures in a row settle it too, so a machine with no network does
+# not pay a timeout per row. Returns 1 on any failure (the caller says what
+# it could not read), 0 with `GH_LINE` set on success.
+gh_api_line() {
+    local what="$1" endpoint="$2" filter="$3" out rc=0
+    GH_LINE=""
+    gh_ready "$what" || return 1
+    out="$(GH_PROMPT_DISABLED=1 GH_NO_UPDATE_NOTIFIER=1 GH_DEBUG='' gh api "$endpoint" \
+        --hostname github.com --jq "$filter" 2>&1)" || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        out="${out%%$'\n'*}"
+        GH_FAILS=$((GH_FAILS + 1))
+        if [ "$rc" -eq 4 ] || [ "$GH_FAILS" -ge 3 ]; then
+            GH_STATE=failed
+            say "    $what: \`gh api ${endpoint%%\?*}\` failed (${out:-no message}); not asked again this run"
+        else
+            say "    $what: \`gh api ${endpoint%%\?*}\` failed (${out:-no message}); the other repositories are still asked"
+        fi
+        return 1
+    fi
+    GH_FAILS=0
+    GH_LINE="${out##*$'\n'}"
+}
+
+# `github.com` THE HOST, not a substring: `github.company.com` is somebody's
+# GitHub Enterprise and `notgithub.com` is somebody else's server, and the
+# question goes to github.com whatever the origin says — so a match on the
+# substring would ask the wrong server about a repository that is not there,
+# with the person's token. Every spelling git accepts: `https://host/…`,
+# `ssh://user@host:port/…`, `user@host:owner/name`.
+is_github_origin() {
+    local url="$1" host
+    case "$url" in
+    *://*) host="${url#*://}"; host="${host%%/*}" ;;
+    *:*) host="${url%%:*}" ;;
+    *) return 1 ;;
+    esac
+    host="${host##*@}"
+    host="${host%%:*}"
+    [ "$(lower "$host")" = "github.com" ]
+}
+
+# A count from GitHub is digits or it is not read: `tostring` on a field the
+# answer lacks is the word `null`, and "null commit(s) behind" is a lie.
+is_count() {
+    case "$1" in
+    '' | *[!0-9]*) return 1 ;;
+    esac
+    return 0
+}
+
+has_upstream() { g "$1" config --get remote.upstream.url >/dev/null 2>&1; }
+
+read_fork() {
+    local repo="$1" branch="$2" counts behind ahead
+    if ! has_upstream "$repo"; then
+        [ "$FETCH" -eq 0 ] || ask_github_fork "$repo" "$branch"
+        return 0
+    fi
+    if ! has_ref "$repo" "refs/remotes/upstream/$branch"; then
+        if [ "$UPSTREAM_FETCHED_OK" -eq 1 ]; then
+            finding "fork: no upstream/$branch after the fetch: upstream has no branch $branch"
+        elif [ "$FETCH" -eq 1 ]; then
+            finding "fork: no upstream/$branch here, and the fetch of upstream above did not bring one"
+        else
+            finding "fork: no upstream/$branch here: the upstream remote was never fetched (\`--fetch\` asks it)"
+        fi
+        return 0
+    fi
+    # No `origin/<branch>` is already a finding above; nothing to compare.
+    has_ref "$repo" "refs/remotes/origin/$branch" || return 0
+    counts="$(g "$repo" rev-list --left-right --count \
+        "upstream/$branch...origin/$branch" 2>/dev/null || true)"
+    [ -n "$counts" ] || return 0
+    behind="${counts%%[[:space:]]*}"
+    ahead="${counts##*[[:space:]]}"
+    [ "$behind" = 0 ] ||
+        finding "fork: origin/$branch is $behind commit(s) behind upstream/$branch, as of the last fetch"
+    [ "$ahead" = 0 ] ||
+        finding "fork: origin/$branch has $ahead commit(s) upstream/$branch does not"
+}
+
+# `gh api`, read-only, twice at most per repository: is origin a fork, and
+# if so how far is its <branch> from the parent's default branch. The fields
+# come back joined by 0x1F for the reason `read_branches` gives: an empty
+# middle field must stay where it was printed.
+ask_github_fork() {
+    local repo="$1" branch="$2" url slug owner is_fork parent parent_default behind ahead
+    url="$(g "$repo" config --get remote.origin.url 2>/dev/null || true)"
+    is_github_origin "$url" || return 0
+    slug="$(repo_slug_of "$url" || true)"
+    [ -n "$slug" ] || return 0
+    owner="${slug%%/*}"
+    gh_api_line "fork check" "repos/$slug" \
+        '[(.fork|tostring), (.parent.full_name // ""), (.parent.default_branch // "")] | join("\u001f")' ||
+        return 0
+    IFS=$'\037' read -r is_fork parent parent_default <<<"$GH_LINE"
+    [ "$is_fork" = true ] || return 0
+    if [ -z "$parent" ]; then
+        finding "fork of a repository GitHub does not show (deleted, or private to you?), and no remote named upstream here"
+        return 0
+    fi
+    finding "fork of $parent (per GitHub), and no remote named upstream here: \`git remote add upstream https://github.com/$parent.git\` reads the drift locally"
+    if gh_api_line "fork check" \
+            "repos/$parent/compare/$parent_default...$owner:$branch?per_page=1" \
+            '[(.behind_by|tostring), (.ahead_by|tostring)] | join("\u001f")'; then
+        IFS=$'\037' read -r behind ahead <<<"$GH_LINE"
+        if ! is_count "$behind" || ! is_count "$ahead"; then
+            finding "fork: GitHub's compare of origin/$branch with $parent's $parent_default was not two counts; not read"
+            return 0
+        fi
+        [ "$behind" = 0 ] ||
+            finding "fork: origin/$branch is $behind commit(s) behind $parent's $parent_default (per GitHub)"
+        [ "$ahead" = 0 ] ||
+            finding "fork: origin/$branch has $ahead commit(s) $parent's $parent_default does not (per GitHub)"
+    else
+        finding "fork: could not compare origin/$branch with $parent's $parent_default (the fork check line above says why)"
+    fi
+}
+
+# --- the shape pin ------------------------------------------------------------
+#
+# THE FOURTH LAYER, under Brett Heap's RULING of 2026-09-11, verbatim: "next
+# layer: shape-pin drift". An assembly root and a family holder each carry
+# `contracts/shape-pin.yaml` — A COPY PIN, in the standard's own words: the
+# scaffold COPIED a small set of files out of openRepoShape (the Makefile, the
+# validators, the bootstrap, the workflow) so a project runs its own gate with
+# no upstream mounted, and the pin records the commit they came from plus a
+# sha256 per copy. Three things can be out of sync with it, and each is read:
+#
+# 1. A COPY EDITED IN PLACE. Every `files:` row is re-hashed with whatever
+#    sha256 this machine has (GNU `sha256sum`, the `shasum` a Mac ships, or
+#    `openssl`); a digest that differs is DRIFT, and the standard's exit is
+#    named with it — carry the change upstream, never re-digest. The same
+#    check the root's own `scripts/validate-pins.py` (or the holder's
+#    `validate-family.py`) makes on every pull request, read here across the
+#    estate without running the validator, which also asks lockstep questions
+#    a report about the shape does not. A row whose file is missing is named.
+# 2. THE MIRROR. `project.yaml` (or `family.yaml`) carries a `shape:` block
+#    that mirrors the pin's commit; `update-shape.py` moves both together, so
+#    two different commits there is a half-done update.
+# 3. THE PIN AGAINST THE SOURCE'S DEFAULT BRANCH. From a clone of the source
+#    under the projects directory when there is one — found by its origin's
+#    slug, the way `--repo` finds an estate, never by folder name — read from
+#    local refs, as of that clone's last fetch; else, under `--fetch`, from
+#    GitHub's compare endpoint, once per pin per run. Behind is a finding
+#    whose exit is `update-shape.py check --root <root>`; a pin the branch
+#    does not contain is a finding too, because the standard squash-merges
+#    and a branch commit is orphaned the moment its pull request lands. When
+#    neither source answered, the note says currency was NOT read and why,
+#    so nobody mistakes "no finding" for "current".
+#
+# A root with no `contracts/shape-pin.yaml` says nothing here: a root adopted
+# before the pin existed, or a probe, is not out of sync with a pin it never
+# had.
+
+SHA_TOOL=""
+# Which sha256 this machine has: GNU `sha256sum`, the `shasum` a Mac ships, or
+# `openssl`. Chosen ONCE, here, and not inside `file_sha256`, whose caller runs
+# it in a command substitution — a subshell, where nothing chosen would
+# survive to the next file.
+choose_sha_tool() {
+    [ -z "$SHA_TOOL" ] || return 0
+    if command -v sha256sum >/dev/null 2>&1; then SHA_TOOL=sha256sum
+    elif command -v shasum >/dev/null 2>&1; then SHA_TOOL=shasum
+    elif command -v openssl >/dev/null 2>&1; then SHA_TOOL=openssl
+    else SHA_TOOL=none
+    fi
+}
+
+# sha256 of one file's bytes, as `file_sha256` in the standard's
+# `scripts/repo_shape.py` computes it. Empty when the tool could not read the
+# file. GNU `sha256sum` and `shasum` mark a name holding a backslash or a
+# newline by prefixing the whole line with `\`; that is about the name, not
+# the digest, and is dropped.
+file_sha256() {
+    local file="$1" out=""
+    case "$SHA_TOOL" in
+    sha256sum) out="$(sha256sum -- "$file" 2>/dev/null || true)" ;;
+    shasum) out="$(shasum -a 256 -- "$file" 2>/dev/null || true)" ;;
+    openssl) out="$(openssl dgst -sha256 -r -- "$file" 2>/dev/null || true)" ;;
+    esac
+    out="${out%% *}"
+    printf '%s' "${out#\\}"
+}
+
+# `path<TAB>sha256` per row of the pin's `files:` block — the rows
+# `update-shape.py` writes as `  - path: <p>` / `    sha256: "<hex>"`, in
+# that order; a hand-edited row the other way round is dropped, which is one
+# reason the note counts rows. A trailing comment on a path is not part of
+# it. A new top-level key ends the block.
+shape_pin_rows() {
+    local file="$1" line path="" digest in_files=0
+    [ -f "$file" ] || return 0
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
+        case "$line" in
+        '#'*) continue ;;
+        'files:'*) in_files=1; path=""; continue ;;
+        [![:space:]]*) in_files=0; continue ;;
+        esac
+        [ "$in_files" -eq 1 ] || continue
+        case "$line" in
+        '  - path:'*)
+            path="$(trim_unquote "${line#*:}")"
+            case "$path" in
+            *' #'*) path="$(trim_unquote "${path%% #*}")" ;;
+            esac
+            ;;
+        '    sha256:'*)
+            digest="$(trim_unquote "${line#*:}")"
+            [ -z "$path" ] || printf '%s\t%s\n' "$path" "$digest"
+            path=""
+            ;;
+        esac
+    done <"$file"
+}
+
+# One two-space-indented scalar out of one top-level section of a manifest —
+# `shape:` / `  commit:` — with parameter expansion only, like `yaml_scalar`.
+nested_scalar() {
+    local file="$1" section="$2" key="$3" line in_section=0
+    [ -f "$file" ] || return 0
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
+        case "$line" in
+        '#'*) continue ;;
+        "$section:"*) in_section=1; continue ;;
+        [![:space:]]*) [ "$in_section" -eq 0 ] || return 0 ;;
+        esac
+        [ "$in_section" -eq 1 ] || continue
+        case "$line" in
+        "  $key:"*) printf '%s\n' "$(trim_unquote "${line#*:}")"; return 0 ;;
+        esac
+    done <"$file"
+}
+
+# THE SOURCE'S DEFAULT BRANCH is what a pin is measured against. openRepoShape's
+# is `main`, but `source_repository:` is whatever a fork of the standard was
+# named, so it is READ where it can be — the clone's `origin/HEAD`, or GitHub's
+# `default_branch` — and remembered per source for the run; `main` when
+# neither says. And the answer about ONE pin serves every root that carries
+# it: a family's holder and members are cut from the same commit, and N
+# identical questions would be N round-trips and N strikes against
+# `gh_api_line`'s budget, which the fork check shares.
+SHAPE_DEFAULT_SOURCE=""
+SHAPE_DEFAULT_BRANCH=""
+SHAPE_ASKED=""
+SHAPE_ASKED_BEHIND=""
+SHAPE_ASKED_AHEAD=""
+
+# The pin's commit against the source's default branch, from a clone of the
+# source under the projects directory — found by its origin's slug, the way
+# `--repo` finds an estate, never by folder name. `merge-base --is-ancestor`
+# says whether the branch contains it, `rev-list --count` says how far behind.
+# Returns 0 when it could answer (finding or not), 1 when there is no such
+# clone or it has never fetched its default branch, so the caller can try
+# GitHub or say "not read".
+shape_currency_from_clone() {
+    local root="$1" commit="$2" source="$3" clone n default
+    clone="$(clone_with_origin "$source" || true)"
+    [ -n "$clone" ] || return 1
+    default="$(g "$clone" symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+    default="${default#origin/}"
+    [ -n "$default" ] || default=main
+    has_ref "$clone" "refs/remotes/origin/$default" || return 1
+    SHAPE_DEFAULT_SOURCE="$source"
+    SHAPE_DEFAULT_BRANCH="$default"
+    if ! g "$clone" cat-file -e "$commit^{commit}" 2>/dev/null; then
+        finding "shape pin $(short "$commit") is not in the clone of $source at $clone, as of its last fetch: fetch it, or the pin is on a commit that was squash-merged away"
+        return 0
+    fi
+    if g "$clone" merge-base --is-ancestor "$commit" "origin/$default" 2>/dev/null; then
+        n="$(g "$clone" rev-list --count "$commit..origin/$default" 2>/dev/null || true)"
+        [ -z "$n" ] || [ "$n" = 0 ] ||
+            finding "shape pin $(short "$commit") is $n commit(s) behind $source $default (per the clone at $clone, as of its last fetch): update-shape.py check --root $root"
+    else
+        finding "shape pin $(short "$commit") is not on $source $default (per the clone at $clone): a branch commit, which the standard's squash-merge orphans"
+    fi
+    return 0
+}
+
+# The same question put to GitHub, under `--fetch` only and only when no clone
+# answered: the source's default branch once per source, then `compare/<pin>
+# ...<default>` once per pin, with the pin as base so `ahead_by` is what the
+# branch has since the pin and `behind_by` is what the pin has that the
+# branch never did. Returns 1 when GitHub did not answer (`gh_api_line` has
+# said why, or an earlier failure settled the run).
+ask_github_shape_pin() {
+    local root="$1" commit="$2" source="$3" behind ahead default
+    if [ "$SHAPE_DEFAULT_SOURCE" = "$source" ] && [ -n "$SHAPE_DEFAULT_BRANCH" ]; then
+        default="$SHAPE_DEFAULT_BRANCH"
+    else
+        gh_api_line "shape check" "repos/$source" '.default_branch // "main"' || return 1
+        default="$GH_LINE"
+        [ -n "$default" ] || default=main
+        SHAPE_DEFAULT_SOURCE="$source"
+        SHAPE_DEFAULT_BRANCH="$default"
+    fi
+    if [ "$SHAPE_ASKED" = "$source $commit" ]; then
+        behind="$SHAPE_ASKED_BEHIND"
+        ahead="$SHAPE_ASKED_AHEAD"
+    else
+        gh_api_line "shape check" "repos/$source/compare/$commit...$default?per_page=1" \
+            '[(.behind_by|tostring), (.ahead_by|tostring)] | join("\u001f")' || return 1
+        IFS=$'\037' read -r behind ahead <<<"$GH_LINE"
+        SHAPE_ASKED="$source $commit"
+        SHAPE_ASKED_BEHIND="$behind"
+        SHAPE_ASKED_AHEAD="$ahead"
+    fi
+    if ! is_count "$behind" || ! is_count "$ahead"; then
+        finding "shape: GitHub's compare of pin $(short "$commit") with $source $default was not two counts; not read"
+        return 0
+    fi
+    [ "$behind" = 0 ] ||
+        finding "shape pin $(short "$commit") is not on $source $default: $behind commit(s) of it are not there (per GitHub) — a branch commit, which the standard's squash-merge orphans"
+    [ "$ahead" = 0 ] ||
+        finding "shape pin $(short "$commit") is $ahead commit(s) behind $source $default (per GitHub): update-shape.py check --root $root"
+    return 0
+}
+
+# A root's or holder's shape pin, all three reads, and one note line saying
+# what was pinned, how many copies matched, and where currency came from — or
+# that it was NOT read, and why, so silence is never mistaken for current.
+read_shape() {
+    local root="$1" manifest="$2" pin commit source mirror path digest actual
+    local ok=0 total=0 currency=""
+    pin="$root/contracts/shape-pin.yaml"
+    [ -f "$pin" ] || return 0
+    commit=""; yaml_scalar "$pin" commit && commit="$YAML_VALUE"
+    source=""; yaml_scalar "$pin" source_repository && source="$YAML_VALUE"
+    if [ -z "$commit" ]; then
+        finding "shape: contracts/shape-pin.yaml records no commit"
+        return 0
+    fi
+    choose_sha_tool
+    while IFS=$'\t' read -r path digest; do
+        [ -n "$path" ] || continue
+        total=$((total + 1))
+        if [ ! -f "$root/$path" ]; then
+            finding "shape copy $path is missing; contracts/shape-pin.yaml names it (update-shape.py check --root $root)"
+            continue
+        fi
+        if [ "$SHA_TOOL" = none ]; then
+            finding "shape copy $path not checked: no sha256sum, shasum or openssl on PATH"
+            continue
+        fi
+        actual="$(file_sha256 "$root/$path")"
+        if [ -z "$actual" ]; then
+            finding "shape copy $path not checked: \`$SHA_TOOL\` could not read it"
+        elif [ "$actual" != "$digest" ]; then
+            finding "shape copy $path edited in place: its sha256 is not the one contracts/shape-pin.yaml records (drift: carry the change upstream, never re-digest)"
+        else
+            ok=$((ok + 1))
+        fi
+    done < <(shape_pin_rows "$pin")
+    # THE MIRROR. `update-shape.py` moves the pin and the manifest's `shape:`
+    # block together, and refuses a manifest that has no such block — so a
+    # pin beside a manifest without one is the same half-done state as two
+    # different commits.
+    mirror="$(nested_scalar "$root/$manifest" shape commit)"
+    if [ -z "$mirror" ]; then
+        finding "shape: $manifest carries no \`shape:\` commit beside contracts/shape-pin.yaml (update-shape.py moves both together)"
+    elif [ "$mirror" != "$commit" ]; then
+        finding "shape: $manifest mirrors $(short "$mirror") but contracts/shape-pin.yaml pins $(short "$commit"): out of step (update-shape.py moves both together)"
+    fi
+    # CURRENCY: the clone first, because it is local and free, and reading it
+    # before asking GitHub is what the documents promise; GitHub only under
+    # `--fetch`, and only when no clone answered.
+    if [ -n "$source" ]; then
+        if shape_currency_from_clone "$root" "$commit" "$source"; then
+            currency="; against $source $SHAPE_DEFAULT_BRANCH per a clone under the projects directory"
+        elif [ "$FETCH" -eq 1 ] && ask_github_shape_pin "$root" "$commit" "$source"; then
+            currency="; against $source $SHAPE_DEFAULT_BRANCH per GitHub"
+        elif [ "$FETCH" -eq 1 ]; then
+            currency="; currency NOT read: no clone of $source with its default branch fetched under the projects directory, and GitHub did not answer (an earlier line says why)"
+        else
+            currency="; currency not read (no clone of $source with its default branch fetched under the projects directory; --fetch asks GitHub)"
+        fi
+    fi
+    say "    shape: pinned at $(short "$commit") of ${source:-an unnamed source}; $ok/$total copies match their digests$currency"
+}
+
+# --- the parked record against disk -------------------------------------------
+#
+# THE FIFTH LAYER, under Brett Heap's RULING of 2026-09-11, verbatim: "next
+# layer: parked record against disk". `park` RECORDS every open feature of an
+# estate in the person's private workspace repository — `workspaces/<org>/
+# <id>.yaml`, one block per project, one entry per feature, and per leg the
+# commit it was parked at and whether that commit was pushed — and `resume`
+# rebuilds the worktrees from that record on the next workstation. Between
+# the two, the record and the disk drift apart in exactly the ways `resume`
+# later refuses, and this layer reads them beforehand, the way `resume.sh`
+# will:
+#
+# 1. A RECORDED FEATURE WITH NO WORKTREE HERE on its branch: parked, and not
+#    resumed on this machine. `resume <Name>` is the exit; nothing here adds
+#    a worktree.
+# 2. A WORKTREE WHOSE BRANCH TIP IS NOT THE PARKED COMMIT: moved on since it
+#    was parked (park again before leaving); or BEHIND it — the record is
+#    newer, parked later on another workstation, which `resume` refuses to
+#    reset; or diverged from it; or a parked commit this machine never
+#    fetched. ONE GAP IS NOT A FINDING: `resume` recreates the worktree at the
+#    parked commit and SOFT-RESETS the WIP commits `park` made, so a resumed
+#    feature's tip is legitimately `<parked>~<wip_depth>` with the work back
+#    in the working tree — `resume.sh`'s `wip_gap_is_ours` is what keeps it
+#    from refusing that, and the same test is made here.
+# 3. A LEG PARKED WITH `--no-push`: the record says `pushed: false`, only the
+#    workstation that parked it has the WIP commit, and `resume` refuses it.
+# 4. A WORKTREE ON DISK THAT THE RECORD DOES NOT KNOW: a feature that was
+#    never parked, which is the one thing `park` exists to carry.
+#
+# THE RECORD IS FOUND WHERE `park` FILES IT AND `resume` LOOKS FOR IT:
+# `${AGENT_PROTOCOL_ROOT:-~/.agents}/workspace.yaml` names the workspace
+# repository and its checkout (`path:`), plus per-org overrides under
+# `orgs:`, each checkout counted ONCE by physical path (an override pointing
+# at the default's clone is one clone, not two orgs); every checkout's
+# `workspaces/<org>/*.yaml` is scanned for the estate's ID — a standalone
+# project's `project.yaml` `id:`, a family's `family.yaml` `id:`, which is
+# the name `park` files under — and then, if none, for the estate's FOLDER
+# name, which is what `resume <Name>` looks up; basenames are compared
+# case-insensitively, as `resume` compares them. No config, a checkout that
+# is not on this machine, or no record for this estate, is a NOTE, not a
+# finding: a machine that never parked has nothing to be out of sync with.
+# Two orgs recording the same id is a note too, unless one of them is the org
+# this root's origin names. Nothing here reads the workspace repository's
+# remote: the record is as of its last pull, and the estate's line says so.
+#
+# A FAMILY's record has one block per MEMBER, matched by its `root:` —
+# `<family folder>/<member folder>`, the casing `workspace_manifest_root_value`
+# writes — and the holder has none. Each leg is read in the repository it
+# lives in: the root for the `repo` and `assembly` roles, the leg's own
+# checkout for `spec`, `code` and any other role `project.yaml` places.
+
+WORKSPACE_CONFIG="${AGENT_PROTOCOL_ROOT:-$HOME/.agents}/workspace.yaml"
+RECORD_FILE=""
+RECORD_NOTE=""
+RECORD_ID=""
+NL=$'\n'
+
+# shellcheck disable=SC2088  # a literal leading ~ is what is matched here
+expand_home() {
+    local value="$1"
+    case "$value" in
+    '~') printf '%s\n' "$HOME" ;;
+    '~/'*) printf '%s\n' "$HOME/${value#\~/}" ;;
+    *) printf '%s\n' "$value" ;;
+    esac
+}
+
+# Every workspace checkout the config names: the top-level `path:` and each
+# `    path:` under `orgs:`. Read only; a malformed block is a block not found.
+workspace_checkouts() {
+    local file="$1" line
+    [ -r "$file" ] || return 0
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
+        case "$line" in
+        '#'*) continue ;;
+        'path:'* | '    path:'*) expand_home "$(trim_unquote "${line#*:}")" ;;
+        esac
+    done <"$file"
+}
+
+# `<org><TAB><file>` for every `workspaces/<org>/<id>.yaml` in every checkout,
+# basename compared case-insensitively — `resume`'s `manifest_candidates`.
+record_candidates() {
+    local want checkout dir file base
+    want="$(lower "$1")"
+    shift
+    for checkout in "$@"; do
+        [ -d "$checkout/workspaces" ] || continue
+        for dir in "$checkout"/workspaces/*/; do
+            dir="${dir%/}"
+            [ -d "$dir" ] || continue
+            for file in "$dir"/*.yaml; do
+                [ -f "$file" ] || continue
+                base="${file##*/}"
+                base="${base%.yaml}"
+                [ "$(lower "$base")" = "$want" ] || continue
+                printf '%s\t%s\n' "${dir##*/}" "$file"
+            done
+        done
+    done
+}
+
+# THIS estate's record, once per estate: RECORD_FILE, or RECORD_NOTE saying
+# why there is none to read. RECORD_ID is what a standalone block is matched
+# by.
+locate_record() {
+    local manifest checkouts candidates count org file owner url line physical seen missing=""
+    local -a dirs=()
+    RECORD_FILE=""
+    RECORD_NOTE=""
+    RECORD_ID=""
+    if [ "$ESTATE_KIND" = "family" ]; then
+        manifest="$ESTATE_ROOT/family.yaml"
+    else
+        manifest="$ESTATE_ROOT/project.yaml"
+    fi
+    if yaml_scalar "$manifest" id; then RECORD_ID="$YAML_VALUE"; fi
+    [ -n "$RECORD_ID" ] || RECORD_ID="$(lower "$ESTATE_NAME")"
+    if [ ! -f "$WORKSPACE_CONFIG" ]; then
+        RECORD_NOTE="parked record: no $WORKSPACE_CONFIG on this machine, so parked features are not read (\`resume --workspace <owner>/<repo>\` writes it)"
+        return 0
+    fi
+    if [ ! -r "$WORKSPACE_CONFIG" ]; then
+        RECORD_NOTE="parked record: $WORKSPACE_CONFIG cannot be read (permissions), so parked features are not read"
+        return 0
+    fi
+    checkouts="$(workspace_checkouts "$WORKSPACE_CONFIG")"
+    if [ -z "$checkouts" ]; then
+        RECORD_NOTE="parked record: $WORKSPACE_CONFIG names no \`path:\`, so parked features are not read"
+        return 0
+    fi
+    # ONE ENTRY PER DIRECTORY, by PHYSICAL path — `resume`'s `add_workspace`,
+    # for its reason (F4 of the review on openRepoShape #83): an `orgs:`
+    # override pointing at the default's clone would otherwise be scanned
+    # twice and every record in it counted twice, which reads as "two orgs
+    # record this id". A checkout the config names and this machine does not
+    # have is skipped and, if none is left, said.
+    while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        [ -d "$line" ] || { missing="${missing:+$missing }$line"; continue; }
+        physical="$(cd "$line" 2>/dev/null && pwd -P)" || physical="$line"
+        for seen in ${dirs[@]+"${dirs[@]}"}; do
+            [ "$seen" != "$physical" ] || continue 2
+        done
+        dirs+=("$physical")
+    done <<<"$checkouts"
+    if [ ${#dirs[@]} -eq 0 ]; then
+        RECORD_NOTE="parked record: the workspace checkout $WORKSPACE_CONFIG names is not on this machine ($missing), so parked features are not read (\`resume\` clones it)"
+        return 0
+    fi
+    candidates="$(record_candidates "$RECORD_ID" "${dirs[@]}")"
+    if [ -z "$candidates" ] && [ "$(lower "$ESTATE_NAME")" != "$(lower "$RECORD_ID")" ]; then
+        # Filed under the id by `park`; looked up by folder by `resume <Name>`.
+        candidates="$(record_candidates "$ESTATE_NAME" "${dirs[@]}")"
+    fi
+    if [ -z "$candidates" ]; then
+        RECORD_NOTE="parked record: none for '$RECORD_ID' under ${dirs[*]} — nothing of this estate has been parked, or not into this workspace"
+        return 0
+    fi
+    count="$(printf '%s\n' "$candidates" | grep -c . || true)"
+    if [ "$count" -eq 1 ]; then
+        RECORD_FILE="${candidates#*	}"
+        return 0
+    fi
+    # Two orgs record this id: the one this root's origin belongs to, if any.
+    url="$(g "$ESTATE_ROOT" config --get remote.origin.url 2>/dev/null || true)"
+    owner="$(repo_slug_of "$url" || true)"
+    owner="${owner%%/*}"
+    while IFS=$'\t' read -r org file; do
+        [ -n "$org" ] || continue
+        if [ -n "$owner" ] && [ "$(lower "$org")" = "$(lower "$owner")" ]; then
+            RECORD_FILE="$file"
+            return 0
+        fi
+    done <<<"$candidates"
+    RECORD_NOTE="parked record: $count records for '$RECORD_ID' in different orgs, and none is the org this root's origin names; not read (\`resume --org\` is how one is chosen)"
+}
+
+# One project block of a record as rows, fields joined by 0x1F (a tab is IFS
+# whitespace, and an absent optional key — `park` writes no key for an empty
+# value — would shift every later field left, the hazard `read_branches`
+# names): `project` with parked_at, parked_on, lane and active, once; `branch`
+# with the branch, per feature; `leg` with branch, role, parked_commit,
+# pushed and wip_depth, per leg. The block is the one whose `id:` (a
+# standalone) or `root:` (a family member) is the selector's. The layout is
+# the fixed one `workspace_write_manifest` emits — two spaces per level,
+# `pushed:` the last key of a leg, which is where the leg's row is emitted —
+# so a hand-edited leg without `pushed:` is dropped; its branch is still
+# known from the `branch` row, so it is never accused of being unparked.
+record_rows() {
+    local file="$1" sel="$2" line matched=0 value
+    local parked_at="" parked_on="" lane="" active="" branch="" role="" commit="" pushed="" depth=""
+    [ -f "$file" ] || return 0
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
+        case "$line" in
+        '  - id:'*)
+            matched=0
+            parked_at=""; parked_on=""; lane=""; active=""; branch=""; role=""
+            value="$(trim_unquote "${line#*:}")"
+            case "$sel" in
+            id=*) [ "$(lower "$value")" != "$(lower "${sel#id=}")" ] || matched=1 ;;
+            esac
+            ;;
+        '    root:'*)
+            value="$(trim_unquote "${line#*:}")"
+            case "$sel" in
+            root=*) [ "$(lower "$value")" != "$(lower "${sel#root=}")" ] || matched=1 ;;
+            esac
+            ;;
+        '    parked_at:'*) parked_at="$(trim_unquote "${line#*:}")" ;;
+        '    parked_on:'*) parked_on="$(trim_unquote "${line#*:}")" ;;
+        '    parked_by_lane:'*) lane="$(trim_unquote "${line#*:}")" ;;
+        '    active_feature:'*) active="$(trim_unquote "${line#*:}")" ;;
+        '    features:'*)
+            if [ "$matched" -eq 1 ]; then
+                printf 'project\037%s\037%s\037%s\037%s\n' "$parked_at" "$parked_on" "$lane" "$active"
+            fi
+            ;;
+        '      - branch:'*)
+            branch="$(trim_unquote "${line#*:}")"
+            if [ "$matched" -eq 1 ] && [ -n "$branch" ]; then
+                printf 'branch\037%s\n' "$branch"
+            fi
+            ;;
+        '          - role:'*) role="$(trim_unquote "${line#*:}")"; commit=""; pushed=""; depth="" ;;
+        '            parked_commit:'*) commit="$(trim_unquote "${line#*:}")" ;;
+        '            wip_depth:'*) depth="$(trim_unquote "${line#*:}")" ;;
+        '            pushed:'*)
+            pushed="$(trim_unquote "${line#*:}")"
+            if [ "$matched" -eq 1 ] && [ -n "$branch" ] && [ -n "$role" ]; then
+                printf 'leg\037%s\037%s\037%s\037%s\037%s\n' "$branch" "$role" "$commit" "$pushed" "$depth"
+            fi
+            ;;
+        esac
+    done <"$file"
+    return 0
+}
+
+# The repository a leg role lives in: the root for `repo` and `assembly`, else
+# the path `project.yaml` gives that role, else a folder named for the role.
+leg_repo_for_role() {
+    local root="$1" want="$2" line role="" path=""
+    case "$want" in
+    repo | assembly) printf '%s\n' "$root"; return 0 ;;
+    esac
+    if [ -f "$root/project.yaml" ]; then
+        while IFS= read -r line || [ -n "$line" ]; do
+            line="${line%$'\r'}"
+            case "$line" in
+            '  - role:'*) role="$(trim_unquote "${line#*:}")"; path="" ;;
+            '    path:'*)
+                path="$(trim_unquote "${line#*:}")"
+                if [ "$role" = "$want" ] && [ -n "$path" ] && [ "$path" != "." ]; then
+                    printf '%s\n' "$root/$path"
+                    return 0
+                fi
+                ;;
+            [![:space:]]*) role="" ;;
+            esac
+        done <"$root/project.yaml"
+    fi
+    if [ -d "$root/$want" ]; then
+        printf '%s\n' "$root/$want"
+        return 0
+    fi
+    return 1
+}
+
+# The path of the worktree checked out on `<branch>` in `<repo>`, main or
+# linked, or nothing.
+worktree_on_branch() {
+    local repo="$1" want="$2" line path=""
+    while IFS= read -r line; do
+        case "$line" in
+        "worktree "*) path="${line#worktree }" ;;
+        "branch refs/heads/$want") printf '%s\n' "$path"; return 0 ;;
+        esac
+    done < <(g "$repo" worktree list --porcelain 2>/dev/null || true)
+    return 1
+}
+
+# THE GAP A RESUME ITSELF LEAVES. `park` commits the WIP under a fixed subject
+# prefix and records how many such commits sit on the tip (`wip_depth`);
+# `resume` recreates the worktree at the parked commit and SOFT-RESETS exactly
+# those commits away, so a resumed feature's tip is legitimately `<parked>~
+# <wip_depth>` with the work back in the working tree. `resume.sh`'s
+# `wip_gap_is_ours` is what keeps it from refusing that state, and this is
+# the same test: the gap is exactly `wip_depth` commits, every one of them a
+# `wip: park …` commit. Read-only (`log -1 --format=%s`).
+WIP_PREFIX='wip: park '
+wip_gap_is_ours() {
+    local repo="$1" from="$2" to="$3" depth="$4" count subject step=0
+    is_count "$depth" || return 1
+    [ "$depth" -gt 0 ] || return 1
+    count="$(g "$repo" rev-list --count "$from..$to" 2>/dev/null || printf 0)"
+    [ "$count" = "$depth" ] || return 1
+    while [ "$step" -lt "$depth" ]; do
+        subject="$(g "$repo" log -1 --format=%s "$to~$step" 2>/dev/null || true)"
+        case "$subject" in
+        "$WIP_PREFIX"*) ;;
+        *) return 1 ;;
+        esac
+        step=$((step + 1))
+    done
+    return 0
+}
+
+# One recorded leg against disk: the four states above, read in the leg's own
+# repository.
+check_parked_leg() {
+    local root="$1" branch="$2" role="$3" commit="$4" pushed="$5" parked_at="$6" parked_on="$7" depth="$8"
+    local repo tree tip n
+    repo="$(leg_repo_for_role "$root" "$role" || true)"
+    if [ -z "$repo" ] || [ ! -e "$repo/.git" ]; then
+        finding "parked feature $branch ($role leg): the record names a leg this root does not mount here"
+        return 0
+    fi
+    if [ "$pushed" = false ]; then
+        finding "parked feature $branch ($role leg): parked with --no-push on ${parked_on:-another workstation}; only that workstation has the WIP commit, and \`resume\` refuses it"
+    fi
+    tree="$(worktree_on_branch "$repo" "$branch" || true)"
+    if [ -z "$tree" ]; then
+        finding "parked feature $branch ($role leg): no worktree on that branch here; parked ${parked_at:-?} on ${parked_on:-?} — \`resume $ESTATE_NAME\` brings it back"
+        return 0
+    fi
+    [ -n "$commit" ] || return 0
+    tip="$(g "$repo" rev-parse -q --verify "refs/heads/$branch" 2>/dev/null || true)"
+    [ -n "$tip" ] || return 0
+    [ "$tip" != "$commit" ] || return 0
+    if ! g "$repo" cat-file -e "$commit^{commit}" 2>/dev/null; then
+        finding "parked feature $branch ($role leg): its parked commit $(short "$commit") is not here — never fetched, or parked with --no-push on ${parked_on:-another workstation}"
+    elif g "$repo" merge-base --is-ancestor "$commit" "$tip" 2>/dev/null; then
+        n="$(g "$repo" rev-list --count "$commit..$tip" 2>/dev/null || true)"
+        finding "parked feature $branch ($role leg): moved on since it was parked, ${n:-?} commit(s) after $(short "$commit") — park again before leaving"
+    elif g "$repo" merge-base --is-ancestor "$tip" "$commit" 2>/dev/null; then
+        # RESUMED HERE, not behind: the gap is the WIP `resume` un-committed.
+        if wip_gap_is_ours "$repo" "$tip" "$commit" "$depth"; then
+            return 0
+        fi
+        finding "parked feature $branch ($role leg): this worktree is BEHIND the parked commit $(short "$commit"), parked ${parked_at:-?} on ${parked_on:-?} — the record is newer, and \`resume\` refuses to reset it"
+    else
+        finding "parked feature $branch ($role leg): diverged from the parked commit $(short "$commit"), parked ${parked_at:-?} on ${parked_on:-?} — reconcile by hand: \`git -C $repo log --oneline $(short "$commit")..$branch\`"
+    fi
+    return 0
+}
+
+# Linked worktrees on disk — in the root and in each mounted leg — whose
+# branch the record does not know: work that was never parked.
+unrecorded_worktrees() {
+    local root="$1" recorded="$2" repo where line path="" branch="" first=1 state leg
+    local -a repos=("$root")
+    while IFS=$'\t' read -r state leg; do
+        [ "$state" = mounted ] || continue
+        repos+=("$root/$leg")
+    done < <(declared_legs "$root")
+    for repo in "${repos[@]}"; do
+        where="${repo#"$root"}"
+        where="${where#/}"
+        [ -n "$where" ] || where="root"
+        first=1; path=""; branch=""
+        while IFS= read -r line; do
+            case "$line" in
+            "worktree "*) path="${line#worktree }"; branch="" ;;
+            "branch "*) branch="${line#branch refs/heads/}" ;;
+            "")
+                if [ "$first" -eq 1 ]; then
+                    first=0
+                elif [ -n "$branch" ]; then
+                    case "$recorded" in
+                    *"$NL$branch$NL"*) ;;
+                    *) finding "worktree on $branch ($where): not in the parked record — never parked; \`park\` carries the features under this root's worktree root, anything else is yours to keep or remove" ;;
+                    esac
+                fi
+                path=""; branch=""
+                ;;
+            esac
+        done < <(g "$repo" worktree list --porcelain 2>/dev/null; printf '\n')
+    done
+}
+
+# A root's block of the record against its disk: the note line, one finding
+# per leg that is out of step, and the worktrees the record does not know.
+# The selectors are tried in order until one names a block: a standalone root
+# by its `id:` first, then by its folder as `root:` — the block a record found
+# by folder name carries — and a family member by its `root:` alone.
+read_record() {
+    local root="$1" sel rows="" kind a b c d e n_features=0
+    local parked_at="" parked_on="" lane="" active="" recorded="$NL"
+    shift
+    [ -n "$RECORD_FILE" ] || return 0
+    for sel in "$@"; do
+        rows="$(record_rows "$RECORD_FILE" "$sel")"
+        [ -z "$rows" ] || break
+    done
+    if [ -z "$rows" ]; then
+        # A root the record does not mention: every worktree here is unparked,
+        # which is the one thing worth saying about it.
+        say "    parked record: no block for this root in ${RECORD_FILE##*/}"
+    else
+        while IFS=$'\037' read -r kind a b c d e; do
+            case "$kind" in
+            project) parked_at="$a"; parked_on="$b"; lane="$c"; active="$d" ;;
+            branch)
+                case "$recorded" in
+                *"$NL$a$NL"*) ;;
+                *) recorded="$recorded$a$NL"; n_features=$((n_features + 1)) ;;
+                esac
+                ;;
+            leg) check_parked_leg "$root" "$a" "$b" "$c" "$d" "$parked_at" "$parked_on" "$e" ;;
+            esac
+        done <<<"$rows"
+        say "    parked record: $n_features feature(s), parked ${parked_at:-?} on ${parked_on:-?}${lane:+ (lane $lane)}${active:+; active $active}"
+    fi
+    unrecorded_worktrees "$root" "$recorded"
+}
+
+ESTATE_FINDINGS=0
+ESTATE_REPOS=0
+#: The footer's last clause, decided once by `--fetch`: what this run changed.
+CHANGED_CLAUSE="nothing was changed."
+
+# --- one estate -------------------------------------------------------------
+#
+# ESTATE_KIND / ESTATE_DIR / ESTATE_ROOT / ESTATE_NAME must already be set —
+# by `estate_walk_up`, `estate_by_name`, `clone_with_origin`, or, for the
+# sweep, a direct `estate_here` on a discovered child. RETURNS 1 when
+# anything was found and 0 when nothing was, so the sweep can carry on and
+# the single-estate call site can turn that straight into its exit code.
+read_one_estate() {
+    local label branch path current_root="" rel line
+    ESTATE_FINDINGS=0
+    ESTATE_REPOS=0
+    if [ "$ESTATE_KIND" = "family" ]; then
+        say "status: $ESTATE_NAME - the family holder at $ESTATE_ROOT"
+        say "  the members' working clones beside it, and their legs, are read too."
+    else
+        say "status: $ESTATE_NAME - the assembly root at $ESTATE_ROOT"
+    fi
+    if [ "$FETCH" -eq 1 ]; then
+        say "  fetched first (--fetch): origin — and upstream, where a fork has one — is asked in every repository below, then it is read."
+    else
+        say "  as of the last fetch: status reads local refs only and fetches nothing."
+    fi
+    locate_record
+    if [ -n "$RECORD_FILE" ]; then
+        say "  parked record: $RECORD_FILE, as of its last pull"
+    else
+        say "  $RECORD_NOTE"
+    fi
+    say ""
+    while IFS=$'\t' read -r label branch path; do
+        [ -n "${path:-}" ] || continue
+        FINDINGS=()
+        FETCHED_OK=0
+        UPSTREAM_FETCHED_OK=0
+        ESTATE_REPOS=$((ESTATE_REPOS + 1))
+        case "$label" in
+        holder | root)
+            current_root="$path"
+            printf '  %-6s %-6s %s\n' "$label" "$branch" "$path"
+            if [ "$FETCH" -eq 1 ]; then
+                fetch_remote "$path" "$branch" origin
+                if has_upstream "$path"; then
+                    fetch_remote "$path" "$branch" upstream
+                fi
+            fi
+            read_head "$path" "$branch"
+            read_tracking "$path" "$branch"
+            read_fork "$path" "$branch"
+            if [ "$label" = holder ]; then
+                read_shape "$path" family.yaml
+            elif [ "$ESTATE_KIND" = "family" ]; then
+                read_shape "$path" project.yaml
+                read_record "$path" "root=$ESTATE_NAME/${path##*/}"
+            else
+                read_shape "$path" project.yaml
+                read_record "$path" "id=$RECORD_ID" "root=$ESTATE_NAME"
+            fi
+            read_worktree_state "$path"
+            read_branches "$path" "$branch"
+            read_worktrees "$path"
+            ;;
+        mounted)
+            printf '  %-6s %-6s %s\n' "leg" "$branch" "$path"
+            if [ "$FETCH" -eq 1 ]; then
+                fetch_remote "$path" "$branch" origin
+                if has_upstream "$path"; then
+                    fetch_remote "$path" "$branch" upstream
+                fi
+            fi
+            rel="${path#"$current_root"/}"
+            read_leg "$current_root" "$rel" "$branch"
+            read_fork "$path" "$branch"
+            ;;
+        unmounted)
+            printf '  %-6s %-6s %s\n' "leg" "$branch" "$path"
+            finding "declared in .gitmodules and not mounted (\`make bootstrap\` places it)"
+            ;;
+        missing)
+            printf '  %-6s %-6s %s\n' "root" "$branch" "$path"
+            finding "not here: no working clone beside the holder (\`resume $ESTATE_NAME\` places it)"
+            ;;
+        esac
+        if [ ${#FINDINGS[@]} -eq 0 ]; then
+            if [ "$label" = "mounted" ]; then
+                say "    at its pin, which is origin/$branch's tip as of the last fetch; clean"
+            else
+                say "    in sync with origin/$branch; clean"
+            fi
+        else
+            for line in "${FINDINGS[@]}"; do
+                say "    - $line"
+            done
+            ESTATE_FINDINGS=$((ESTATE_FINDINGS + ${#FINDINGS[@]}))
+        fi
+    done < <(estate_repos)
+    say ""
+    if [ "$ESTATE_REPOS" -eq 1 ]; then
+        say "status: $ESTATE_NAME - $ESTATE_FINDINGS finding(s) in 1 repository; $CHANGED_CLAUSE"
+    else
+        say "status: $ESTATE_NAME - $ESTATE_FINDINGS finding(s) in $ESTATE_REPOS repositories; $CHANGED_CLAUSE"
+    fi
+    [ "$ESTATE_FINDINGS" -eq 0 ]
+}
+
+# --- every estate -----------------------------------------------------------
+
+# Every estate under the projects directory, `<name><TAB><dir>` per row, in
+# NAME order — `park`'s own discovery, spelled the same way and for the same
+# reason: `~/projects` and `~/Projects` can each hold estates when both
+# exist, and name order reads them together.
+all_estate_dirs() {
+    local dir child
+    for dir in "${PROJECTS_DIRS[@]}"; do
+        [ -d "$dir" ] || continue
+        for child in "$dir"/*; do
+            [ -d "$child" ] || continue
+            if is_family_folder "$child" || is_project_root "$child"; then
+                printf '%s\t%s\n' "${child##*/}" "$child"
+            fi
+        done
+    done | LC_ALL=C sort -t $'\t' -k1,1
+}
+
+# Read every estate in `$1`, in name order, and end with a summary. An estate
+# with findings does not stop the others being read; the exit code is 1 when
+# any had findings. NOTHING IS SKIPPED HERE: `park`'s sweep skips a root
+# without the Speckit overlay because there is nothing to RUN in it; there is
+# always something to read.
+status_every_estate() {
+    local rows="$1" name dir total=0 bad=0 estate_status line
+    local -a summary=()
+    while IFS=$'\t' read -r name dir; do
+        [ -n "$name" ] || continue
+        estate_here "$dir" || continue
+        say "=== status $ESTATE_NAME ==="
+        total=$((total + 1))
+        estate_status=0
+        read_one_estate || estate_status=$?
+        if [ "$estate_status" -eq 0 ]; then
+            summary+=("  in sync    $ESTATE_NAME")
+        else
+            summary+=("  findings   $ESTATE_NAME ($ESTATE_FINDINGS)")
+            bad=$((bad + 1))
+        fi
+        say ""
+    done <<<"$rows"
+    say "status: summary"
+    if [ ${#summary[@]} -gt 0 ]; then
+        for line in "${summary[@]}"; do
+            say "$line"
+        done
+    fi
+    say "status: $((total - bad)) estate(s) in sync, $bad with findings; $CHANGED_CLAUSE"
+    [ "$bad" -eq 0 ]
+}
+
+# --- arguments -------------------------------------------------------------
+while [ $# -gt 0 ]; do
+    case "$1" in
+    -h | --help) usage; exit 0 ;;
+    -a | --all) STATUS_ALL=1; shift ;;
+    # A MISSING VALUE IS A REFUSAL, exit 2, in this command's own words:
+    # `${2:?…}` would be bash's message and bash's exit 1 — and 1 is what
+    # this command means by "findings were printed", so a typo must not be
+    # able to read as a report.
+    --repo)
+        [ $# -ge 2 ] || die "--repo needs a value: <owner>/<name>, or any url spelling of one."
+        REPO_SLUG="$2"; REPO_ARG="$REPO_SLUG"; shift 2 ;;
+    --name | --project)
+        [ $# -ge 2 ] || die "$1 needs a value: one estate folder name under your projects directory."
+        NAME="$2"; shift 2 ;;
+    # THE SECOND LAYER (Brett Heap's RULING of 2026-09-11, "next layer:
+    # --fetch"): ask origin in every repository first. See `fetch_remote`.
+    --fetch) FETCH=1; CHANGED_CLAUSE="only remote-tracking refs and fetched objects were changed (--fetch)."; shift ;;
+    -*)
+        usage >&2
+        die "$SELF_NAME does not know $1. Its flags are listed above; it takes nothing for
+    the extension, because it runs nothing."
+        ;;
+    *)
+        [ -z "$NAME" ] ||
+            die "two estate names, '$NAME' and '$1'. One positional <Name>, then flags."
+        NAME="$1"; shift ;;
+    esac
+done
+
+[ -z "$NAME" ] || [ -z "$REPO_SLUG" ] ||
+    die "both <Name> ('$NAME') and --repo '$REPO_SLUG'. One estate per run: name it
+    either way, not both."
+if [ "$STATUS_ALL" -eq 1 ]; then
+    [ -z "$NAME" ] ||
+        die "both <Name> ('$NAME') and --all. \`--all\` reads EVERY estate under your
+    projects directory; <Name> reads one. Drop one of them."
+    [ -z "$REPO_SLUG" ] ||
+        die "both --repo '$REPO_ARG' and --all. \`--all\` reads EVERY estate under your
+    projects directory; \`--repo\` reads the one that clone belongs to. Drop one
+    of them."
+fi
+
+# GIT IS THE WHOLE MECHANISM, and every call below is `|| true`-guarded so a
+# missing ref reads as a finding rather than a crash — which means a git that
+# cannot run AT ALL would otherwise be reported as an estate with no commits,
+# no branches and no legs, exit 1, and no line saying nothing was read.
+# `--no-optional-locks` is git 2.15 (2017) and is what makes this command take
+# no lock, so a git that does not know it is refused BY NAME rather than
+# answered wrongly. `--help` has already exited above and needs neither.
+command -v git >/dev/null 2>&1 ||
+    die "no \`git\` on PATH, so nothing can be read."
+git --no-optional-locks --version >/dev/null 2>&1 ||
+    die "this \`git\` does not know \`--no-optional-locks\` (git 2.15, 2017), which is
+    what stops \`$SELF_NAME\` taking a lock on a repository somebody else is using.
+    Upgrade git and re-run; every answer here would otherwise be read off a git
+    that refused every command."
+
+# --- resolve ---------------------------------------------------------------
+if [ "$STATUS_ALL" -eq 1 ]; then
+    ALL_ROWS="$(all_estate_dirs)"
+    [ -n "$ALL_ROWS" ] ||
+        die "--all found no estate under ${PROJECTS_DIRS[*]}, so nothing was read.
+    An estate is a FAMILY folder (<Name>/<Name>/family.yaml) or a standalone
+    project root (<Name>/project.yaml), one level under your projects
+    directory; \`resume <Name>\` brings one back."
+    say "status --all: reading every estate under ${PROJECTS_DIRS[*]}:"
+    say ""
+    say "$(estates_or_none)"
+    say ""
+elif [ -n "$REPO_SLUG" ]; then
+    # ANY SPELLING A PERSON MIGHT PASTE, through the same reader that reads a
+    # clone's `origin` — `park`'s rule, for `park`'s reasons.
+    REPO_SLUG="$(repo_slug_of "$REPO_SLUG" || true)"
+    [ -n "$REPO_SLUG" ] || die "--repo '$REPO_ARG' is not a repository: it wants <owner>/<name>, or any
+    url spelling of one (https://…/<owner>/<name>.git, git@host:<owner>/<name>).
+    A family's members may live in another organisation, so there is no owner
+    to assume, and a path on disk has none to read."
+    MATCH="$(clone_with_origin "$REPO_SLUG" || true)"
+    [ -n "$MATCH" ] || die "no clone under your projects directory has origin $REPO_SLUG.
+    \`--repo\` names a clone you ALREADY HAVE; nothing here clones one. Bring the
+    estate back with \`resume <Name>\`, or read one of these:
+
+$(estates_or_none)"
+    estate_walk_up "$MATCH" ||
+        die "$MATCH is a clone of $REPO_SLUG, but nothing at or above it is an
+    estate: no \`family.yaml\` holder beside it and no \`project.yaml\` root. It
+    is a clone, not a project of this shape."
+elif [ -n "$NAME" ]; then
+    is_safe_folder_name "$NAME" ||
+        die "'$NAME' is not an estate name: it is a path, or it carries a
+    character an estate folder may not. <Name> is ONE folder name under your
+    projects directory — no slash, no leading dot. To read a checkout
+    somewhere else, stand in it and run \`$SELF_NAME\` with no <Name>."
+    estate_by_name "$NAME" || die "no estate named '$NAME' under your projects directory.
+    An estate is a FAMILY folder ($NAME/$NAME/family.yaml) or a standalone
+    project root ($NAME/project.yaml). Bring it back with \`resume $NAME\`, or
+    read one of these:
+
+$(estates_or_none)"
+else
+    # THE WALK-UP WINS FIRST, as it does for `park`: standing inside an estate
+    # reads THAT estate. Outside every estate, every estate is read — WITHOUT
+    # the question `park` asks, because a read changes nothing and the
+    # answer to "which estate did you mean" is, for a report, all of them.
+    if ! estate_walk_up "$PWD"; then
+        ALL_ROWS="$(all_estate_dirs)"
+        [ -n "$ALL_ROWS" ] ||
+            die "no estate around $PWD, no <Name> was given, and there is no estate under
+    ${PROJECTS_DIRS[*]} at all, so there is nothing to read. An estate is a
+    FAMILY folder (<Name>/<Name>/family.yaml) or a standalone project root
+    (<Name>/project.yaml), one level under your projects directory;
+    \`resume <Name>\` brings one back."
+        STATUS_ALL=1
+        say "status: no estate around $PWD; reading every estate under ${PROJECTS_DIRS[*]}:"
+        say ""
+        say "$(estates_or_none)"
+        say ""
+    fi
+fi
+
+if [ "$STATUS_ALL" -eq 1 ]; then
+    STATUS=0
+    status_every_estate "$ALL_ROWS" || STATUS=$?
+    exit "$STATUS"
+fi
+
+STATUS=0
+read_one_estate || STATUS=$?
+exit "$STATUS"

--- a/devBenches/base-image/upstream-pin.yaml
+++ b/devBenches/base-image/upstream-pin.yaml
@@ -57,15 +57,18 @@ sources:
     source_repository: opensoft/openRepoTools
     materialization: copied
     revision_kind: commit
-    commit: "ff1f01aae70b8f21dce0e4654da071a1281b41a4"
+    commit: "f519f31c28fad3ab2f54cd60d828226d866db3f5"
     vendor_dir: files/openrepotools
     files:
       - path: openRepoTools
-        sha256: "15e4cb8ca6bb51ff17dd3b59223037c1f2d84c010e6238496a94514a61a915d1"
+        sha256: "636a8aa268c70ec414c700d72974e029ab45ffc1051a213bcd955ad73fc0dd9a"
         mode: "100755"
       - path: park
-        sha256: "6c2dca99f2e1dc8db4c0817f28b5a31805ab096fd3e372df5e4944377fe8b60b"
+        sha256: "034911a3a5dbcc6f9ec1e6e5da351f018e3eebaeb8b3b7608f536c884c7f8a60"
         mode: "100755"
       - path: resume
-        sha256: "a5a147f89cf9a1b97a0d8c1e8868d17323e41b238f96d9e59d8ddd766af387eb"
+        sha256: "155a852ae3f3642fcf4e8cc2e77148aca8620f00b51462e18f960022596283a3"
+        mode: "100755"
+      - path: status
+        sha256: "2bf505350c16631393b6a76cafe27469a9c9923a814bd068132abb98e3365654"
         mode: "100755"

--- a/devcontainer.test/test-setup-estate-commands.sh
+++ b/devcontainer.test/test-setup-estate-commands.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Regression test for scripts/setup-estate-commands.sh (opensoft/workBenches#37):
-# the host's openRepoShape, openRepoTools, park and resume come from
+# the host's openRepoShape, openRepoTools, park, resume and status come from
 # workBenches' own vendored pin, and the script places them, re-places them
 # when they differ from the pin (either direction), and refuses to place
 # anything when the vendored copies themselves no longer match the pin.
@@ -23,6 +23,7 @@ SHAPE_VENDOR="$BASE_IMAGE_DIR/files/openreposhape/openRepoShape"
 TOOLS_VENDOR="$BASE_IMAGE_DIR/files/openrepotools/openRepoTools"
 PARK_VENDOR="$BASE_IMAGE_DIR/files/openrepotools/park"
 RESUME_VENDOR="$BASE_IMAGE_DIR/files/openrepotools/resume"
+STATUS_VENDOR="$BASE_IMAGE_DIR/files/openrepotools/status"
 
 TMPDIR_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR_ROOT"' EXIT
@@ -150,7 +151,7 @@ TOOLS_COMMIT="$(pin_commit_for openrepotools)"
 assert_matches "$SHAPE_COMMIT" '^[0-9a-f]{40}$' 'pin file yields a 40-hex openreposhape commit'
 assert_matches "$TOOLS_COMMIT" '^[0-9a-f]{40}$' 'pin file yields a 40-hex openrepotools commit'
 
-printf '%s\n' '--- Scenario (a): fresh bin dir installs all four commands from the vendored copies ---'
+printf '%s\n' '--- Scenario (a): fresh bin dir installs all five commands from the vendored copies ---'
 BIN_A="$TMPDIR_ROOT/bin-a"
 mkdir -p "$BIN_A"
 STATUS_A=0
@@ -161,16 +162,19 @@ assert_file_executable "$BIN_A/openRepoShape" 'fresh install places openRepoShap
 assert_file_executable "$BIN_A/openRepoTools" 'fresh install places openRepoTools, executable'
 assert_file_executable "$BIN_A/park" 'fresh install places park, executable'
 assert_file_executable "$BIN_A/resume" 'fresh install places resume, executable'
+assert_file_executable "$BIN_A/status" 'fresh install places status, executable'
 assert_identical "$BIN_A/openRepoShape" "$SHAPE_VENDOR" 'fresh openRepoShape is byte-identical to the vendored copy'
 assert_identical "$BIN_A/openRepoTools" "$TOOLS_VENDOR" 'fresh openRepoTools is byte-identical to the vendored copy'
 assert_identical "$BIN_A/park" "$PARK_VENDOR" 'fresh park is byte-identical to the vendored copy'
 assert_identical "$BIN_A/resume" "$RESUME_VENDOR" 'fresh resume is byte-identical to the vendored copy'
+assert_identical "$BIN_A/status" "$STATUS_VENDOR" 'fresh status is byte-identical to the vendored copy'
 assert_contains "$OUTPUT_A" "openRepoShape pinned at $SHAPE_COMMIT" 'fresh install prints the openRepoShape pin commit'
 assert_contains "$OUTPUT_A" "openRepoTools pinned at $TOOLS_COMMIT" 'fresh install prints the openRepoTools pin commit'
 assert_contains "$OUTPUT_A" 'openRepoShape: installed at' 'fresh install reports an installed verb for openRepoShape'
 assert_contains "$OUTPUT_A" 'openRepoTools: installed at' 'fresh install reports an installed verb for openRepoTools'
 assert_contains "$OUTPUT_A" 'park: installed at' 'fresh install reports an installed verb for park'
 assert_contains "$OUTPUT_A" 'resume: installed at' 'fresh install reports an installed verb for resume'
+assert_contains "$OUTPUT_A" 'status: installed at' 'fresh install reports an installed verb for status'
 assert_contains "$OUTPUT_A" 'Estate commands verified against the vendored pin.' 'fresh install reports success only after post-install verification'
 # Scenario (f) folded in here: a brand-new temp dir is never on $PATH. Fix 4
 # removed this script's own PATH warning (the shims already print theirs),
@@ -188,10 +192,12 @@ assert_contains "$OUTPUT_B" 'openRepoShape: already installed at' 'second run re
 assert_contains "$OUTPUT_B" 'openRepoTools: already installed at' 'second run reports openRepoTools unchanged'
 assert_contains "$OUTPUT_B" 'park: already installed at' 'second run reports park unchanged'
 assert_contains "$OUTPUT_B" 'resume: already installed at' 'second run reports resume unchanged'
+assert_contains "$OUTPUT_B" 'status: already installed at' 'second run reports status unchanged'
 assert_identical "$BIN_A/openRepoShape" "$SHAPE_VENDOR" 'openRepoShape still byte-identical after the second run'
 assert_identical "$BIN_A/openRepoTools" "$TOOLS_VENDOR" 'openRepoTools still byte-identical after the second run'
 assert_identical "$BIN_A/park" "$PARK_VENDOR" 'park still byte-identical after the second run'
 assert_identical "$BIN_A/resume" "$RESUME_VENDOR" 'resume still byte-identical after the second run'
+assert_identical "$BIN_A/status" "$STATUS_VENDOR" 'status still byte-identical after the second run'
 
 printf '%s\n' '--- Scenario (c): a locally-modified park is replaced and reported updated ---'
 printf '%s\n' '# a local edit, not the vendored bytes' >> "$BIN_A/park"
@@ -204,6 +210,7 @@ assert_identical "$BIN_A/park" "$PARK_VENDOR" 'park is byte-identical to the ven
 # The other three were untouched, so this run still reports them unchanged.
 assert_contains "$OUTPUT_C" 'openRepoShape: already installed at' 'updated-park run still reports openRepoShape unchanged'
 assert_contains "$OUTPUT_C" 'resume: already installed at' 'updated-park run still reports resume unchanged'
+assert_contains "$OUTPUT_C" 'status: already installed at' 'updated-park run still reports status unchanged'
 
 printf '%s\n' '--- Scenario (d): a corrupted vendor copy refuses to install anything ---'
 CORRUPT_BASE="$TMPDIR_ROOT/corrupt-base-image"
@@ -345,6 +352,7 @@ assert_mode "$BIN_A/openRepoShape" '755' 'placed openRepoShape is mode 0755'
 assert_mode "$BIN_A/openRepoTools" '755' 'placed openRepoTools is mode 0755'
 assert_mode "$BIN_A/park" '755' 'placed park is mode 0755'
 assert_mode "$BIN_A/resume" '755' 'placed resume is mode 0755'
+assert_mode "$BIN_A/status" '755' 'placed status is mode 0755'
 
 printf '%s\n' '--- Scenario (m): the operator'"'"'s own *_REF/*_REPO are overridden by the sentinel, not used ---'
 # Dynamically: an operator's environment must not change the happy-path

--- a/scripts/setup-estate-commands.sh
+++ b/scripts/setup-estate-commands.sh
@@ -3,7 +3,7 @@
 # scripts/setup-estate-commands.sh
 #
 # Installs the estate commands on this host from workBenches' own vendored
-# pin: openRepoShape, openRepoTools, park and resume, placed by the vendored
+# pin: openRepoShape, openRepoTools, park, resume and status, placed by the vendored
 # shims' own `--install` (devBenches/base-image/files/openreposhape/openRepoShape
 # and devBenches/base-image/files/openrepotools/openRepoTools). This script
 # adds no install logic of its own: it runs `update-upstream.py check`, then
@@ -27,7 +27,7 @@
 #     it never fails setup.sh.
 #
 # Guarantees added by the adversarial review round:
-#   - Refuses (exit 1) before running either shim if any of the four install
+#   - Refuses (exit 1) before running either shim if any of the five install
 #     targets already exists as a symlink, as anything other than a regular
 #     file (e.g. a directory), or is not writable -- or if its bin dir exists
 #     and is not writable. Nothing is installed once any one target fails
@@ -43,7 +43,7 @@
 #     above, it fails loudly naming the sentinel rather than silently
 #     succeeding against whatever the operator's shell happened to export
 #     (D3, defense in depth).
-#   - After both installers exit 0, every one of the four placed files is
+#   - After both installers exit 0, every one of the five placed files is
 #     re-checked: a regular, non-symlink file, mode exactly 0755, and
 #     `cmp`-identical to its vendored copy. Only then does this script
 #     report success (D1/D2/D3/D4 residue, closed in one place).
@@ -93,6 +93,7 @@ SHAPE_SHIM="$BASE_IMAGE_DIR/files/openreposhape/openRepoShape"
 TOOLS_SHIM="$BASE_IMAGE_DIR/files/openrepotools/openRepoTools"
 PARK_FILE="$BASE_IMAGE_DIR/files/openrepotools/park"
 RESUME_FILE="$BASE_IMAGE_DIR/files/openrepotools/resume"
+STATUS_FILE="$BASE_IMAGE_DIR/files/openrepotools/status"
 
 if [ ! -f "$PIN_FILE" ]; then
     echo "Estate command install refused: the pin file is missing or" >&2
@@ -101,7 +102,7 @@ if [ ! -f "$PIN_FILE" ]; then
 fi
 
 missing=""
-for f in "$UPDATE_UPSTREAM" "$SHAPE_SHIM" "$TOOLS_SHIM" "$PARK_FILE" "$RESUME_FILE"; do
+for f in "$UPDATE_UPSTREAM" "$SHAPE_SHIM" "$TOOLS_SHIM" "$PARK_FILE" "$RESUME_FILE" "$STATUS_FILE"; do
     if [ ! -f "$f" ]; then
         missing="${missing:+$missing }$f"
     fi
@@ -178,6 +179,7 @@ require_pin_row "openRepoShape"
 require_pin_row "openRepoTools"
 require_pin_row "park"
 require_pin_row "resume"
+require_pin_row "status"
 
 echo "openRepoShape pinned at $shape_commit"
 echo "openRepoTools pinned at $tools_commit"
@@ -193,14 +195,14 @@ refuse_preflight() {
 
 refuse_postverify() {
     echo "Estate command install refused: $1" >&2
-    echo "One or more of the four commands may now be in a mixed state;" >&2
+    echo "One or more of the five commands may now be in a mixed state;" >&2
     echo "fix the problem above and re-run this script." >&2
     exit 1
 }
 
 # D1/D2/most of D4: every target either shim is about to write to is
 # checked BEFORE either of them runs, so a bad target refuses before
-# anything at all is placed -- never after only some of the four are done.
+# anything at all is placed -- never after only some of the five are done.
 check_target_preflight() {
     local target="$1" dir="$2"
     if [ -L "$target" ]; then
@@ -221,6 +223,7 @@ check_target_preflight "$shape_bin_dir/openRepoShape" "$shape_bin_dir"
 check_target_preflight "$tools_bin_dir/openRepoTools" "$tools_bin_dir"
 check_target_preflight "$tools_bin_dir/park" "$tools_bin_dir"
 check_target_preflight "$tools_bin_dir/resume" "$tools_bin_dir"
+check_target_preflight "$tools_bin_dir/status" "$tools_bin_dir"
 
 # D3, defense in depth: every file the checks above proved is present and
 # pinned is about to be installed with no fetch ever reachable, because
@@ -236,8 +239,8 @@ export OPENREPOTOOLS_REPO="$ESTATE_SENTINEL"
 export OPENREPOTOOLS_REF="$ESTATE_SENTINEL"
 
 # Ruling 2 (the host follows the pin, both ways): each shim, invoked as a
-# FILE, installs its own bytes (and openRepoTools copies park and resume
-# from beside itself); it reports each target `already installed ...
+# FILE, installs its own bytes (and openRepoTools copies park, resume and
+# status from beside itself); it reports each target `already installed ...
 # (unchanged)`, `updated`, or `installed`. That per-file report is relayed
 # unchanged below -- this script adds no version logic and no flags of its
 # own to either shim (ruling 4).
@@ -255,7 +258,7 @@ fi
 # shims reported success above, but `cp` can write through a symlink or into
 # a directory without either shim noticing -- so every placed file is
 # re-checked against the vendored copy it was supposed to become, and only
-# once all four pass does this script report success itself.
+# once all five pass does this script report success itself.
 file_mode_octal() {
     stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null
 }
@@ -278,6 +281,7 @@ verify_installed "$shape_bin_dir/openRepoShape" "$SHAPE_SHIM"
 verify_installed "$tools_bin_dir/openRepoTools" "$TOOLS_SHIM"
 verify_installed "$tools_bin_dir/park" "$PARK_FILE"
 verify_installed "$tools_bin_dir/resume" "$RESUME_FILE"
+verify_installed "$tools_bin_dir/status" "$STATUS_FILE"
 
 echo "Estate commands verified against the vendored pin."
 

--- a/setup.sh
+++ b/setup.sh
@@ -176,7 +176,7 @@ if [ -x "${SCRIPT_DIR}/scripts/setup-shell.sh" ]; then
     echo ""
 fi
 
-# Estate commands (openRepoShape, openRepoTools, park, resume) come from
+# Estate commands (openRepoShape, openRepoTools, park, resume, status) come from
 # workBenches' own vendored pin and are placed by their own installers; see
 # scripts/setup-estate-commands.sh. Best-effort, like the other host-user
 # steps here: it never fails setup.sh. WORKBENCHES_SKIP_ESTATE_COMMANDS=1 skips it.


### PR DESCRIPTION
The `openrepotools` source pin moves from ff1f01aae70b8f21dce0e4654da071a1281b41a4
(pinned in #39) to f519f31c28fad3ab2f54cd60d828226d866db3f5 —
`gh api repos/opensoft/openRepoTools/compare/main...f519f31c28fad3ab2f54cd60d828226d866db3f5`
says `identical`, so it is the commit opensoft/openRepoTools's main carries after
opensoft/openRepoTools#15.

Between the two commits (opensoft/openRepoTools#8-#15, all squash-merged):
`status` is the FOURTH command, read-only, runs nothing, in five layers — the
local layer (ahead/behind as of the last fetch, dirty, branches, worktrees, legs
against their pins), `--fetch` (the one write bounded to remote-tracking refs by
a pinned refspec), a fork against a remote named `upstream` or, under `--fetch`,
one read-only `gh api` question, the shape pin (contracts/shape-pin.yaml
re-hashed, the pin read against the standard's main) and the parked record
against disk (#9-#13, Brett Heap's rulings of 2026-09-10 and 2026-09-11); bare
`park` parks the estate around the cwd and ASKS before sweeping, `park --all` /
`-a` is the sweep unasked (#8, his ruling of 2026-09-10); `park` and `resume`
refuse a value-less flag with exit 2 in their own words (#14); `park` and
`status` read `.gitmodules` with `git config -z` (#15). `openRepoTools --install`
now places four files, so its vendored shim changes too.

So this is one `apply --add status` run AND the consumers that enumerate the
commands, each gaining the fifth name: the Dockerfile COPYs and chmods
/usr/local/bin/status beside the other three; scripts/setup-estate-commands.sh
pre-flights a fifth target, requires its pin row and post-verifies it;
setup.sh's and README's lists name it; and
devcontainer.test/test-setup-estate-commands.sh asserts the fifth placement,
its second-run `already installed` line, its byte-identity to the vendored copy
and its 0755 mode. update-upstream.py is untouched.

check: exit 0, 6 rows across 2 sources.
devcontainer.test/test-setup-estate-commands.sh: 83 PASS (was 76), GREEN, exit 0.
devBenches/devcontainer.test/test-speckit-git-feature.sh: 56 PASS, GREEN, exit 0.
The base image was not rebuilt here; the COPY and chmod lines are the only
Dockerfile changes beyond comments.

Lane: openrepotools-3 (openRepoTools-3)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Re-vendor openRepoTools and integrate its new read-only `status` command across the base image, host setup, documentation, and regression tests.

New Features:
- Add the read-only `status` estate command alongside `openRepoShape`, `openRepoTools`, `park`, and `resume`.
- Update the vendored openRepoTools release to provide the enhanced `park`, `resume`, and `status` command behavior.

Enhancements:
- Extend estate-command installation and verification to manage five commands, including pin validation, safe preflight checks, post-install integrity checks, and repeat-install reporting.

Build:
- Include the vendored `status` command in the base image and set its executable permissions.

Documentation:
- Update setup and README documentation to describe the five installed estate commands.

Tests:
- Expand estate-command regression coverage to verify installation, idempotency, byte identity, and executable permissions for `status`.
- Run the estate-command and Speckit Git feature test suites successfully.

Chores:
- Move the openRepoTools source pin to commit f519f31c28fad3ab2f54cd60d828226d866db3f5 and update vendored file checksums.