### PR TITLE
devBenches/base-image: re-vendor openRepoShape at 57ddeac — seventeen commits landed upstream, no vendored byte changes

### DIFF
--- a/devBenches/base-image/upstream-pin.yaml
+++ b/devBenches/base-image/upstream-pin.yaml
@@ -43,7 +43,7 @@ sources:
     source_repository: opensoft/openRepoShape
     materialization: copied
     revision_kind: commit
-    commit: "cd57c4bbd84ee323616f952b35cbb5fe8ac88196"
+    commit: "57ddeacc9f1d8b0e0223602574b7e41df1e0e65a"
     vendor_dir: files/openreposhape
     files:
       - path: openRepoShape


### PR DESCRIPTION
Lane: openreposhape-2 (openRepoShape-2)
Claim: https://github.com/opensoft/workBenches/issues/61#issuecomment-5647088913

Closes #61.

## What was wrong

The `openreposhape` source pin in `devBenches/base-image/upstream-pin.yaml` named `cd57c4bbd84e`, and opensoft/openRepoShape's `main` has moved seventeen commits past it. A pin that is not what `main` carries cannot tell a reader which openRepoShape the vendored bytes were taken from.

## What landed

One line, written by the tool that owns that file — `python3 devBenches/base-image/update-upstream.py apply --source openreposhape --at 57ddeacc9f1d8b0e0223602574b7e41df1e0e65a --yes`, rehearsed first without `--yes` (it prints the plan and refuses):

```diff
-    commit: "cd57c4bbd84ee323616f952b35cbb5fe8ac88196"
+    commit: "57ddeacc9f1d8b0e0223602574b7e41df1e0e65a"
```

`apply` re-took both vendored files and reported each `unchanged`; the `openrepotools` source is untouched. Nothing is hand-edited and no `sha256` is recomputed to fit.

**No vendored byte moved.** This repository vendors exactly two openRepoShape paths — `openRepoShape` (the shim) and `templates/assembly-root/project.yaml` — and neither is among the 36 paths the span touches. The shim's sha256 `6efcd6142eed678d7ebd9017bcbde84318708f3407b61d38b54c2ae16a748219` is the same at `cd57c4b` and `57ddeac`, and is also the sha256 of the copy installed at `~/.local/bin/openRepoShape` on Eagle. **So no Eagle reinstall and no image rebuild is owed by this change.**

Seventeen commits land in this span: openRepoShape#112 gave `update-shape.py apply --branch` and `family.py bump` a repeatable `--trailer "<Key>: <value>"`, #124 gave `main` a push trigger for the ubuntu job, and the remaining fifteen are the SonarCloud cognitive-complexity sweep across the tooling and the tests, every split proven behaviour-preserving.

This is the last leg of today's estate re-pin on Brett Heap's word "re-pin the estate". The InkRouter estate took the same commit first: InkRouter/IRRS#24 → `04fd4e4faf07`, InkRouter/IRSS#24 → `05a3e0808066`, InkRouter/InkRouter#43 → `283d74febfbc` (holder shape) and #45 → `ec91b1e19b6c` (member pins).

## How it was proven

- `gh api repos/opensoft/openRepoShape/compare/main...57ddeacc9f1d8b0e0223602574b7e41df1e0e65a -q .status` → `identical`.
- `gh api repos/opensoft/openRepoShape/compare/cd57c4bbd84ee323616f952b35cbb5fe8ac88196...57ddeacc9f1d8b0e0223602574b7e41df1e0e65a` → `ahead_by 17, behind_by 0`; neither vendored path appears in its `.files[].filename`.
- `git diff --stat` on the branch → `devBenches/base-image/upstream-pin.yaml | 2 +-`, exactly one file, one line.
- `python3 devBenches/base-image/update-upstream.py check` → exit 0, **6 rows across 2 sources, all `ok`**, now reading `openreposhape (opensoft/openRepoShape) @ 57ddeacc9f1d`.
- `devcontainer.test/test-setup-estate-commands.sh` → **83/83 GREEN**, exit 0 (the installer that reads this pin).
- `devBenches/devcontainer.test/test-speckit-git-feature.sh` → **59/59 GREEN**, exit 0.
- `sha256sum` of the vendored shim, of `~/.local/bin/openRepoShape` on Eagle and of `git show 57ddeac:openRepoShape` — all three `6efcd6142eed…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Update the vendored openRepoShape source pin to the current upstream commit while preserving the existing vendored content.