### PR TITLE
devcontainer.test/test-claude-tmux-statusline.sh: make the fake tmux/claude sandbox authoritative over the caller's real tmux identity

### DIFF
--- a/devcontainer.test/test-claude-tmux-statusline.sh
+++ b/devcontainer.test/test-claude-tmux-statusline.sh
@@ -13,21 +13,33 @@ trap 'rm -rf "$TEST_ROOT"' EXIT
 # This test drives the real launcher and statusline scripts against a fake
 # tmux/claude sandbox built below, then asserts on the fake tmux/claude logs
 # that sandbox produces. Both scripts also read tmux identity straight from
-# the environment (WORKBENCHES_CLAUDE_TMUX*, TMUX*, WORKBENCHES_TMUX_*). If
-# this test itself is run from inside a real tmux session — a live
-# claude-profile-launched Claude Code pane included — those variables leak
-# in from the caller and are indistinguishable from the sandbox's own state.
-# That alone corrupts the assertions below, and it can also abort the
-# launcher outright: with a real TMUX inherited but only the fake tmux
-# binary on PATH, the launcher's export_tmux_identity() queries tmux, gets
-# back nothing the fake understands, and its last command's failure under
-# `set -e` kills the launcher before it ever reaches Claude. Mirrors the
-# same guard in test-claude-profile-lane-start.sh, extended to also cover
+# the environment (WORKBENCHES_CLAUDE_TMUX*, TMUX*, WORKBENCHES_TMUX_*), and
+# the launcher separately reads CLAUDE_LANE to decide whether to hand the
+# launch off to `lane-start` instead of the fake claude. If this test itself
+# is run from inside a real tmux session — a live claude-profile-launched
+# Claude Code pane included — those variables leak in from the caller and
+# are indistinguishable from the sandbox's own state. That alone corrupts
+# the assertions below, and it can also abort the launcher outright: with a
+# real TMUX inherited but only the fake tmux binary on PATH, the launcher's
+# export_tmux_identity() queries tmux, gets back nothing the fake
+# understands, and its last command's failure under `set -e` kills the
+# launcher before it ever reaches Claude. A leaked CLAUDE_LANE is worse in a
+# different way: if a real `lane-start` happens to be on PATH (as it is in
+# exactly the lane sessions this test is likeliest to be run from), the
+# launcher hands the whole launch to it instead of the fake claude — a test
+# run invoking real lane tooling. Mirrors the same guard in
+# test-claude-profile-lane-start.sh, extended to also cover
 # WORKBENCHES_CLAUDE_TMUX (the opt-out switch claude_run_is_interactive
-# reads). Clear all of it before the sandbox runs, so the sandbox's own
-# state is always authoritative.
+# reads) and CLAUDE_LANE (the launcher's lane-start hand-off switch). Clear
+# all of it before the sandbox runs, so the sandbox's own state is always
+# authoritative. (CLAUDE_BIN/CLAUDE_PROFILES_HOME/CLAUDE_PROFILES_MANIFEST/
+# WORKBENCHES_SHARED_MCP_FAMILIES are already owned below via common_env's
+# explicit assignments on every launcher invocation, so an inherited value
+# for any of those is always overridden rather than leaked; CLAUDE_CONFIG_DIR
+# is only ever written by the launcher for its children, never read as one
+# of its own inputs, so nothing to clear there either.)
 unset TMUX TMUX_PANE WORKBENCHES_CLAUDE_TMUX WORKBENCHES_CLAUDE_TMUX_CHILD \
