### PR TITLE
resume.sh's RR6 says what the record's `pushed:` says: only `false` is the `--no-push` park, and a value that is neither true nor false is named, not read as a claim nobody made

### DIFF
--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/commands/speckit.git.resume.md
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/commands/speckit.git.resume.md
@@ -66,6 +66,7 @@ Print the script's own message verbatim, then add the reading below.
 | the local branch is BEHIND the parked commit | This workstation had the feature before the other one parked newer work. The remediation is the fast-forward the message prints, then `make resume` again — not a deletion |
 | the local branch diverged | Local commits exist that the parked commit does not contain. Rename or delete that branch; look first with the printed `log` command |
 | parked with `--no-push` | The parked commit exists only on the workstation that parked it. Push it there, re-run `park`, then resume here |
+| the record's `pushed:` is neither true nor false | A value `park` never writes — a hand-edit or a bad merge of the record. Do NOT read it as `--no-push`: the record rules nothing out, so whether the parked commit ever left that workstation cannot be read from it. The exit is a park from the workstation that has the worktree, which writes the record afresh |
 | the workspace has no entry for this project | Either nothing was parked for it, or it was parked into a differently named file; the message prints the `grep` over that org's directory |
 | `workspace-config-invalid` | The config's `orgs:` block is malformed. It refuses rather than falling back to the default workspace, because a confidential org's work must never be indexed in the wrong repository |
 

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/commands/speckit.git.resume.md
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/commands/speckit.git.resume.md
@@ -67,6 +67,7 @@ Print the script's own message verbatim, then add the reading below.
 | the local branch diverged | Local commits exist that the parked commit does not contain. Rename or delete that branch; look first with the printed `log` command |
 | parked with `--no-push` | The parked commit exists only on the workstation that parked it. Push it there, re-run `park`, then resume here |
 | the record's `pushed:` is neither true nor false | A value `park` never writes — a hand-edit or a bad merge of the record. Do NOT read it as `--no-push`: the record rules nothing out, so whether the parked commit ever left that workstation cannot be read from it. The exit is a park from the workstation that has the worktree, which writes the record afresh |
+| the record has no `pushed:` for a leg | The record says nothing at all about that leg, which is not the same as saying `false`. It rules nothing out either, and the exit is the same park from the workstation that has the worktree |
 | the workspace has no entry for this project | Either nothing was parked for it, or it was parked into a differently named file; the message prints the `grep` over that org's directory |
 | `workspace-config-invalid` | The config's `orgs:` block is malformed. It refuses rather than falling back to the default workspace, because a confidential org's work must never be indexed in the wrong repository |
 

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/resume.sh
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/resume.sh
@@ -471,17 +471,24 @@ while [ "$selection" -lt "${#SELECTED_INDEXES[@]}" ]; do
                 >&2 echo "Push it there, re-run \`make park\`, then resume here."
                 record_refusal "$branch" "parked with --no-push" "re-run \`make park\` on $MANIFEST_PARKED_ON"
             else
+                # The stderr line names the leg in front of the clause; the
+                # branch-level REFUSED line and the `--json` reason do not, so
+                # "this leg" had no antecedent there — the reason names the
+                # leg itself (the independent review of this change, 2026-09-11).
                 if [ -z "$pushed_seen" ]; then
                     unreadable_pushed="the record has no \`pushed:\` for this leg"
+                    refusal_reason="the record has no \`pushed:\` for the $role leg"
                 elif [ -z "$pushed" ]; then
                     unreadable_pushed="its record's \`pushed:\` has no value, which is neither true nor false"
+                    refusal_reason="$unreadable_pushed"
                 else
                     unreadable_pushed="its record's \`pushed:\` says '$pushed', which is neither true nor false"
+                    refusal_reason="$unreadable_pushed"
                 fi
                 >&2 echo "Error: $branch ($role leg): $unreadable_pushed; that feature was NOT recreated."
                 >&2 echo "Whether its parked commit $parked_commit ever left ${MANIFEST_PARKED_ON:-the workstation that parked it} cannot be read from the record."
                 >&2 echo "Park it again from there, which writes the record afresh, then resume here."
-                record_refusal "$branch" "$unreadable_pushed" \
+                record_refusal "$branch" "$refusal_reason" \
                     "re-run \`make park\` on ${MANIFEST_PARKED_ON:-the workstation that parked it} to write the record afresh"
             fi
             refused=true

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/resume.sh
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/resume.sh
@@ -290,6 +290,7 @@ LEG_TREES=()
 LEG_COMMITS=()
 LEG_DEPTHS=()
 LEG_PUSHEDS=()
