### PR TITLE
Re-vendor openRepoTools at a2c8521: `status`'s record layer reads a deleted worktree as none, one workspace as one record, never sends a `--no-push` record to `resume`; every value-taking flag refuses an empty value

### DIFF
--- a/devBenches/base-image/files/openrepotools/park
+++ b/devBenches/base-image/files/openrepotools/park
@@ -889,16 +889,30 @@ while [ $# -gt 0 ]; do
     # anywhere, with no question (the RULING of 2026-09-10 at the sweep's
     # section head: "park all should be park -a or park --all").
     -a | --all) PARK_ALL=1; shift ;;
-    # A MISSING VALUE IS THIS COMMAND'S REFUSAL, exit 2, in its own words:
-    # `${2:?…}` would be bash's message and bash's exit 1, which is not a
-    # status this command means anything by (`status` gave the reason first:
+    # A MISSING OR EMPTY VALUE IS THIS COMMAND'S REFUSAL, exit 2, in its own
+    # words: `${2:?…}` would be bash's message and bash's exit 1, which is not
+    # a status this command means anything by (`status` gave the reason first:
     # its 1 is "findings"; here, a typo must not read like `make park`'s own
     # exit).
+    # EMPTY IS REFUSED THE SAME WAY, which is why every arm below asks for a
+    # NON-EMPTY `$2` and not only for a second argument. `${2:?…}` rejected
+    # unset AND null; `[ $# -ge 2 ]` alone rejects only the first, and what it
+    # lets through is read later as "was this given at all?" — so
+    # `park --lane ""` would carry on with `LANE` empty, the lane is then left
+    # out of the `make park` invocation, and the WIP commit subject a person
+    # asked to be labelled comes back unlabelled. `park --repo ""` is the same
+    # silence with more behind it: an empty slug falls past the `--repo` branch
+    # of the resolver into the walk-up, which is the one thing naming a clone's
+    # origin was there to prevent. A value that came out empty is a flag that
+    # was typed and lost, never one that was never typed, and the two must not
+    # do different things (Copilot's review of #14).
     --lane)
