### PR TITLE
devBenches/base-image: re-vendor openRepoShape at cd57c4b — four shape-doctor.py fixes landed upstream, no vendored byte changes

### DIFF
--- a/devBenches/base-image/upstream-pin.yaml
+++ b/devBenches/base-image/upstream-pin.yaml
@@ -43,7 +43,7 @@ sources:
     source_repository: opensoft/openRepoShape
     materialization: copied
     revision_kind: commit
-    commit: "32450eb5c5d18fbb0747dc5ad420cf67742cfa99"
+    commit: "cd57c4bbd84ee323616f952b35cbb5fe8ac88196"
     vendor_dir: files/openreposhape
     files:
       - path: openRepoShape


### PR DESCRIPTION
Lane: openreposhape-2 (openRepoShape-2)
Claim: https://github.com/opensoft/workBenches/issues/57#issuecomment-5638006754

Closes #57.

**What lands.** `devBenches/base-image/upstream-pin.yaml`'s `openreposhape` source moves from `32450eb5c5d18fbb0747dc5ad420cf67742cfa99` (pinned in #49, carried by #50) to `cd57c4bbd84ee323616f952b35cbb5fe8ac88196` — `gh api repos/opensoft/openRepoShape/compare/main...cd57c4bbd84ee323616f952b35cbb5fe8ac88196 -q .status` says `identical`, so it is the commit `main` carries after four commits landed since the last pin (opensoft/openRepoShape#106, #108, #107 and #110 — Brett Heap's standing order: "merge when green, pin-only re-vendor in workBenches, reinstall on Eagle"). **The tool does not change** — one `apply` run and nothing else.

**Upstream, between the two commits (four commits on `main` since the last pin, not one):**

- opensoft/openRepoShape#106 (`c3f4c03`, closes #103) — `scaffold_command` quotes for the platform it was asked for, not the host it runs on, so one call is one line on every machine.
- opensoft/openRepoShape#108 (`dac5380`, closes #104) — the naming row puts `--` before repository names, so `--help` and `-x` are names to argparse again, not options.
- opensoft/openRepoShape#107 (`e6ec62b`, closes #105) — `cp` is `Copy-Item` on Windows and its `-Path` reads `[old]` as a wildcard, so the drifted-file repair says `Copy-Item -LiteralPath` there.
- opensoft/openRepoShape#110 (`cd57c4b`, closes #109) — the way-in row hands back the identity the `naming` row already classified, verbatim, instead of an unconditional respelling of it.

None of these are `openRepoShape` or `templates/assembly-root/project.yaml`, the two files this repository vendors — the whole span touches only two paths. Confirmed from a run, not from reasoning: `gh api repos/opensoft/openRepoShape/compare/32450eb5c5d18fbb0747dc5ad420cf67742cfa99...cd57c4bbd84ee323616f952b35cbb5fe8ac88196 -q '.files[].filename'` lists only `shape-doctor.py` and `tests/test_shape_doctor.py` — no vendored path among them.

**The `apply` run, verbatim:**

```
$ python3 devBenches/base-image/update-upstream.py apply --source openreposhape --at cd57c4bbd84ee323616f952b35cbb5fe8ac88196 --yes
source      openreposhape (opensoft/openRepoShape)
pinned      32450eb5c5d1
target      cd57c4bbd84e (on main)
vendor      files/openreposhape

  unchanged openRepoShape
  unchanged templates/assembly-root/project.yaml
  re-pin    commit 32450eb5c5d1 -> cd57c4bbd84e

  wrote     files/openreposhape/openRepoShape  0755
  wrote     files/openreposhape/templates/assembly-root/project.yaml  0644
  re-pinned devBenches/base-image/upstream-pin.yaml  2 row(s) at cd57c4bbd84e

NEXT  python3 devBenches/base-image/update-upstream.py check
```

Both vendored files come back `unchanged` — the brief's claim proven from a run. Only the pin row's `commit:` moves.

**Proofs, all run on this branch's HEAD.**

| Run | Result |
|---|---|
| `update-upstream.py check` | exit 0, **6** vendored copies across 2 sources (`openreposhape`: `openRepoShape`, `templates/assembly-root/project.yaml`; `openrepotools`: `openRepoTools`, `park`, `resume`, `status`), all `ok` |
| `git diff --stat` | 1 file: `devBenches/base-image/upstream-pin.yaml`, 1 line — no vendored byte anywhere, no tool change, no Dockerfile change |
| `devBenches/devcontainer.test/test-speckit-git-feature.sh` | 56/56 GREEN, exit 0 |
| `devcontainer.test/test-setup-estate-commands.sh` | 83/83 GREEN, exit 0 |

**Not proven here: the image.** `dev-bench-base` carries the new pin only after its next rebuild — not run in this PR, and moot here since no vendored byte moved. Eagle's host reinstall is unaffected (the installed shim bytes are unchanged) and is done on Brett Heap's standing order on opensoft/openRepoShape#101/#109 ("merge when green, pin-only re-vendor in workBenches, reinstall on Eagle").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Update the vendored openRepoShape source pin to the latest upstream commit without changing any vendored files.