+LEG_PUSHED_SEENS=()
 
 collect_legs() {
     local feature_index="$1"
@@ -304,6 +305,7 @@ collect_legs() {
     LEG_COMMITS=()
     LEG_DEPTHS=()
     LEG_PUSHEDS=()
+    LEG_PUSHED_SEENS=()
     while [ "$index" -lt "${#MANIFEST_LEG_ROLE[@]}" ]; do
         if [ "${MANIFEST_LEG_FEATURE[$index]}" != "$feature_index" ]; then
             index=$((index + 1))
@@ -335,6 +337,7 @@ collect_legs() {
         LEG_COMMITS[${#LEG_COMMITS[@]}]="${MANIFEST_LEG_COMMIT[$index]}"
         LEG_DEPTHS[${#LEG_DEPTHS[@]}]="${MANIFEST_LEG_DEPTH[$index]}"
         LEG_PUSHEDS[${#LEG_PUSHEDS[@]}]="${MANIFEST_LEG_PUSHED[$index]}"
+        LEG_PUSHED_SEENS[${#LEG_PUSHED_SEENS[@]}]="${MANIFEST_LEG_PUSHED_SEEN[$index]}"
         index=$((index + 1))
     done
     [ "${#LEG_ROLES[@]}" -gt 0 ]
@@ -432,6 +435,7 @@ while [ "$selection" -lt "${#SELECTED_INDEXES[@]}" ]; do
         tree="${LEG_TREES[$leg]}"
         parked_commit="${LEG_COMMITS[$leg]}"
         pushed="${LEG_PUSHEDS[$leg]}"
+        pushed_seen="${LEG_PUSHED_SEENS[$leg]}"
         LEG_ACTION[leg]="create"
         leg=$((leg + 1))
 
@@ -453,6 +457,13 @@ while [ "$selection" -lt "${#SELECTED_INDEXES[@]}" ]; do
         # worktree writes it afresh. The refusal itself is unchanged —
         # `!= true` — because a reader that cannot read the field must not
         # recreate the feature on a guess.
+        #
+        # AND NO `pushed:` AT ALL IS ITS OWN STATE, not a spelling of the one
+        # above: the record is not saying something that cannot be read, it is
+        # saying nothing. `workspace_load_project` keeps the two apart in
+        # `MANIFEST_LEG_PUSHED_SEEN` for that reason, and these are
+        # `openRepoTools`' `status`'s words for the same four states, so the
+        # two tools tell the person one story.
         if [ "$pushed" != true ]; then
             if [ "$pushed" = false ]; then
                 >&2 echo "Error: $branch ($role leg) was parked with --no-push; that feature was NOT recreated."
@@ -460,15 +471,17 @@ while [ "$selection" -lt "${#SELECTED_INDEXES[@]}" ]; do
                 >&2 echo "Push it there, re-run \`make park\`, then resume here."
                 record_refusal "$branch" "parked with --no-push" "re-run \`make park\` on $MANIFEST_PARKED_ON"
             else
-                if [ -z "$pushed" ]; then
-                    unreadable_pushed="its record's \`pushed:\` has no value"
+                if [ -z "$pushed_seen" ]; then
+                    unreadable_pushed="the record has no \`pushed:\` for this leg"
+                elif [ -z "$pushed" ]; then
+                    unreadable_pushed="its record's \`pushed:\` has no value, which is neither true nor false"
                 else
-                    unreadable_pushed="its record's \`pushed:\` says '$pushed'"
+                    unreadable_pushed="its record's \`pushed:\` says '$pushed', which is neither true nor false"
                 fi
-                >&2 echo "Error: $branch ($role leg): $unreadable_pushed, which is neither true nor false; that feature was NOT recreated."
+                >&2 echo "Error: $branch ($role leg): $unreadable_pushed; that feature was NOT recreated."
                 >&2 echo "Whether its parked commit $parked_commit ever left ${MANIFEST_PARKED_ON:-the workstation that parked it} cannot be read from the record."
                 >&2 echo "Park it again from there, which writes the record afresh, then resume here."
-                record_refusal "$branch" "$unreadable_pushed, which is neither true nor false" \
+                record_refusal "$branch" "$unreadable_pushed" \
                     "re-run \`make park\` on ${MANIFEST_PARKED_ON:-the workstation that parked it} to write the record afresh"
             fi
             refused=true

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/resume.sh
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/resume.sh
@@ -435,12 +435,42 @@ while [ "$selection" -lt "${#SELECTED_INDEXES[@]}" ]; do
         LEG_ACTION[leg]="create"
         leg=$((leg + 1))
 
-        # RR6 — parked with --no-push.
+        # RR6 — the record's `pushed:` is not `true`.
+        #
+        # AS STRICT AS IT EVER WAS, and no longer worded past what the record
+        # says. `park.sh` writes the literal `true` or `false` it computed from
+        # the push it just made, and `workspace_write_manifest` drops a key
+        # whose value is empty — so `false` IS the `--no-push` park and keeps
+        # that wording byte for byte. ANYTHING ELSE IS A VALUE THIS EXTENSION
+        # NEVER WROTE: a hand-edit or a bad merge of the record. Saying
+        # "parked with --no-push" over `pushed: maybe` made a claim nobody
+        # made — the same reading `openRepoTools`' `status` stopped making on
+        # 2026-09-11 — and, worse, told the person the parked commit is on the
+        # workstation that parked it and nowhere else, which the record does
+        # not say either. So the unreadable value is named for what it is, and
+        # the one thing that is true of it is what the line offers: the record
+        # rules nothing out, and only a park from the workstation that has the
+        # worktree writes it afresh. The refusal itself is unchanged —
+        # `!= true` — because a reader that cannot read the field must not
+        # recreate the feature on a guess.
         if [ "$pushed" != true ]; then
-            >&2 echo "Error: $branch ($role leg) was parked with --no-push; that feature was NOT recreated."
-            >&2 echo "Its parked commit $parked_commit exists only on the workstation that parked it ($MANIFEST_PARKED_ON)."
-            >&2 echo "Push it there, re-run \`make park\`, then resume here."
-            record_refusal "$branch" "parked with --no-push" "re-run \`make park\` on $MANIFEST_PARKED_ON"
+            if [ "$pushed" = false ]; then
+                >&2 echo "Error: $branch ($role leg) was parked with --no-push; that feature was NOT recreated."
+                >&2 echo "Its parked commit $parked_commit exists only on the workstation that parked it ($MANIFEST_PARKED_ON)."
+                >&2 echo "Push it there, re-run \`make park\`, then resume here."
+                record_refusal "$branch" "parked with --no-push" "re-run \`make park\` on $MANIFEST_PARKED_ON"
+            else
+                if [ -z "$pushed" ]; then
+                    unreadable_pushed="its record's \`pushed:\` has no value"
+                else
+                    unreadable_pushed="its record's \`pushed:\` says '$pushed'"
+                fi
+                >&2 echo "Error: $branch ($role leg): $unreadable_pushed, which is neither true nor false; that feature was NOT recreated."
+                >&2 echo "Whether its parked commit $parked_commit ever left ${MANIFEST_PARKED_ON:-the workstation that parked it} cannot be read from the record."
+                >&2 echo "Park it again from there, which writes the record afresh, then resume here."
+                record_refusal "$branch" "$unreadable_pushed, which is neither true nor false" \
+                    "re-run \`make park\` on ${MANIFEST_PARKED_ON:-the workstation that parked it} to write the record afresh"
+            fi
             refused=true
             break
         fi

--- a/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/workspace-common.sh
+++ b/devBenches/base-image/files/speckit-worktree/templates/specify/extensions/git/scripts/bash/workspace-common.sh
@@ -615,6 +615,21 @@ PY
 #   MANIFEST_FEATURE_BRANCHES[]   MANIFEST_FEATURE_DIRECTORIES[]
 #   MANIFEST_LEG_FEATURE[]        the feature index each leg row belongs to
 #   MANIFEST_LEG_ROLE[] _REMOTE[] _COMMIT[] _WIP[] _DEPTH[] _PUSHED[]
+#   MANIFEST_LEG_PUSHED_SEEN[]    the word `pushed` where that leg's record
+#                                 carried the key, empty where it did not
+#
+# _PUSHED[] IS NOT DEFAULTED TO A VALUE THE RECORD DOES NOT CARRY. It was
+# seeded with "false" at the `- role:` line, so a leg with no `pushed:` key
+# loaded as though the record said `pushed: false` — and two readers then
+# spoke for a record that had said nothing: `resume.sh`'s RR6 refused the leg
+# in the `--no-push` words, and `park.sh`'s `emit_recorded_feature`, which
+# carries a REFUSED feature's loaded entry forward verbatim, wrote
+# `pushed: false` back into the file. The seed is the empty string instead,
+# which `workspace_write_manifest` drops rather than writes, so a refused park
+# carries the hole forward as a hole. _PUSHED_SEEN[] is what keeps the two
+# empties apart — a key that is absent from a key that is there with no value
+# after the colon — because they are two different things for a reader to say,
+# and a reader never guesses.
 #
 # Bash 3.2 has no nested arrays, so the leg rows are a flat table keyed by
 # feature index. The file is written by this extension with a fixed layout, so
@@ -647,6 +662,7 @@ workspace_load_project() {
     MANIFEST_LEG_WIP=()
     MANIFEST_LEG_DEPTH=()
     MANIFEST_LEG_PUSHED=()
+    MANIFEST_LEG_PUSHED_SEEN=()
 
     [ -f "$file" ] || return 1
     while IFS= read -r raw || [ -n "$raw" ]; do
@@ -774,7 +790,8 @@ workspace_load_project() {
             MANIFEST_LEG_COMMIT[${#MANIFEST_LEG_COMMIT[@]}]=""
             MANIFEST_LEG_WIP[${#MANIFEST_LEG_WIP[@]}]="false"
             MANIFEST_LEG_DEPTH[${#MANIFEST_LEG_DEPTH[@]}]="0"
-            MANIFEST_LEG_PUSHED[${#MANIFEST_LEG_PUSHED[@]}]="false"
+            MANIFEST_LEG_PUSHED[${#MANIFEST_LEG_PUSHED[@]}]=""
+            MANIFEST_LEG_PUSHED_SEEN[${#MANIFEST_LEG_PUSHED_SEEN[@]}]=""
             continue
         fi
 
@@ -788,7 +805,10 @@ workspace_load_project() {
                 parked_commit) MANIFEST_LEG_COMMIT[leg_index]="$_SHAPE_SCALAR" ;;
                 wip) MANIFEST_LEG_WIP[leg_index]="$_SHAPE_SCALAR" ;;
                 wip_depth) MANIFEST_LEG_DEPTH[leg_index]="$_SHAPE_SCALAR" ;;
-                pushed) MANIFEST_LEG_PUSHED[leg_index]="$_SHAPE_SCALAR" ;;
+                pushed)
+                    MANIFEST_LEG_PUSHED[leg_index]="$_SHAPE_SCALAR"
+                    MANIFEST_LEG_PUSHED_SEEN[leg_index]=pushed
+                    ;;
             esac
         fi
     done < "$file"

--- a/devBenches/devcontainer.test/test-speckit-git-feature.sh
+++ b/devBenches/devcontainer.test/test-speckit-git-feature.sh
@@ -2909,6 +2909,147 @@ Fast-forward it, then re-run:
         'the replayed resume un-committed the parked WIP'
 }
 
+# Hand-edit one leg's `pushed:` in a workspace manifest: `park` writes the
+# literal `true` or `false` it computed and `workspace_write_manifest` drops a
+# key whose value is empty, so every other state of that field reaches a
+# record through an editor or a bad merge, and this is how a fixture reaches
+# one. `absent` removes the key; an empty value leaves it bare.
+set_manifest_pushed() {
+    local manifest="$1"
+    local role="$2"
+    local value="$3"
+
+    python3 - "$manifest" "$role" "$value" <<'PY'
+import sys
+
+path, role, value = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path, "r", encoding="utf-8") as stream:
+    lines = stream.read().splitlines()
+out = []
+in_leg = False
+edited = 0
+for line in lines:
+    if line.startswith("          - role:"):
+        in_leg = line.split(":", 1)[1].strip() == role
+    if in_leg and line.startswith("            pushed:"):
+        edited += 1
+        if value == "absent":
+            continue
+        line = "            pushed:" + (" " + value if value else "")
+    out.append(line)
+if edited != 1:
+    raise SystemExit(
+        "expected exactly one pushed: line for the %s leg, found %d" % (role, edited)
+    )
+with open(path, "w", encoding="utf-8") as stream:
+    stream.write("\n".join(out) + "\n")
+PY
+}
+
+# RR6 over the record `park --no-push` actually writes. Its wording is the one
+# state of `pushed:` that this extension does write, so it is asserted byte
+# for byte and must not move: nothing here is pushed anywhere, which is
+# exactly what the refusal is about.
+test_resume_refuses_a_no_push_record_in_the_unchanged_words() {
+    local stderr_file="$FIXTURE_ROOT/resume-no-push.stderr"
+    local root clone manifest parked_spec
+
+    # Given: a feature parked with --no-push, so its commit is on this
+    # workstation and nowhere else.
+    initialize_three_leg_parked_fixture 'resume-no-push' "$PARKED_CONFIG" || return 1
+    initialize_workspace_fixture 'resume-no-push-ws' || return 1
+    root="$PARKED_ROOT"
+    create_parked_feature "$root" 'Add routing core' "$stderr_file" || return 1
+    printf 'draft\n' > "$root/worktrees/001-routing-core/spec/specs/001-routing-core/spec.md" || return 1
+    invoke_park "$root" "$stderr_file" --no-push
+    if [ "$PARK_STATUS" -ne 0 ]; then
+        printf 'the --no-push park failed (%s): %s\n' "$PARK_STATUS" "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    manifest="$WORKSPACE_DIR/workspaces/dummy/fixture-project.yaml"
+    assert_equal '2' "$(manifest_line_count "$manifest" '^            pushed: false$')" \
+        '--no-push recorded pushed: false for both legs' || return 1
+    parked_spec="$(git -C "$root/worktrees/001-routing-core/spec" rev-parse HEAD)"
+
+    # When: another checkout resumes it.
+    clone="$PARKED_BASE/second"
+    clone_three_leg_root "$root" "$clone" || return 1
+    invoke_resume "$clone" "$stderr_file"
+
+    # Then: RR6, byte-for-byte, and nothing was recreated.
+    assert_equal '2' "$RESUME_STATUS" 'no-push resume exit code' || return 1
+    assert_contains_block "$stderr_file" \
+"Error: 001-routing-core (spec leg) was parked with --no-push; that feature was NOT recreated.
+Its parked commit $parked_spec exists only on the workstation that parked it (Fixture).
+Push it there, re-run \`make park\`, then resume here." 'RR6 --no-push wording' || return 1
+    if ! printf '%s\n' "$RESUME_OUTPUT" | grep -Fq 'REFUSED: 001-routing-core — parked with --no-push'; then
+        printf 'assertion failed: the --no-push summary line\n%s\n' "$RESUME_OUTPUT" >&2
+        return 1
+    fi
+    assert_file_absent "$clone/worktrees/001-routing-core" 'the --no-push feature directory'
+}
+
+# A `pushed:` that is neither true nor false is refused exactly as strictly —
+# nothing is recreated on a guess — but the refusal says what the record says.
+# Reading it as --no-push made a claim nobody made, and told the person the
+# parked commit is on one workstation and nowhere else, which the record does
+# not say either. A follow-up to a reviewer's note on opensoft/openRepoTools
+# #19 and #20 (2026-09-11); nobody has ruled on it.
+test_resume_names_an_unreadable_pushed_rather_than_claiming_no_push() {
+    local stderr_file="$FIXTURE_ROOT/resume-pushed-unreadable.stderr"
+    local clone manifest
+
+    # Given: a parked feature whose spec leg's `pushed:` was hand-edited to a
+    # value park never writes.
+    park_then_clone 'resume-pushed-unreadable' "$stderr_file" || return 1
+    clone="$RESUME_ROOT"
+    manifest="$WORKSPACE_DIR/workspaces/dummy/fixture-project.yaml"
+    set_manifest_pushed "$manifest" spec 'maybe' || return 1
+
+    # When: resume runs there.
+    invoke_resume "$clone" "$stderr_file"
+
+    # Then: the refusal names the value, offers the only exit there is, and
+    # never says --no-push.
+    assert_equal '2' "$RESUME_STATUS" 'unreadable-pushed resume exit code' || return 1
+    assert_contains_block "$stderr_file" \
+"Error: 001-routing-core (spec leg): its record's \`pushed:\` says 'maybe', which is neither true nor false; that feature was NOT recreated.
+Whether its parked commit $RESUME_PARKED_SPEC ever left Fixture cannot be read from the record.
+Park it again from there, which writes the record afresh, then resume here." 'RR6 unreadable wording' || return 1
+    if grep -Fq -- '--no-push' "$stderr_file"; then
+        printf 'assertion failed: an unreadable pushed: drew a --no-push claim\n%s\n' \
+            "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    if ! printf '%s\n' "$RESUME_OUTPUT" \
+        | grep -Fq "REFUSED: 001-routing-core — its record's \`pushed:\` says 'maybe', which is neither true nor false"; then
+        printf 'assertion failed: the unreadable-pushed summary line\n%s\n' "$RESUME_OUTPUT" >&2
+        return 1
+    fi
+    if printf '%s\n' "$RESUME_OUTPUT" | grep -Fq -- '--no-push'; then
+        printf 'assertion failed: the summary claimed --no-push\n%s\n' "$RESUME_OUTPUT" >&2
+        return 1
+    fi
+    assert_file_absent "$clone/worktrees/001-routing-core" 'the unreadable-pushed feature directory' || return 1
+
+    # When: the key is bare instead — present, with nothing after the colon.
+    set_manifest_pushed "$manifest" spec '' || return 1
+    invoke_resume "$clone" "$stderr_file"
+
+    # Then: the same refusal, worded for a key that carries no value.
+    assert_equal '2' "$RESUME_STATUS" 'valueless-pushed resume exit code' || return 1
+    assert_contains_block "$stderr_file" \
+"Error: 001-routing-core (spec leg): its record's \`pushed:\` has no value, which is neither true nor false; that feature was NOT recreated.
+Whether its parked commit $RESUME_PARKED_SPEC ever left Fixture cannot be read from the record.
+Park it again from there, which writes the record afresh, then resume here." 'RR6 valueless wording' || return 1
+    if grep -Fq -- '--no-push' "$stderr_file"; then
+        printf 'assertion failed: a bare pushed: drew a --no-push claim\n%s\n' \
+            "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    assert_file_absent "$clone/worktrees/001-routing-core" 'the valueless-pushed feature directory'
+}
+
 test_manifest_round_trip() {
     local stderr_file="$FIXTURE_ROOT/manifest-round-trip.stderr"
     local root manifest first_bytes second_bytes commits_before
@@ -3587,6 +3728,8 @@ run_scenario 'resume is idempotent when the worktrees already exist' test_resume
 run_scenario 'resume refuses a foreign directory at the worktree path' test_resume_refuses_a_foreign_directory
 run_scenario 'resume refuses a local branch that diverged from the parked commit' test_resume_refuses_a_local_branch_that_is_not_the_parked_commit
 run_scenario 'resume refuses a local branch behind the parked commit and names the fast-forward' test_resume_refuses_a_local_branch_behind_the_parked_commit
+run_scenario 'resume refuses a --no-push record in the unchanged wording' test_resume_refuses_a_no_push_record_in_the_unchanged_words
+run_scenario 'resume names a pushed: that is neither true nor false and never claims --no-push' test_resume_names_an_unreadable_pushed_rather_than_claiming_no_push
 run_scenario 'the workspace manifest round-trips byte-identically' test_manifest_round_trip
 run_scenario 'a missing workspace config refuses both verbs' test_missing_workspace_config_refuses
 run_scenario 'two workstations share one workspace repository' test_two_workstations_share_the_workspace_repository

--- a/devBenches/devcontainer.test/test-speckit-git-feature.sh
+++ b/devBenches/devcontainer.test/test-speckit-git-feature.sh
@@ -3086,7 +3086,7 @@ Park it again from there, which writes the record afresh, then resume here." 'RR
         return 1
     fi
     if ! printf '%s\n' "$RESUME_OUTPUT" \
-        | grep -Fq 'REFUSED: 001-routing-core — the record has no `pushed:` for this leg'; then
+        | grep -Fq 'REFUSED: 001-routing-core — the record has no `pushed:` for the spec leg'; then
         printf 'assertion failed: the absent-pushed summary line\n%s\n' "$RESUME_OUTPUT" >&2
         return 1
     fi
@@ -3100,8 +3100,14 @@ Park it again from there, which writes the record afresh, then resume here." 'RR
     invoke_park "$root" "$stderr_file"
 
     # Then: the entry survives with its parked commit, and the hole stays a
-    # hole — the refused park invents no `pushed: false`.
+    # hole — the refused park invents no `pushed: false`. First that the
+    # refused park WROTE the manifest at all, or every assertion below would
+    # hold of a park that wrote nothing (the independent review, 2026-09-11).
     assert_equal '2' "$PARK_STATUS" 'refused-park exit code' || return 1
+    if ! printf '%s\n' "$PARK_OUTPUT" | grep -Fq 'COMMITTED: workspaces/'; then
+        printf 'assertion failed: the refused park wrote no manifest\n%s\n' "$PARK_OUTPUT" >&2
+        return 1
+    fi
     if ! grep -Fq '      - branch: 001-routing-core' "$manifest"; then
         printf 'assertion failed: the refused feature was erased\n%s\n' "$(<"$manifest")" >&2
         return 1

--- a/devBenches/devcontainer.test/test-speckit-git-feature.sh
+++ b/devBenches/devcontainer.test/test-speckit-git-feature.sh
@@ -3050,6 +3050,76 @@ Park it again from there, which writes the record afresh, then resume here." 'RR
     assert_file_absent "$clone/worktrees/001-routing-core" 'the valueless-pushed feature directory'
 }
 
+# NO `pushed:` AT ALL is a different thing for a record to say than a value
+# that cannot be read: it says nothing about that leg. Both ends of it are
+# here, because both ends used to speak for it — `resume` refused the leg in
+# the `--no-push` words, and a park that REFUSED the feature wrote
+# `pushed: false` back into the file, a --no-push claim nobody made. A
+# follow-up to a reviewer's note on opensoft/openRepoTools #19 and #20
+# (2026-09-11); nobody has ruled on it.
+test_a_record_without_pushed_is_neither_read_nor_written_as_no_push() {
+    local stderr_file="$FIXTURE_ROOT/pushed-absent.stderr"
+    local root clone manifest
+
+    # Given: a parked feature whose spec leg has no `pushed:` key.
+    park_then_clone 'pushed-absent' "$stderr_file" || return 1
+    root="$PARKED_ROOT"
+    clone="$RESUME_ROOT"
+    manifest="$WORKSPACE_DIR/workspaces/dummy/fixture-project.yaml"
+    set_manifest_pushed "$manifest" spec 'absent' || return 1
+    git -C "$WORKSPACE_DIR" add workspaces || return 1
+    git -C "$WORKSPACE_DIR" commit -qm 'drop the spec leg pushed: key' || return 1
+    git -C "$WORKSPACE_DIR" push -q origin main || return 1
+
+    # When: the other checkout resumes it.
+    invoke_resume "$clone" "$stderr_file"
+
+    # Then: the refusal says the record says nothing, and never --no-push.
+    assert_equal '2' "$RESUME_STATUS" 'absent-pushed resume exit code' || return 1
+    assert_contains_block "$stderr_file" \
+"Error: 001-routing-core (spec leg): the record has no \`pushed:\` for this leg; that feature was NOT recreated.
+Whether its parked commit $RESUME_PARKED_SPEC ever left Fixture cannot be read from the record.
+Park it again from there, which writes the record afresh, then resume here." 'RR6 absent-key wording' || return 1
+    if grep -Fq -- '--no-push' "$stderr_file"; then
+        printf 'assertion failed: a missing pushed: drew a --no-push claim\n%s\n' \
+            "$(<"$stderr_file")" >&2
+        return 1
+    fi
+    if ! printf '%s\n' "$RESUME_OUTPUT" \
+        | grep -Fq 'REFUSED: 001-routing-core — the record has no `pushed:` for this leg'; then
+        printf 'assertion failed: the absent-pushed summary line\n%s\n' "$RESUME_OUTPUT" >&2
+        return 1
+    fi
+    assert_file_absent "$clone/worktrees/001-routing-core" 'the absent-pushed feature directory' || return 1
+
+    # Given: back where it was parked, that leg's worktree is gone, so the
+    # next park REFUSES the feature and carries its recorded entry forward.
+    git -C "$root/spec" worktree remove --force "$root/worktrees/001-routing-core/spec" || return 1
+
+    # When: park runs there.
+    invoke_park "$root" "$stderr_file"
+
+    # Then: the entry survives with its parked commit, and the hole stays a
+    # hole — the refused park invents no `pushed: false`.
+    assert_equal '2' "$PARK_STATUS" 'refused-park exit code' || return 1
+    if ! grep -Fq '      - branch: 001-routing-core' "$manifest"; then
+        printf 'assertion failed: the refused feature was erased\n%s\n' "$(<"$manifest")" >&2
+        return 1
+    fi
+    if ! grep -Fq "            parked_commit: $RESUME_PARKED_SPEC" "$manifest"; then
+        printf 'assertion failed: the refused feature lost its parked commit\n%s\n' \
+            "$(<"$manifest")" >&2
+        return 1
+    fi
+    assert_equal '1' "$(manifest_line_count "$manifest" '^            pushed: ')" \
+        'only the code leg carries a pushed: key after the refused park' || return 1
+    if grep -Fq '            pushed: false' "$manifest"; then
+        printf 'assertion failed: a refused park wrote a --no-push claim nobody made\n%s\n' \
+            "$(<"$manifest")" >&2
+        return 1
+    fi
+}
+
 test_manifest_round_trip() {
     local stderr_file="$FIXTURE_ROOT/manifest-round-trip.stderr"
     local root manifest first_bytes second_bytes commits_before
@@ -3730,6 +3800,7 @@ run_scenario 'resume refuses a local branch that diverged from the parked commit
 run_scenario 'resume refuses a local branch behind the parked commit and names the fast-forward' test_resume_refuses_a_local_branch_behind_the_parked_commit
 run_scenario 'resume refuses a --no-push record in the unchanged wording' test_resume_refuses_a_no_push_record_in_the_unchanged_words
 run_scenario 'resume names a pushed: that is neither true nor false and never claims --no-push' test_resume_names_an_unreadable_pushed_rather_than_claiming_no_push
+run_scenario 'a record with no pushed: key is neither read nor written as --no-push' test_a_record_without_pushed_is_neither_read_nor_written_as_no_push
 run_scenario 'the workspace manifest round-trips byte-identically' test_manifest_round_trip
 run_scenario 'a missing workspace config refuses both verbs' test_missing_workspace_config_refuses
 run_scenario 'two workstations share one workspace repository' test_two_workstations_share_the_workspace_repository


### PR DESCRIPTION
A follow-up to a reviewer's note recorded on opensoft/openRepoTools #19 and #20 (2026-09-11), taken on the note alone — nobody has ruled on it, and it is yours to decide. `resume.sh`'s RR6 refused every leg whose `pushed:` was not `true` in the words "was parked with --no-push", so a record whose `pushed:` said `maybe`, had no value, or was missing altogether drew a `--no-push` claim nobody made — and, because `workspace_load_project` seeded a missing key as `false` and `park.sh`'s `emit_recorded_feature` carries a REFUSED feature's loaded entry forward, a park that refused such a feature then WROTE `pushed: false` into the record, persisting the claim. Three commits, each droppable on its own:

1. RR6 says what the record says. The refusal is exactly as strict (`!= true` still refuses every non-`true` value, nothing is recreated), but `false` alone is the `--no-push` park — its three stderr lines, the REFUSED summary and the `--json` reason are byte-identical to today's — while a value that is neither true nor false is named for what it is: "its record's `pushed:` says 'maybe', which is neither true nor false", "… has no value, …", "the record has no `pushed:` for this leg", each followed by "Whether its parked commit … ever left <workstation> cannot be read from the record." and "Park it again from there, which writes the record afresh, then resume here." — the same story openRepoTools' `status` now tells for the same record. Two rows in `commands/speckit.git.resume.md`.
2. The loader stops inventing `false`. `workspace_load_project` gains `MANIFEST_LEG_PUSHED_SEEN[]` (set where a `pushed:` key was read) and seeds an absent key as the empty string, so absent and bare stay apart; `MANIFEST_LEG_PUSHED` has exactly two readers (`resume.sh`'s RR6 and `park.sh`'s `emit_recorded_feature`), both tolerant of the empty string, and `workspace_write_manifest` already drops an empty value — so a refused park now carries the hole forward instead of writing `pushed: false`, while `park`'s own success path still writes the literal `true`/`false` it computes for every leg it parks. Every record any past `park` wrote carries `pushed:` for every leg, so nothing already on disk reads differently. There is no PowerShell twin of park/resume/the loader to move in step.
3. From the independent review of this branch: the branch-level REFUSED line and the `--json` reason for an absent key name the leg ("for the spec leg") rather than "this leg", which had no antecedent there; and the absent-key test asserts the refused park really rewrote the manifest before asserting what it did not write.

Proved: `devBenches/devcontainer.test/test-speckit-git-feature.sh` 59 PASS / 0 FAIL (56 on main; the two biting scenarios fail against main's scripts with exactly the old `--no-push` text, and the write-back half fails on the manifest — `pushed: false` invented); `test-speckit-git-compat.sh` 22 / 0; both suites under the workflow's pinned bash 3.2.57 and git 2.34.1 images, 81 / 0 each; `update-upstream.py check` 6 vendored copies match (nothing vendored is touched); shellcheck findings identical to main's on all three scripts; no bash-4 construct. The independent review (168 runs of resume.sh across eight `pushed:` spellings, main against this branch; a six-leg two-project manifest through the loader proving the parallel arrays stay in step; the write-back proved on a multi-leg fixture both ways) returned "merge as is".

Follow-up this creates, in openRepoTools and then a re-vendor here: `status`'s absent-`pushed:` clause says "`resume` reads a missing one as not pushed and refuses it" — after commit 2 the reason is stale (the outcome, refused and re-park, is unchanged) — and three comments there describe the old loader; that change lands in openRepoTools first, then the vendored `status` moves here with a pin bump. The vendored copy is deliberately untouched in this PR.

Pre-existing, unrelated: `devcontainer.test/test-openspeckit-bootstrap.sh` has two failing lines on main today (OPSX template hash), byte-identical before and after this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make resume report only what the manifest establishes about whether parked work was pushed, while preserving strict refusal for uncertain records.

New Features:
- Distinguish explicit `pushed: false`, invalid values, bare values, and missing keys when reporting resume refusals.

Bug Fixes:
- Prevent resume from falsely claiming a feature was parked with `--no-push` when the manifest does not make that claim.
- Preserve missing `pushed:` fields when a refused park rewrites the workspace manifest instead of inventing `pushed: false`.

Enhancements:
- Keep manifest loading aware of whether each leg explicitly contained a `pushed:` key while retaining strict refusal of every value other than `true`.
- Align resume refusal messages and summaries with the information actually recorded in the manifest.

Documentation:
- Document the separate handling of invalid and missing `pushed:` metadata in the resume command guidance.

Tests:
- Add coverage for explicit no-push records, invalid and valueless `pushed:` entries, and missing keys including refused-park write-back behavior.