-    WORKBENCHES_TMUX_SESSION WORKBENCHES_TMUX_PANE 2>/dev/null || true
+    WORKBENCHES_TMUX_SESSION WORKBENCHES_TMUX_PANE CLAUDE_LANE 2>/dev/null || true
 
 fail() {
     echo "FAIL: $*" >&2

--- a/devcontainer.test/test-claude-tmux-statusline.sh
+++ b/devcontainer.test/test-claude-tmux-statusline.sh
@@ -10,6 +10,25 @@ STATUSLINE="${2:-$REPO_ROOT/base-image/files/claude-statusline-command.sh}"
 TEST_ROOT="$(mktemp -d)"
 trap 'rm -rf "$TEST_ROOT"' EXIT
 
+# This test drives the real launcher and statusline scripts against a fake
+# tmux/claude sandbox built below, then asserts on the fake tmux/claude logs
+# that sandbox produces. Both scripts also read tmux identity straight from
+# the environment (WORKBENCHES_CLAUDE_TMUX*, TMUX*, WORKBENCHES_TMUX_*). If
+# this test itself is run from inside a real tmux session — a live
+# claude-profile-launched Claude Code pane included — those variables leak
+# in from the caller and are indistinguishable from the sandbox's own state.
+# That alone corrupts the assertions below, and it can also abort the
+# launcher outright: with a real TMUX inherited but only the fake tmux
+# binary on PATH, the launcher's export_tmux_identity() queries tmux, gets
+# back nothing the fake understands, and its last command's failure under
+# `set -e` kills the launcher before it ever reaches Claude. Mirrors the
+# same guard in test-claude-profile-lane-start.sh, extended to also cover
+# WORKBENCHES_CLAUDE_TMUX (the opt-out switch claude_run_is_interactive
+# reads). Clear all of it before the sandbox runs, so the sandbox's own
+# state is always authoritative.
+unset TMUX TMUX_PANE WORKBENCHES_CLAUDE_TMUX WORKBENCHES_CLAUDE_TMUX_CHILD \
+    WORKBENCHES_TMUX_SESSION WORKBENCHES_TMUX_PANE 2>/dev/null || true
+
 fail() {
     echo "FAIL: $*" >&2
     exit 1


### PR DESCRIPTION
Lane: openreposhape-2 (openRepoShape-2)

Closes #52.

## Problem

`devcontainer.test/test-claude-tmux-statusline.sh` builds a fake
`claude`/`tmux` sandbox and drives `base-image/files/claude-profile` and
`claude-statusline-command.sh` against it, but its launcher-invoking
assertions (the interactive tmux-session-creation check and the
non-interactive `mcp list` check) never touched `TMUX`, `TMUX_PANE`,
`WORKBENCHES_CLAUDE_TMUX`, `WORKBENCHES_CLAUDE_TMUX_CHILD`,
`WORKBENCHES_TMUX_SESSION`, or `WORKBENCHES_TMUX_PANE` — every one of them a
variable `claude-profile` or `claude-statusline-command.sh` reads straight
from the environment. Run the test from inside any real tmux session (a
live `claude-profile`-launched Claude Code pane included) and the caller's
own values for those variables leak straight through.

That's more than a mismatched assertion: with `TMUX` inherited but only the
fake `tmux` binary on `PATH`, the launcher's `claude_run_is_interactive()`
sees `TMUX` set and treats the launch as non-interactive, while
`export_tmux_identity()` *also* sees `TMUX` set and unconditionally shells
out to `tmux` to resolve `#S`/`#{pane_id}`. The fake `tmux` only logs its
argv and prints nothing, so both come back empty, and
`export_tmux_identity()`'s last statement —
`[[ -n "$pane" ]] && export WORKBENCHES_TMUX_PANE=...` — evaluates false.
Under the launcher's own `set -euo pipefail` that kills the launcher before
it ever execs the fake `claude` binary; `script -e` propagates the failure,
and the test's own `set -e` aborts the whole file right there, silently,
before any `grep ... || fail` line runs.

Reproduced from inside this lane's own live tmux-backed session:
- **As-is:** `bash devcontainer.test/test-claude-tmux-statusline.sh` → exit
  1, zero output, not even a `FAIL: ...` message. `bash -x` shows it dying
  at the `script -qefc "$tty_command" /dev/null` line — the launcher itself
  aborts before the test ever reaches an assertion.
- **With the caller's tmux identity removed:**
  `env -u TMUX -u TMUX_PANE -u WORKBENCHES_CLAUDE_TMUX_CHILD -u
  WORKBENCHES_TMUX_SESSION -u WORKBENCHES_TMUX_PANE bash
  devcontainer.test/test-claude-tmux-statusline.sh` → passes:
  `claude tmux statusline tests passed`, exit 0.

This is a different bug from the one #48 fixed: #48 stopped the test's
*statusline* invocations from leaking `$HOME`-scoped snapshot artifacts into
the caller's real home directory. This is about the *launcher* invocations
earlier in the same file leaking the caller's tmux identity inward. PR #44
(which added the sibling `test-claude-profile-lane-start.sh`) already
engineered exactly this guard for that new file, with a comment calling out
the same hazard, but never retrofitted the older
`test-claude-tmux-statusline.sh` — noted in passing, left unfixed. See #52
for the full trace.

## Fix

Clear `TMUX`, `TMUX_PANE`, `WORKBENCHES_CLAUDE_TMUX`,
`WORKBENCHES_CLAUDE_TMUX_CHILD`, `WORKBENCHES_TMUX_SESSION`, and
`WORKBENCHES_TMUX_PANE` near the top of the test, before the sandbox is
built — mirroring the guard `test-claude-profile-lane-start.sh` already
carries, extended to also cover `WORKBENCHES_CLAUDE_TMUX` (the opt-out
switch `claude_run_is_interactive` also reads). The test's existing
per-call `env -u TMUX -u TMUX_PANE -u WORKBENCHES_TMUX_SESSION -u
WORKBENCHES_TMUX_PANE` around the non-tmux statusline panel assertion is
untouched (now redundant, still harmless, keeps that one assertion
self-documenting). Purely additive: 19 lines added, 0 removed, 0 changed.

## Test plan

- [x] `bash devcontainer.test/test-claude-tmux-statusline.sh` from inside
      this lane's own live tmux-backed Claude Code session — passes
      (`claude tmux statusline tests passed`, exit 0); repeated 3x, no
      flakiness.
- [x] `env -u TMUX -u TMUX_PANE -u WORKBENCHES_CLAUDE_TMUX_CHILD -u
      WORKBENCHES_TMUX_SESSION -u WORKBENCHES_TMUX_PANE bash
      devcontainer.test/test-claude-tmux-statusline.sh` — passes, same
      result.
- [x] Same test invoked with explicit launcher/statusline paths (the form
      `devcontainer.test/test.sh` uses inside the built image) — passes.
- [x] `devcontainer.test/test-claude-profile-lane-start.sh` — passes both
      inside this live tmux session and with the variables unset.
- [x] `devcontainer.test/test-claude-profile-preserves-model.sh` — passes
      both ways (unaffected either way: it only exercises the launcher's
      `status` action, which never reaches the tmux-sensitive code paths).
- [x] `devcontainer.test/test-claude-statusline-snapshots.sh` — passes both
      ways.
- [x] Confirmed `.github/workflows/speckit-git-bash.yml` and
      `speckit-git-powershell.yml` don't invoke any `test-claude-*.sh` suite
      (they only run the speckit/git-bootstrap tests), so CI's own
      invocation of these tests is unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Isolate the Claude tmux statusline test from the caller's tmux and lane environment so it consistently exercises only the fake sandbox.

Bug Fixes:
- Prevent tmux and lane-related environment variables from leaking into the Claude tmux statusline test and causing false failures or unintended real-tool invocations.

Tests:
- Make the sandbox-based tmux statusline test authoritative and reliable when run from within an existing tmux or Claude lane session.