-        [ $# -ge 2 ] || die "--lane needs a value: the lane recorded in the WIP commit subject."
+        [ $# -ge 2 ] && [ -n "$2" ] ||
+            die "--lane needs a value: the lane recorded in the WIP commit subject."
         LANE="$2"; shift 2 ;;
     --repo)
-        [ $# -ge 2 ] || die "--repo needs a value: <owner>/<name>, or any url spelling of one."
+        [ $# -ge 2 ] && [ -n "$2" ] ||
+            die "--repo needs a value: <owner>/<name>, or any url spelling of one."
         REPO_SLUG="$2"; REPO_ARG="$REPO_SLUG"; shift 2 ;;
     # `--project <Name>` and `--name <Name>` are the positional under a flag,
     # because the issue's own words are "park --project <project> or park
@@ -906,7 +920,8 @@ while [ $# -gt 0 ]; do
     # value is never mistaken for the positional this way, which is the same
     # reason `openRepoShape` names its value-taking flags.
     --name | --project)
-        [ $# -ge 2 ] || die "$1 needs a value: one estate folder name under your projects directory."
+        [ $# -ge 2 ] && [ -n "$2" ] ||
+            die "$1 needs a value: one estate folder name under your projects directory."
         NAME="$2"; shift 2 ;;
     # EVERYTHING AFTER `--` IS THE EXTENSION'S, verbatim. `park.sh` has flags
     # this command has no opinion about (--feature, --message, --no-push,

--- a/devBenches/base-image/files/openrepotools/resume
+++ b/devBenches/base-image/files/openrepotools/resume
@@ -758,21 +758,45 @@ while [ $# -gt 0 ]; do
     case "$1" in
     -h | --help) usage; exit 0 ;;
     --dry-run) DRY_RUN=1; shift ;;
-    # A MISSING VALUE IS THIS COMMAND'S REFUSAL, exit 2, in its own words:
-    # `${2:?…}` would be bash's message and bash's exit 1 — and a `resume`
-    # that exits non-zero is read as "something was refused", so the refusal
-    # has to be one this command wrote and a person can act on.
+    # A MISSING OR EMPTY VALUE IS THIS COMMAND'S REFUSAL, exit 2, in its own
+    # words: `${2:?…}` would be bash's message and bash's exit 1 — and a
+    # `resume` that exits non-zero is read as "something was refused", so the
+    # refusal has to be one this command wrote and a person can act on.
+    # EMPTY IS REFUSED THE SAME WAY, which is why every arm below asks for a
+    # NON-EMPTY `$2` and not only for a second argument. `${2:?…}` rejected
+    # unset AND null; `[ $# -ge 2 ]` alone rejects only the first, and every
+    # value here is read later as "was this given at all?" — so
+    # `resume --repo ""` would fall past the `--repo` branch of the resolver
+    # into the walk-up and resume the estate around the cwd, which is the one
+    # thing naming a clone's origin was there to prevent, and `--org ""` would
+    # stop narrowing the very manifests it was passed to choose between.
+    # `--workspace ""` GOES TWO WAYS, and neither is the one that was typed.
+    # WITH A CONFIG ALREADY HERE, the empty slug slips past the refusal below
+    # that never silently replaces an existing config — that comparison is
+    # `[ -n "$WORKSPACE_SLUG" ]`-guarded — and this machine's own config is
+    # used, unchecked, in place of the repository named on the command line.
+    # WITH NO CONFIG, the run reaches the refusal that says no workspace
+    # record is configured: true about the machine, and a lie about the
+    # command line, which named one. That second branch is the one the tests
+    # exercise, their `$HOME` having no `~/.agents` in it.
+    # A value that came out empty is a flag that was typed and lost, never one
+    # that was never typed, and the two must not do different things
+    # (Copilot's review of #14).
     --repo)
-        [ $# -ge 2 ] || die "--repo needs a value: <owner>/<name>, or any url spelling of one."
+        [ $# -ge 2 ] && [ -n "$2" ] ||
+            die "--repo needs a value: <owner>/<name>, or any url spelling of one."
         REPO_SLUG="$2"; REPO_ARG="$REPO_SLUG"; shift 2 ;;
     --workspace)
-        [ $# -ge 2 ] || die "--workspace needs a value: <owner>/<name> of your private workspace repository."
+        [ $# -ge 2 ] && [ -n "$2" ] ||
+            die "--workspace needs a value: <owner>/<name> of your private workspace repository."
         WORKSPACE_SLUG="$2"; shift 2 ;;
     --org)
-        [ $# -ge 2 ] || die "--org needs a value: the organisation whose manifest to read."
+        [ $# -ge 2 ] && [ -n "$2" ] ||
+            die "--org needs a value: the organisation whose manifest to read."
         ORG_WANTED="$2"; shift 2 ;;
     --name | --project)
-        [ $# -ge 2 ] || die "$1 needs a value: one estate folder name under your projects directory."
+        [ $# -ge 2 ] && [ -n "$2" ] ||
+            die "$1 needs a value: one estate folder name under your projects directory."
         NAME="$2"; shift 2 ;;
     # `park --all` exists; `resume --all` deliberately does not (see the
     # header). Said here in so many words, because the generic answer below
@@ -1005,16 +1029,21 @@ else
     # checkouts of one workspace repository is ONE record, and `--org` could
     # not have told them apart; two DISTINCT orgs is the case `--org` exists
     # for. So the pairs are deduped on `<org>` plus the file's basename and
-    # the refusal counts the orgs that are left.
+    # the refusal counts the orgs that are left. BOTH HALVES OF THAT KEY ARE
+    # LOWERED, because both were MATCHED that way: `manifest_candidates`
+    # compares the basename case-insensitively, so `Atlas.yaml` in one
+    # checkout and `atlas.yaml` in another are one record — a key that folded
+    # only the org counted them as two and refused, naming one org twice
+    # (Copilot on openRepoTools #18).
     while IFS=$'\t' read -r org file _; do
         [ -n "${file:-}" ] || continue
         if [ -n "$ORG_WANTED" ] && [ "$(lower "$org")" != "$(lower "$ORG_WANTED")" ]; then
             continue
         fi
         case " $FOUND_ORGS " in
-        *" $(lower "$org")/${file##*/} "*) continue ;;
+        *" $(lower "$org")/$(lower "${file##*/}") "*) continue ;;
         esac
-        FOUND_ORGS="$FOUND_ORGS $(lower "$org")/${file##*/}"
+        FOUND_ORGS="$FOUND_ORGS $(lower "$org")/$(lower "${file##*/}")"
         FOUND=$((FOUND + 1))
         FOUND_ROWS="$FOUND_ROWS  $org/${file##*/}   $file
 "

--- a/devBenches/base-image/files/openrepotools/status
+++ b/devBenches/base-image/files/openrepotools/status
@@ -79,7 +79,8 @@
 # `~/.agents/workspace.yaml` names — and `resume` rebuilds the worktrees from
 # it; between the two, record and disk drift apart in exactly the ways
 # `resume` later refuses, and this reads them beforehand: a recorded feature
-# with no worktree here (parked, not resumed — `resume <Name>` is the exit), a
+# with no worktree here (parked, not resumed — `resume <Name>` is the exit,
+# unless `--no-push` left the commit on the workstation that parked it), a
 # worktree whose branch tip is not the parked commit (moved on, or BEHIND a
 # newer record by more than the WIP commits `resume` itself un-committed, or
 # diverged), a leg parked with `--no-push`, and a worktree on disk the record
@@ -143,8 +144,13 @@ pin that has fallen behind is named with the exit, `update-shape.py check
 --root <root>`. THE PARKED RECORD (`~/.agents/workspace.yaml` names the
 workspace repository; `workspaces/<org>/<id>.yaml` in it) is read against the
 worktrees on disk: a recorded feature with no worktree here (`resume <Name>`
-brings it back), a worktree whose tip is not the parked commit, a leg parked
-with `--no-push`, and a worktree the record does not know (never parked).
+brings it back — unless the record says `--no-push`, when only the
+workstation that has the WIP commit can park it again; and where `git
+worktree list` still holds a registration that is no longer a worktree, that
+is cleared with `worktree prune`, after a `worktree unlock` if it is locked
+and with any leftover directory moved aside, before `resume` can recreate
+anything), a worktree whose tip is not the parked commit, a leg parked with
+`--no-push`, and a worktree the record does not know (never parked).
 
 <Name> is the estate's folder under your projects directory: a FAMILY folder
 (<Name>/<Name>/family.yaml) or a standalone project root (<Name>/project.yaml).
@@ -159,9 +165,13 @@ a clone you ALREADY HAVE, in any spelling git accepts.
                       are current: THE ONE WRITE this command makes, to
                       remote-tracking refs, the objects behind them and
                       FETCH_HEAD; never a local branch, tag, HEAD, index or
-                      working tree, because the refspec is pinned. A fetch that
-                      fails is a finding on that row, read as of the last fetch
-                      that worked. An ssh prompt is ssh's own and still blocks.
+                      working tree, because the refspec is pinned. EVERY
+                      repository is fetched before the FIRST ROW is printed,
+                      so the report appears after them; a fetch that fails is
+                      a finding on its own row, read as of the last fetch that
+                      worked. An ssh prompt is ssh's own, still blocks, and
+                      blocks with no row in front of it: it belongs to a
+                      fetch, not to the row you are looking at.
   --all, -a           read EVERY estate under your projects directory
   --project <Name>    the positional under a flag (also --name)
 
@@ -772,6 +782,15 @@ read_branches() {
 # so the first block is skipped rather than compared by path (a Mac's
 # `/tmp` is `/private/tmp`, and two spellings of one path would compare
 # unequal).
+#
+# WHAT IS ON DISK IS `worktree_is_usable`'s ANSWER, below, the same rule the
+# record layer and its sweep now apply — so the three readers of this
+# porcelain agree about what a worktree on disk IS: a directory with its own
+# `.git`. A leftover directory without one is not a worktree to read, and
+# reading it is worse than useless where the feature worktrees live UNDER the
+# root, which is where the extension puts them: `git status` there finds no
+# repository, walks UP, and reports the ROOT's dirty paths on the worktree's
+# row, under a branch that has nothing to do with them.
 read_worktrees() {
     local repo="$1" line path="" branch="" first=1 out n
     while IFS= read -r line; do
@@ -781,7 +800,7 @@ read_worktrees() {
         "")
             if [ "$first" -eq 1 ]; then
                 first=0
-            elif [ -n "$path" ] && [ -d "$path" ]; then
+            elif [ -n "$path" ] && worktree_is_usable "$path"; then
                 out="$(g "$path" status --porcelain --ignore-submodules=all 2>/dev/null || true)"
                 if [ -n "$out" ]; then
                     n="$(printf '%s\n' "$out" | wc -l | tr -d ' ')"
@@ -909,22 +928,145 @@ fetch_remote() {
         if [ "$remote" = origin ]; then FETCHED_OK=1; else UPSTREAM_FETCHED_OK=1; fi
         after="$(g "$repo" rev-parse -q --verify "refs/remotes/$remote/$branch" 2>/dev/null || true)"
         if [ -n "$before" ] && [ -z "$after" ]; then
-            say "    fetched $remote: $remote/$branch is GONE (was $(short "$before")): deleted or renamed on $remote"
+            fetch_say "    fetched $remote: $remote/$branch is GONE (was $(short "$before")): deleted or renamed on $remote"
         elif [ -n "$after" ] && [ "$before" != "$after" ]; then
             if [ -n "$before" ]; then
-                say "    fetched $remote: $remote/$branch moved $(short "$before") -> $(short "$after")"
+                fetch_say "    fetched $remote: $remote/$branch moved $(short "$before") -> $(short "$after")"
             else
-                say "    fetched $remote: $remote/$branch is here now, at $(short "$after")"
+                fetch_say "    fetched $remote: $remote/$branch is here now, at $(short "$after")"
             fi
         elif [ -z "$after" ]; then
-            say "    fetched $remote: there is no $remote/$branch"
+            fetch_say "    fetched $remote: there is no $remote/$branch"
         else
-            say "    fetched $remote: nothing new on $remote/$branch"
+            fetch_say "    fetched $remote: nothing new on $remote/$branch"
         fi
     else
         err="${err%%$'\n'*}"
         finding "$what failed: ${err:-git said nothing}; what follows is as of the last fetch that worked"
     fi
+}
+
+#: WHAT THE PRE-PASS BELOW STORES, one entry per REPOSITORY of the estate in
+#: row order: the path it is keyed by, the lines its fetch printed, the
+#: findings its fetch made, and the two flags the reads branch on. Parallel
+#: arrays and a linear scan, because bash 3.2 has no associative array and an
+#: estate holds a handful of repositories. `FETCH_SAY` is where `fetch_remote`
+#: puts a line instead of printing it.
+FETCH_KEYS=()
+FETCH_SAID=()
+FETCH_FOUND=()
+FETCH_OK_AT=()
+FETCH_UP_OK_AT=()
+FETCH_SAY=""
+fetch_say() { FETCH_SAY="$FETCH_SAY$1"$'\n'; }
+
+# THE KEY IS THE PHYSICAL PATH, the idiom `locate_record` uses on the
+# workspace checkouts and for the same reason: ONE DIRECTORY HAS MORE THAN ONE
+# SPELLING. The rows come from `estate_repos`, which builds a leg's path out
+# of `.gitmodules`; the record layer asks about the path `project.yaml` gives
+# that role — `./spec` against `spec` is the same leg and two strings — and a
+# symlinked projects directory, or a Mac's `/tmp` beside `/private/tmp`, does
+# the same to a root. A key that is a spelling would have said "never fetched"
+# about a repository fetched two rows below.
+physical_path() {
+    local resolved
+    resolved="$(cd "$1" 2>/dev/null && pwd -P)" || resolved="$1"
+    printf '%s\n' "$resolved"
+}
+
+# EVERY REPOSITORY IS FETCHED BEFORE ANY ROW IS READ, which is what `--fetch`
+# has said since it landed — "in every repository first, so the answers are
+# current" — and what it did not quite do: the fetches ran row by row, and THE
+# RECORD LAYER IS READ ON THE ROOT'S ROW, before the legs, whose own origins
+# hold the commits it compares the record against. A feature parked from
+# another workstation into a LEG's origin was therefore reported as a parked
+# commit that "is not here" by the very run that fetched it a moment later,
+# and the finding vanished on the second run (the review of #18). Nothing
+# else moves: each row still prints its own fetch's lines, carries its own
+# fetch's findings and reads its own fetch's flags — `replay_fetch` puts them
+# back where the row-by-row version printed and counted them — so the report
+# reads exactly as it did.
+fetch_estate_first() {
+    local label branch path key seen
+    FETCH_KEYS=()
+    FETCH_SAID=()
+    FETCH_FOUND=()
+    FETCH_OK_AT=()
+    FETCH_UP_OK_AT=()
+    while IFS=$'\t' read -r label branch path; do
+        [ -n "${path:-}" ] || continue
+        case "$label" in
+        holder | root | mounted) ;;
+        *) continue ;;
+        esac
+        key="$(physical_path "$path")"
+        # ONE FETCH PER REPOSITORY, not per row. `family.yaml` is a file
+        # people edit, and a member listed twice is one repository: fetching
+        # it twice would make the second fetch report "nothing new" about
+        # what the first had just moved, and the row that replays the one
+        # entry says what was really done.
+        for seen in ${FETCH_KEYS[@]+"${FETCH_KEYS[@]}"}; do
+            [ "$seen" != "$key" ] || continue 2
+        done
+        FETCH_SAY=""
+        FINDINGS=()
+        fetch_remote "$path" "$branch" origin
+        if has_upstream "$path"; then
+            fetch_remote "$path" "$branch" upstream
+        fi
+        FETCH_KEYS+=("$key")
+        FETCH_SAID+=("$FETCH_SAY")
+        FETCH_FOUND+=("$(printf '%s\n' ${FINDINGS[@]+"${FINDINGS[@]}"})")
+        FETCH_OK_AT+=("$FETCHED_OK")
+        FETCH_UP_OK_AT+=("$UPSTREAM_FETCHED_OK")
+    done <<<"$1"
+    FINDINGS=()
+}
+
+# One row's stored fetch, put back: its lines where they were printed before,
+# its findings in this row's list, its flags in the two the reads branch on.
+# A row the pre-pass skipped — an unmounted leg, a member with no clone — and
+# every row of a run without `--fetch` leaves the flags at 0, which is what
+# "as of the last fetch" means there.
+replay_fetch() {
+    local path i=0 line
+    path="$(physical_path "$1")"
+    FETCHED_OK=0
+    UPSTREAM_FETCHED_OK=0
+    while [ "$i" -lt "${#FETCH_KEYS[@]}" ]; do
+        if [ "${FETCH_KEYS[$i]}" = "$path" ]; then
+            [ -z "${FETCH_SAID[$i]}" ] || printf '%s' "${FETCH_SAID[$i]}"
+            if [ -n "${FETCH_FOUND[$i]}" ]; then
+                while IFS= read -r line; do
+                    [ -z "$line" ] || finding "$line"
+                done <<<"${FETCH_FOUND[$i]}"
+            fi
+            FETCHED_OK="${FETCH_OK_AT[$i]}"
+            UPSTREAM_FETCHED_OK="${FETCH_UP_OK_AT[$i]}"
+            return 0
+        fi
+        i=$((i + 1))
+    done
+    return 0
+}
+
+# Whether the fetch THIS RUN made in `<repo>` worked — the store's answer for
+# any repository of the estate, not only the row being read, which is what
+# lets the record layer tell "never fetched here" from "origin has not got
+# it" for a leg it reads from the root's row. False without `--fetch`, and
+# false for a repository the pre-pass never saw.
+fetched_ok_at() {
+    local path i=0
+    [ "$FETCH" -eq 1 ] || return 1
+    path="$(physical_path "$1")"
+    while [ "$i" -lt "${#FETCH_KEYS[@]}" ]; do
+        if [ "${FETCH_KEYS[$i]}" = "$path" ]; then
+            [ "${FETCH_OK_AT[$i]}" = 1 ] || return 1
+            return 0
+        fi
+        i=$((i + 1))
+    done
+    return 1
 }
 
 # --- the fork against its upstream --------------------------------------------
@@ -1385,7 +1527,14 @@ read_shape() {
 #
 # 1. A RECORDED FEATURE WITH NO WORKTREE HERE on its branch: parked, and not
 #    resumed on this machine. `resume <Name>` is the exit; nothing here adds
-#    a worktree.
+#    a worktree. Unless the record is a `--no-push` one (3): then there is
+#    nothing here to resume FROM, and the exit is the workstation that has it.
+#    And where the porcelain still holds a REGISTRATION for that branch that
+#    is no longer a worktree — its directory gone, or git's own `prunable`
+#    with the directory left behind — what clears it is named first: a prune,
+#    after an unlock where the registration is locked, and a move of any
+#    leftover directory. `resume` cannot recreate a worktree git still
+#    believes it has, nor write over a directory it did not create.
 # 2. A WORKTREE WHOSE BRANCH TIP IS NOT THE PARKED COMMIT: moved on since it
 #    was parked (park again before leaving); or BEHIND it — the record is
 #    newer, parked later on another workstation, which `resume` refuses to
@@ -1396,7 +1545,9 @@ read_shape() {
 #    in the working tree — `resume.sh`'s `wip_gap_is_ours` is what keeps it
 #    from refusing that, and the same test is made here.
 # 3. A LEG PARKED WITH `--no-push`: the record says `pushed: false`, only the
-#    workstation that parked it has the WIP commit, and `resume` refuses it.
+#    workstation that parked it has the WIP commit, and `resume` refuses it —
+#    so no line under this state names `resume` as the exit, and none blames
+#    a missing parked commit on a fetch that never had one to make.
 # 4. A WORKTREE ON DISK THAT THE RECORD DOES NOT KNOW: a feature that was
 #    never parked, which is the one thing `park` exists to carry.
 #
@@ -1454,8 +1605,22 @@ workspace_checkouts() {
 
 # `<org><TAB><file>` for every `workspaces/<org>/<id>.yaml` in every checkout,
 # basename compared case-insensitively — `resume`'s `manifest_candidates`.
+#
+# ONE ROW PER `<org>/<basename>`, because that is what `resume` counts as one
+# record (F4 of the review on openRepoShape #83): the same `<org>/<id>.yaml`
+# reached through TWO CHECKOUTS of one workspace repository — a second clone
+# of it named by an `orgs:` override — is ONE record, and `--org` could not
+# have told the two apart. The checkouts are already deduped by physical path
+# in `locate_record`; this is the other half of the same rule, for two clones
+# that really are two directories. Without it they counted as two, which read
+# as "two orgs record this id" and, where origin names no owner to settle it,
+# SKIPPED a record that was never ambiguous. BOTH HALVES OF THE KEY ARE
+# LOWERED, because both were MATCHED that way — the basename two lines above,
+# the org as `resume` folds it — so `Atlas.yaml` in one checkout and
+# `atlas.yaml` in another are one record here too (Copilot on #18).
 record_candidates() {
-    local want checkout dir file base
+    local want checkout dir file base key seen
+    local -a keys=()
     want="$(lower "$1")"
     shift
     for checkout in "$@"; do
@@ -1466,8 +1631,12 @@ record_candidates() {
             for file in "$dir"/*.yaml; do
                 [ -f "$file" ] || continue
                 base="${file##*/}"
-                base="${base%.yaml}"
-                [ "$(lower "$base")" = "$want" ] || continue
+                [ "$(lower "${base%.yaml}")" = "$want" ] || continue
+                key="$(lower "${dir##*/}")/$(lower "$base")"
+                for seen in ${keys[@]+"${keys[@]}"}; do
+                    [ "$seen" != "$key" ] || continue 2
+                done
+                keys+=("$key")
                 printf '%s\t%s\n' "${dir##*/}" "$file"
             done
         done
@@ -1536,7 +1705,8 @@ locate_record() {
         RECORD_FILE="${candidates#*	}"
         return 0
     fi
-    # Two orgs record this id: the one this root's origin belongs to, if any.
+    # Two orgs record this id — genuinely two, the rows being one per
+    # `<org>/<basename>`: the one this root's origin belongs to, if any.
     url="$(g "$ESTATE_ROOT" config --get remote.origin.url 2>/dev/null || true)"
     owner="$(repo_slug_of "$url" || true)"
     owner="${owner%%/*}"
@@ -1641,16 +1811,87 @@ leg_repo_for_role() {
     return 1
 }
 
+# A REGISTERED PATH IS A WORKTREE ONLY WHILE ITS OWN `.git` IS THERE. A linked
+# worktree's is a FILE holding `gitdir: <repo>/.git/worktrees/<name>`; the main
+# worktree's is a DIRECTORY; a path with neither is a leftover directory git
+# will not resume into. Git says as much itself for an unlocked registration
+# — `prunable gitdir file points to non-existent location` — but it computes
+# no `prunable` for a LOCKED one (verified against git 2.43: lock a worktree,
+# delete its `.git` file, and the block says only `locked`), and that pair is
+# what this test catches: the directory is there, the worktree is not, and
+# `resume` is blocked by a registration nothing had reported (Copilot on #18).
+worktree_is_usable() {
+    [ -d "$1" ] && [ -e "$1/.git" ]
+}
+
 # The path of the worktree checked out on `<branch>` in `<repo>`, main or
-# linked, or nothing.
+# linked. FOUR ANSWERS, because the porcelain has four: 0 and the path when a
+# worktree is really there; 2 AND THE PATH when the only block for that
+# branch is a REGISTRATION WITHOUT A WORKTREE; 3 and the path when such a
+# registration is also LOCKED; 1 and nothing when there is no block at all.
+#
+# GIT'S OWN VERDICT FIRST, THEN THE WORKTREE ITSELF. `worktree list
+# --porcelain` keeps the block of a linked worktree that is no longer one
+# until somebody prunes it, and says so with `prunable <reason>` — which it
+# prints whether or not the DIRECTORY is still there: delete only the
+# worktree's `.git` file and the directory stays, the block says "prunable
+# gitdir file points to non-existent location", and a `-d` test alone would
+# call that live and the recorded feature CLEAN (Copilot on #18). So a
+# `prunable` block is stale whatever is on disk, and what decides the rest is
+# `worktree_is_usable` rather than the directory alone — because git computes
+# no `prunable` for a `locked` block, and a locked one can have a directory
+# with no `.git` in it, or no directory at all, with nothing said either way.
+#
+# AND A STALE BLOCK IS NOT "NOTHING HERE" EITHER, which is why it comes back
+# as 2 or 3 rather than as 1: it is the thing that STOPS the exit this layer
+# would otherwise name — see `check_parked_leg`. The two are told apart
+# because THE EXIT IS NOT THE SAME: `worktree prune` clears an unlocked
+# registration — even one whose directory is still on disk, leaving the
+# directory — and SKIPS a locked one (verified against git 2.43: `prune -v`
+# prints nothing for a locked block, `unlock` then `prune` removes it, and
+# `worktree remove` refuses both a locked one, "cannot remove a locked
+# working tree; use 'remove -f -f' to override or unlock first", and one
+# whose `.git` is gone, "validation failed, cannot remove working tree:
+# '…/.git' does not exist"). Naming a prune that cannot clear it would leave
+# `resume` blocked by the very thing the finding said to clear.
+#
+# TWO STALE REGISTRATIONS FOR ONE BRANCH is a state `worktree add --force`
+# makes, and the LOCKED one is the one to name: `prune` takes every unlocked
+# one in the repository with it, so an `unlock` of the locked path plus that
+# prune clears both, while naming the unlocked path alone would leave the
+# locked registration standing and `resume` still blocked.
+#
+# `locked` AND `prunable` COME AFTER `branch` IN THE BLOCK, so every block is
+# read to its blank line before it is judged, and the whole list is read
+# before the answer is chosen: a live worktree on the branch wins over any
+# stale registration for it, and a locked stale registration wins over an
+# unlocked one.
 worktree_on_branch() {
-    local repo="$1" want="$2" line path=""
+    local repo="$1" want="$2" line path="" hit=0 prunable=0 locked=0
+    local live="" stale="" stale_locked=""
     while IFS= read -r line; do
         case "$line" in
-        "worktree "*) path="${line#worktree }" ;;
-        "branch refs/heads/$want") printf '%s\n' "$path"; return 0 ;;
+        "worktree "*) path="${line#worktree }"; hit=0; prunable=0; locked=0 ;;
+        "branch refs/heads/$want") hit=1 ;;
+        locked | "locked "*) locked=1 ;;
+        prunable | "prunable "*) prunable=1 ;;
+        "")
+            if [ "$hit" -eq 1 ]; then
+                if [ "$prunable" -eq 0 ] && worktree_is_usable "$path"; then
+                    [ -n "$live" ] || live="$path"
+                elif [ "$locked" -eq 1 ]; then
+                    [ -n "$stale_locked" ] || stale_locked="$path"
+                else
+                    [ -n "$stale" ] || stale="$path"
+                fi
+            fi
+            hit=0; prunable=0; locked=0; path=""
+            ;;
         esac
-    done < <(g "$repo" worktree list --porcelain 2>/dev/null || true)
+    done < <(g "$repo" worktree list --porcelain 2>/dev/null; printf '\n')
+    [ -z "$live" ] || { printf '%s\n' "$live"; return 0; }
+    [ -z "$stale_locked" ] || { printf '%s\n' "$stale_locked"; return 3; }
+    [ -z "$stale" ] || { printf '%s\n' "$stale"; return 2; }
     return 1
 }
 
@@ -1684,18 +1925,77 @@ wip_gap_is_ours() {
 # repository.
 check_parked_leg() {
     local root="$1" branch="$2" role="$3" commit="$4" pushed="$5" parked_at="$6" parked_on="$7" depth="$8"
-    local repo tree tip n
+    local repo tree="" ghost="" ghost_is="" clear="" out rc=0 tip n
     repo="$(leg_repo_for_role "$root" "$role" || true)"
     if [ -z "$repo" ] || [ ! -e "$repo/.git" ]; then
         finding "parked feature $branch ($role leg): the record names a leg this root does not mount here"
         return 0
     fi
+    out="$(worktree_on_branch "$repo" "$branch")" || rc=$?
+    case "$rc" in
+    0) tree="$out" ;;
+    2)
+        ghost="$out"
+        ghost_is="a stale worktree registration for it is still recorded at $ghost"
+        clear="\`git -C $repo worktree prune\`"
+        ;;
+    3)
+        ghost="$out"
+        ghost_is="a stale worktree registration for it is still recorded at $ghost and LOCKED, which \`worktree prune\` skips"
+        clear="\`git -C $repo worktree unlock $ghost\`, then \`git -C $repo worktree prune\`"
+        ;;
+    esac
+    # THE DIRECTORY THE PRUNE LEAVES BEHIND is the second half of that exit
+    # where git called the registration stale with the directory still on
+    # disk: the prune clears the registration and touches nothing on disk, and
+    # `git worktree add` then refuses the path in its own words, "already
+    # exists". That directory holds whatever the worktree held, so it is moved
+    # aside rather than deleted here or anywhere else.
+    if [ -n "$ghost" ] && [ -d "$ghost" ]; then
+        ghost_is="$ghost_is, whose directory is still on disk and is no longer a worktree"
+        clear="$clear and a move of that directory aside (\`git worktree add\` refuses a path that \"already exists\")"
+    fi
+    # A STALE REGISTRATION IS NAMED BEFORE THE EXIT IT BLOCKS, and what
+    # clears it before that, because this layer reads the record THE WAY
+    # `resume.sh` WILL JUDGE IT and `resume.sh` judges this one badly: its
+    # `leg_registered_at` matches on the registered PATH alone — fed by
+    # `git-common.sh`'s `load_git_worktrees`, which takes `worktree list
+    # --porcelain -z` raw, with no test that the directory is there — so a
+    # stale block AT the path it computes reads as already done ("worktree
+    # already registered at …; left as it is") and nothing is recreated,
+    # while a stale block at ANOTHER path leaves its plain `git worktree add`
+    # to be refused ("already used by worktree at …"). `resume.sh` names the
+    # hazard itself, where it rolls back what it created: "a phantom
+    # registration a later resume reads as 'already registered' for a path
+    # that is not there". Naming `resume` alone would be naming an exit that
+    # does not work — and the house rule is that the exit named is one that
+    # does, which is also why the LOCKED registration gets the `unlock` in
+    # front of the prune that would otherwise skip it (Copilot on #18).
+    #
+    # `--no-push` IS THE ONE RECORD `resume` CANNOT ANSWER, so no line under
+    # it offers `resume` as the exit: the WIP commit is on the workstation
+    # that parked it and nowhere else, which is exactly what `resume.sh`
+    # refuses the leg for. Saying "`resume` refuses it" and then "`resume
+    # <Name>` brings it back" sent the person to the command the line above
+    # had just ruled out, so where both states hold they are ONE line, and it
+    # names the only exit there is: park it again, with the push, from there.
+    if [ "$pushed" = false ] && [ -z "$tree" ]; then
+        if [ -n "$ghost" ]; then
+            finding "parked feature $branch ($role leg): parked with --no-push on ${parked_on:-another workstation} and no worktree on that branch here, but $ghost_is — clear it with $clear; only that workstation has the WIP commit, so nothing here brings it back — park it again from there"
+        else
+            finding "parked feature $branch ($role leg): parked with --no-push on ${parked_on:-another workstation} and no worktree on that branch here; only that workstation has the WIP commit, so nothing here brings it back — park it again from there"
+        fi
+        return 0
+    fi
     if [ "$pushed" = false ]; then
         finding "parked feature $branch ($role leg): parked with --no-push on ${parked_on:-another workstation}; only that workstation has the WIP commit, and \`resume\` refuses it"
     fi
-    tree="$(worktree_on_branch "$repo" "$branch" || true)"
     if [ -z "$tree" ]; then
-        finding "parked feature $branch ($role leg): no worktree on that branch here; parked ${parked_at:-?} on ${parked_on:-?} — \`resume $ESTATE_NAME\` brings it back"
+        if [ -n "$ghost" ]; then
+            finding "parked feature $branch ($role leg): no worktree on that branch here, but $ghost_is — clear it with $clear, then \`resume $ESTATE_NAME\` brings it back"
+        else
+            finding "parked feature $branch ($role leg): no worktree on that branch here; parked ${parked_at:-?} on ${parked_on:-?} — \`resume $ESTATE_NAME\` brings it back"
+        fi
         return 0
     fi
     [ -n "$commit" ] || return 0
@@ -1703,7 +2003,25 @@ check_parked_leg() {
     [ -n "$tip" ] || return 0
     [ "$tip" != "$commit" ] || return 0
     if ! g "$repo" cat-file -e "$commit^{commit}" 2>/dev/null; then
-        finding "parked feature $branch ($role leg): its parked commit $(short "$commit") is not here — never fetched, or parked with --no-push on ${parked_on:-another workstation}"
+        # WHAT THE RECORD ITSELF RULES OUT IS NOT OFFERED AS A REASON. With
+        # `pushed: true` the commit left that workstation, so what is left is
+        # this repository never fetching it, or origin not having it any more;
+        # `pushed: false` is the other case, has its own line above, and here
+        # only says where the commit is. AND AFTER A FETCH THAT WORKED IN THIS
+        # REPOSITORY the first of those is ruled out too, so the line says so
+        # — the way `no_origin_branch_finding` does for a missing
+        # `origin/<branch>`, and for the same reason: contradicting the
+        # `fetched origin:` line printed a moment earlier is worse than saying
+        # nothing. `fetched_ok_at` is the pre-pass's answer for THIS
+        # repository, root or leg, because every one of them is fetched before
+        # any row is read.
+        if [ "$pushed" = false ]; then
+            finding "parked feature $branch ($role leg): its parked commit $(short "$commit") is not here, which is what --no-push means — ${parked_on:-that workstation} is the only place it is"
+        elif fetched_ok_at "$repo"; then
+            finding "parked feature $branch ($role leg): its parked commit $(short "$commit") is not here after this run's fetch — the record says it was pushed, so origin has not got it either: rewritten there, or pushed somewhere this clone is not looking"
+        else
+            finding "parked feature $branch ($role leg): its parked commit $(short "$commit") is not here — the record says it was pushed, so this repository has never fetched it, or origin no longer has it"
+        fi
     elif g "$repo" merge-base --is-ancestor "$commit" "$tip" 2>/dev/null; then
         n="$(g "$repo" rev-list --count "$commit..$tip" 2>/dev/null || true)"
         finding "parked feature $branch ($role leg): moved on since it was parked, ${n:-?} commit(s) after $(short "$commit") — park again before leaving"
@@ -1720,9 +2038,20 @@ check_parked_leg() {
 }
 
 # Linked worktrees on disk — in the root and in each mounted leg — whose
-# branch the record does not know: work that was never parked.
+# branch the record does not know: work that was never parked. ON DISK is
+# meant literally, for `worktree_on_branch`'s reason: the porcelain keeps a
+# deleted worktree's block until `git worktree prune` runs, and telling
+# somebody that a directory which is not there was never parked is a finding
+# about nothing. `read_worktrees` checks the same path before reading it.
+# GIT'S `prunable` IS READ HERE TOO, and for the same reason: a registration
+# git itself calls stale is not a worktree `park` could carry, whatever is
+# left in its directory — that leftover is the person's to move aside, and
+# `park` would no more see it than `resume` could write to it. And where git
+# says nothing because the block is `locked`, `worktree_is_usable` is what
+# says it: a directory with no `.git` in it is not a worktree either, and
+# accusing it of never having been parked is the same finding about nothing.
 unrecorded_worktrees() {
-    local root="$1" recorded="$2" repo where line path="" branch="" first=1 state leg
+    local root="$1" recorded="$2" repo where line path="" branch="" first=1 state leg prunable=0
     local -a repos=("$root")
     while IFS=$'\t' read -r state leg; do
         [ "$state" = mounted ] || continue
@@ -1735,18 +2064,20 @@ unrecorded_worktrees() {
         first=1; path=""; branch=""
         while IFS= read -r line; do
             case "$line" in
-            "worktree "*) path="${line#worktree }"; branch="" ;;
+            "worktree "*) path="${line#worktree }"; branch=""; prunable=0 ;;
             "branch "*) branch="${line#branch refs/heads/}" ;;
+            prunable | "prunable "*) prunable=1 ;;
             "")
                 if [ "$first" -eq 1 ]; then
                     first=0
-                elif [ -n "$branch" ]; then
+                elif [ -n "$branch" ] && [ "$prunable" -eq 0 ] &&
+                    worktree_is_usable "$path"; then
                     case "$recorded" in
                     *"$NL$branch$NL"*) ;;
                     *) finding "worktree on $branch ($where): not in the parked record — never parked; \`park\` carries the features under this root's worktree root, anything else is yours to keep or remove" ;;
                     esac
                 fi
-                path=""; branch=""
+                path=""; branch=""; prunable=0
                 ;;
             esac
         done < <(g "$repo" worktree list --porcelain 2>/dev/null; printf '\n')
@@ -1802,7 +2133,7 @@ CHANGED_CLAUSE="nothing was changed."
 # anything was found and 0 when nothing was, so the sweep can carry on and
 # the single-estate call site can turn that straight into its exit code.
 read_one_estate() {
-    local label branch path current_root="" rel line
+    local label branch path current_root="" rel line rows
     ESTATE_FINDINGS=0
     ESTATE_REPOS=0
     if [ "$ESTATE_KIND" = "family" ]; then
@@ -1816,6 +2147,12 @@ read_one_estate() {
     else
         say "  as of the last fetch: status reads local refs only and fetches nothing."
     fi
+    # THE ROWS ARE READ ONCE and fetched in full before any of them is
+    # printed, so "then it is read" above is the order this runs in — the
+    # record layer included, which is read on the root's row and compares
+    # against commits the LEGS' origins hold.
+    rows="$(estate_repos)"
+    [ "$FETCH" -eq 0 ] || fetch_estate_first "$rows"
     locate_record
     if [ -n "$RECORD_FILE" ]; then
         say "  parked record: $RECORD_FILE, as of its last pull"
@@ -1833,12 +2170,7 @@ read_one_estate() {
         holder | root)
             current_root="$path"
             printf '  %-6s %-6s %s\n' "$label" "$branch" "$path"
-            if [ "$FETCH" -eq 1 ]; then
-                fetch_remote "$path" "$branch" origin
-                if has_upstream "$path"; then
-                    fetch_remote "$path" "$branch" upstream
-                fi
-            fi
+            replay_fetch "$path"
             read_head "$path" "$branch"
             read_tracking "$path" "$branch"
             read_fork "$path" "$branch"
@@ -1857,12 +2189,7 @@ read_one_estate() {
             ;;
         mounted)
             printf '  %-6s %-6s %s\n' "leg" "$branch" "$path"
-            if [ "$FETCH" -eq 1 ]; then
-                fetch_remote "$path" "$branch" origin
-                if has_upstream "$path"; then
-                    fetch_remote "$path" "$branch" upstream
-                fi
-            fi
+            replay_fetch "$path"
             rel="${path#"$current_root"/}"
             read_leg "$current_root" "$rel" "$branch"
             read_fork "$path" "$branch"
@@ -1888,7 +2215,7 @@ read_one_estate() {
             done
             ESTATE_FINDINGS=$((ESTATE_FINDINGS + ${#FINDINGS[@]}))
         fi
-    done < <(estate_repos)
+    done <<<"$rows"
     say ""
     if [ "$ESTATE_REPOS" -eq 1 ]; then
         say "status: $ESTATE_NAME - $ESTATE_FINDINGS finding(s) in 1 repository; $CHANGED_CLAUSE"
@@ -1955,15 +2282,30 @@ while [ $# -gt 0 ]; do
     case "$1" in
     -h | --help) usage; exit 0 ;;
     -a | --all) STATUS_ALL=1; shift ;;
-    # A MISSING VALUE IS A REFUSAL, exit 2, in this command's own words:
-    # `${2:?…}` would be bash's message and bash's exit 1 — and 1 is what
-    # this command means by "findings were printed", so a typo must not be
-    # able to read as a report.
+    # A MISSING OR EMPTY VALUE IS A REFUSAL, exit 2, in this command's own
+    # words: `${2:?…}` would be bash's message and bash's exit 1 — and 1 is
+    # what this command means by "findings were printed", so a typo must not
+    # be able to read as a report.
+    # EMPTY IS REFUSED THE SAME WAY, which is why both arms below ask for a
+    # NON-EMPTY `$2` and not only for a second argument. THESE TWO WERE NEVER
+    # `${2:?…}`: they have been arity-only since this file's first commit, so
+    # when Copilot's review of #14 said that `[ $# -ge 2 ]` checks only that
+    # an argument slot exists — said of `park` and `resume`, which had just
+    # swapped `${2:?…}` for exactly that — `status` was not in front of it,
+    # and it kept the hole the other two then closed. It is the same hole:
+    # every value here is read further down as "was this given at all?", so
+    # `status --repo ""` fell past the `--repo` branch of the resolver into
+    # the walk-up and reported the estate around the cwd as though `--repo`
+    # had never been typed. A wrong answer is worse here than in either verb,
+    # not better: nothing was changed, so there is nothing to undo and no
+    # reason for anybody to look twice.
     --repo)
-        [ $# -ge 2 ] || die "--repo needs a value: <owner>/<name>, or any url spelling of one."
+        [ $# -ge 2 ] && [ -n "$2" ] ||
+            die "--repo needs a value: <owner>/<name>, or any url spelling of one."
         REPO_SLUG="$2"; REPO_ARG="$REPO_SLUG"; shift 2 ;;
     --name | --project)
-        [ $# -ge 2 ] || die "$1 needs a value: one estate folder name under your projects directory."
+        [ $# -ge 2 ] && [ -n "$2" ] ||
+            die "$1 needs a value: one estate folder name under your projects directory."
         NAME="$2"; shift 2 ;;
     # THE SECOND LAYER (Brett Heap's RULING of 2026-09-11, "next layer:
     # --fetch"): ask origin in every repository first. See `fetch_remote`.

--- a/devBenches/base-image/upstream-pin.yaml
+++ b/devBenches/base-image/upstream-pin.yaml
@@ -57,18 +57,18 @@ sources:
     source_repository: opensoft/openRepoTools
     materialization: copied
     revision_kind: commit
-    commit: "f519f31c28fad3ab2f54cd60d828226d866db3f5"
+    commit: "a2c85219942eb8a8fbb2cfd20131e0ebf0336c10"
     vendor_dir: files/openrepotools
     files:
       - path: openRepoTools
         sha256: "636a8aa268c70ec414c700d72974e029ab45ffc1051a213bcd955ad73fc0dd9a"
         mode: "100755"
       - path: park
-        sha256: "034911a3a5dbcc6f9ec1e6e5da351f018e3eebaeb8b3b7608f536c884c7f8a60"
+        sha256: "b0bcf13a97f4c6688bb6bbc4637e6b1f3142448bbb0b66c105396765f0b7d62b"
         mode: "100755"
       - path: resume
-        sha256: "155a852ae3f3642fcf4e8cc2e77148aca8620f00b51462e18f960022596283a3"
+        sha256: "db6fe6237648714936467be7236cd6450db23e9d5bd96c415a6ae1322becab07"
         mode: "100755"
       - path: status
-        sha256: "2bf505350c16631393b6a76cafe27469a9c9923a814bd068132abb98e3365654"
+        sha256: "617dfae1a288c47cb76967f1b438a72f3a6aac023fb96ea5d14082bf092d658b"
         mode: "100755"


### PR DESCRIPTION
The `openrepotools` source pin moves from f519f31c28fad3ab2f54cd60d828226d866db3f5
(pinned in #51) to a2c85219942eb8a8fbb2cfd20131e0ebf0336c10 —
`gh api repos/opensoft/openRepoTools/compare/main...a2c85219942eb8a8fbb2cfd20131e0ebf0336c10`
says `identical`, so it is the commit opensoft/openRepoTools's main carries after
opensoft/openRepoTools#18.

Between the two commits (opensoft/openRepoTools#16, #17 and #18, all squash-merged):
openRepoTools pins openRepoShape at 32450eb, its main of 2026-09-11, the commit this
repository's own `openreposhape` row already carries (#16; none of the eight mounted
files moved). Every value-taking flag of `park`, `resume` and `status` refuses an
EMPTY value in the same words as a missing one, exit 2, so `--lane ""` no longer parks
with the lane dropped and `--repo ""` no longer falls back to the walk-up (#17). And
`status`'s parked-record layer, the follow-up Copilot's two reviews of #13 were owed
(#18): a recorded feature whose worktree is gone is "no worktree here", not clean; a
registration `git worktree list` still holds for it is told apart from none, and the
finding names `git -C <repo> worktree prune` before `resume <Name>`, `git worktree
unlock <path>` first when the block is locked, since prune skips a locked one, and a
leftover directory is moved aside, never deleted; a block git itself calls `prunable`
is stale whatever is on disk, and a registered path is a worktree only while its own
`.git` is there — the record layer, the unrecorded sweep and the local layer's
`read_worktrees` now apply the one rule; two checkouts of one workspace repository
are one record, keyed on `<org>/<basename>` with both halves case-folded, in `status`
and `resume` alike; a `--no-push` record with no worktree here is one line naming the
only exit and never names `resume`; and `status --fetch` fetches every repository of
the estate FIRST, before the first row prints, keyed by physical path, so a parked
commit that lived only on a leg's origin is no longer reported missing and then
fetched further down the same report. The installer places the same four files.

So this is one `apply` run and nothing else: no command was added or removed, so
the Dockerfile COPYs, scripts/setup-estate-commands.sh, setup.sh, the README and the
test scripts that enumerate the commands are untouched. update-upstream.py is untouched.

check: exit 0, 6 rows across 2 sources.
devcontainer.test/test-setup-estate-commands.sh: 83 PASS, GREEN, exit 0.
devBenches/devcontainer.test/test-speckit-git-feature.sh: 56 PASS, GREEN, exit 0.
The base image was not rebuilt here; only the vendored copies and their pin rows change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Re-vendor openRepoTools to improve worktree status accuracy, workspace record consolidation, fetch behavior, and command-line validation.

Bug Fixes:
- Ensure status consistently distinguishes missing, stale, locked, and registered worktrees, including safe handling of leftover directories and proper resume guidance.
- Make status --fetch update all repositories before reporting results and consolidate multiple checkouts of the same workspace into one record.
- Reject empty values for all value-taking park, resume, and status flags.
- Prevent status from suggesting resume for worktree-less --no-push records.

Enhancements:
- Re-vendor openRepoTools and update its upstream commit and file checksums.