### PR TITLE
ensure-sonarqube-mcp.sh registers the SonarQube MCP proxy's host and container addresses with workbenches-mcp-sync, so host Claude/Codex profiles resolve it over loopback instead of the Docker-only hostname

### DIFF
--- a/.github/workflows/devbenches-helper-safety.yml
+++ b/.github/workflows/devbenches-helper-safety.yml
@@ -1,0 +1,40 @@
+name: DevBenches Helper Safety
+
+on:
+  push:
+    paths:
+      - .github/workflows/devbenches-helper-safety.yml
+      - devBenches/scripts/ensure-sonarqube-mcp.sh
+      - devBenches/scripts/test-helper-safety.sh
+      - devBenches/scripts/reconcile-devcontainer-container.sh
+      - scripts/workbenches-mcp-sync
+      - base-image/files/workbenches-mcp-sync
+  pull_request:
+    paths:
+      - .github/workflows/devbenches-helper-safety.yml
+      - devBenches/scripts/ensure-sonarqube-mcp.sh
+      - devBenches/scripts/test-helper-safety.sh
+      - devBenches/scripts/reconcile-devcontainer-container.sh
+      - scripts/workbenches-mcp-sync
+      - base-image/files/workbenches-mcp-sync
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  regression:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Verify runtime prerequisites
+        run: |
+          jq --version
+          flock --version | sed -n '1p'
+          stat --version | sed -n '1p'
+
+      - name: Run devBenches helper safety suite
+        run: bash ./devBenches/scripts/test-helper-safety.sh

--- a/devBenches/scripts/ensure-sonarqube-mcp.sh
+++ b/devBenches/scripts/ensure-sonarqube-mcp.sh
@@ -20,6 +20,17 @@ LEGACY_CONTAINER_NAME="devbench-sonarqube-mcp"
 LEGACY_PROXY_CONTAINER_NAME="devbench-sonarqube-mcp-proxy"
 SECRET_FILE="${SONARQUBE_ENV_FILE:-$HOME/.config/sonarqube/sonar.env}"
 
+# Host-side Claude/Codex profiles and bench (container) configs must resolve
+# SonarQube MCP through different addresses: the host cannot resolve the
+# Docker service name without an /etc/hosts entry nobody writes (WSL
+# regenerates /etc/hosts on boot), while a bench container cannot reach the
+# host's 127.0.0.1 loopback. workbenches-mcp-sync's shared MCP registry
+# already supports both (`url` for host, `containerUrl` for a bench), but
+# nothing previously taught it the SonarQube proxy's two addresses.
+REPO_ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SHARED_MCP_HELPER="$REPO_ROOT_DIR/scripts/workbenches-mcp-sync"
+SHARED_MCP_FAMILY="${SONARQUBE_MCP_SHARED_FAMILY:-opensoft}"
+
 case "${1:-}" in
   --stop)
     docker rm -f "$PROXY_CONTAINER_NAME" "$CONTAINER_NAME" "$LEGACY_PROXY_CONTAINER_NAME" "$LEGACY_CONTAINER_NAME" >/dev/null 2>&1 || true
@@ -124,9 +135,20 @@ ensure_compose_services() {
     up -d
 }
 
+register_shared_mcp_route() {
+  [[ -x "$SHARED_MCP_HELPER" ]] || return 0
+  "$SHARED_MCP_HELPER" put-http \
+    "$SHARED_MCP_FAMILY" \
+    sonarqube \
+    "http://${HOST_BIND}:${PROXY_PORT}/mcp" \
+    "http://${PROXY_CONTAINER_NAME}:${PROXY_PORT}/mcp" \
+    || log "Warning: shared SonarQube MCP registry setup failed."
+}
+
 ensure_network
 ensure_storage_volume
 remove_legacy_containers
 ensure_compose_services
+register_shared_mcp_route
 
 log "Reusable SonarQube MCP is available at http://${HOST_BIND}:${PROXY_PORT}/mcp"

--- a/devBenches/scripts/test-helper-safety.sh
+++ b/devBenches/scripts/test-helper-safety.sh
@@ -84,6 +84,18 @@ grep -Fx 'compose org_set=x org=opensoft url=https://sonarcloud.io' "$DOCKER_LOG
 run_sonar_case SONARQUBE_URL=https://sonar.example.test
 grep -Fx 'compose org_set= org= url=https://sonar.example.test' "$DOCKER_LOG" >/dev/null
 
+# ensure-sonarqube-mcp.sh must also teach workbenches-mcp-sync's shared MCP
+# registry the SonarQube proxy's two addresses, so host-side Claude/Codex
+# profiles resolve it over loopback while bench containers keep the Docker
+# service name (see devBenches/scripts/ensure-sonarqube-mcp.sh).
+shared_mcp_registry="$TMP_ROOT/home/projects/.workbenches/mcp/opensoft/registry.json"
+jq -e '.servers.sonarqube.definition.url == "http://127.0.0.1:64130/mcp"' "$shared_mcp_registry" >/dev/null
+jq -e '.servers.sonarqube.definition.containerUrl == "http://sonarqube-mcp-proxy:64130/mcp"' \
+  "$shared_mcp_registry" >/dev/null
+rendered_claude_config="$(env -i HOME="$TMP_ROOT/home" PATH="$BIN_DIR:/usr/bin:/bin" \
+  "$REPO_ROOT/scripts/workbenches-mcp-sync" claude-config opensoft)"
+jq -e '.mcpServers.sonarqube.url == "http://127.0.0.1:64130/mcp"' "$rendered_claude_config" >/dev/null
+
 : > "$DOCKER_LOG"
 if PATH="$BIN_DIR:$PATH" DOCKER_LOG="$DOCKER_LOG" \
   MOCK_CURRENT_PROJECT=other-project MOCK_CURRENT_SERVICE=other-service \


### PR DESCRIPTION
Lane: openreposhape-2 (openRepoShape-2)
Claim: https://github.com/opensoft/workBenches/issues/64#issuecomment-5647496379

Closes #64.

## What was wrong

`devBenches/scripts/ensure-sonarqube-mcp.sh` is the only script that starts the `sonarqube-mcp` + `sonarqube-mcp-proxy` containers (the devcontainer `initializeCommand` at `devBenches/.devcontainer/devcontainer.json:6`, also invoked directly by `devBenches/scripts/test-helper-safety.sh:72`). It only ran `docker compose up -d` and logged the host URL to stderr — it never registered either of the proxy's two addresses with `workbenches-mcp-sync`, the shared registry that `render_claude_config()` (`scripts/workbenches-mcp-sync:125-182`) reads to decide between a host `url` and a container `containerUrl` (`context_name()`, `:62-70`, keyed on `/.dockerenv`). The only `put-http` call anywhere in this repository registers `vibe-annotations` (`devBenches/setup.sh:167-174`); `sonarqube` was never registered from source at all.

The live registry did carry a correct `sonarqube` entry (`url: http://127.0.0.1:64130/mcp`, `containerUrl: http://sonarqube-mcp-proxy:64130/mcp`), but only from an undocumented, one-off manual command — not reproducible, and not something a profile picks up unless it happens to be freshly relaunched through `claude-profile` after that value existed. Every opensoft profile's `.claude.json` that was last synced before then (or simply never resynced, e.g. a long-running tmux session) is left with `mcpServers.sonarqube.url` set to the Docker Compose service name, which only resolves inside a devbench container. Every Claude Code session on the host (Eagle, WSL2 Ubuntu-24.04) then fails to connect the `sonarqube` MCP server with `getaddrinfo ENOTFOUND sonarqube-mcp-proxy` — reproduced live by this very session before the fix, and confirmed to affect 6 of the 322 opensoft profile files on Eagle (`team-02j`, `team-03h`, `team-05b`, `team-05d`, `team-05f`, `team-05h`).

`specs/001-pybench-sonarqube-mcp/*` and `openspec/changes/fix-pybench-sonarqube-mcp/design.md` are unrelated: that already-completed change gives the **Codex** `py-bench` **container** a private route via `CODEX_SONARQUBE_MCP_URL` and dual Docker networking, entirely separate from the `workbenches-mcp-sync` registry, and explicitly requires the shared host profile to stay untouched (FR-007). It does not register anything for Claude, and does not touch this registry.

## What landed

- `devBenches/scripts/ensure-sonarqube-mcp.sh`: a new `register_shared_mcp_route()` calls `workbenches-mcp-sync put-http "$SHARED_MCP_FAMILY" sonarqube "http://${HOST_BIND}:${PROXY_PORT}/mcp" "http://${PROXY_CONTAINER_NAME}:${PROXY_PORT}/mcp"` right after the compose services come up, mirroring the existing `vibe-annotations` registration in `devBenches/setup.sh:167-174`. `SHARED_MCP_FAMILY` defaults to `opensoft` (overridable via `SONARQUBE_MCP_SHARED_FAMILY`, following this script's existing env-var-default idiom). The call is guarded (`[[ -x "$SHARED_MCP_HELPER" ]] || return 0`) and non-fatal (`|| log "Warning: ..."`), so a missing or unreadable `workbenches-mcp-sync` cannot break bench startup — same posture as the vibe-annotations precedent.
- `devBenches/scripts/test-helper-safety.sh`: a new assertion block after the existing `run_sonar_case` scenarios checks that the shared registry received both addresses (`.servers.sonarqube.definition.url` / `.containerUrl`) and that a host-context `workbenches-mcp-sync claude-config opensoft` render resolves the loopback URL.
- No compose or container changes: `sonarqube-mcp.compose.yml` already published the proxy to `127.0.0.1:64130` (line 34); the containers were not restarted or recreated.
- Live, out-of-band patch on Eagle (not part of this diff, recorded here per the task): a one-off, JSON-aware (`json.load`/`json.dump`, `indent=2`, `ensure_ascii=False`, key order preserved) rewrite of `mcpServers.sonarqube.url` from `http://sonarqube-mcp-proxy:64130/mcp` to `http://127.0.0.1:64130/mcp` in the 6 affected `~/.claude-profiles/profiles/opensoft/**/.claude.json` files, each preceded by a backup at `<profile dir>/backups/.claude.json.backup.<epoch ms>` (the existing naming convention there) and followed by a post-write diff check confirming no other key changed. A full re-scan of all 322 opensoft profile files afterward found 0 remaining stale entries and 65 correct (up from 59).

No digest-pinned or dual-copy file was touched: `ensure-sonarqube-mcp.sh` and `test-helper-safety.sh` each exist in exactly one place in this repository (unlike `workbenches-mcp-sync` and `claude-profile`, which are intentionally byte-identical between `scripts/` and `base-image/files/` and were not modified here).

## How it was proven

- `bash -n` on both changed files: clean.
- `devBenches/scripts/test-helper-safety.sh` run directly: **passed** (`helper safety tests passed`), including the new assertions.
- Test-first check: with only `test-helper-safety.sh`'s new assertions in place and `ensure-sonarqube-mcp.sh` reverted (`git stash` of that one file), the same test run **failed** (`jq: error: ... registry.json: No such file or directory`) — proving the new assertions actually exercise the fix. Restored and re-ran green afterward.
- Live verification on Eagle: `curl -s -o /dev/null -w '%{http_code}' -X POST http://127.0.0.1:64130/mcp ...` with a JSON-RPC `initialize` body → **HTTP 200**, with a full valid MCP `initialize` response body (`serverInfo.name == "sonarqube-mcp-server"`, version `1.17.0.2569`).
- `workbenches-mcp-sync claude-config opensoft` (read-only), run directly on Eagle in this same host shell: renders `sonarqube.url == "http://127.0.0.1:64130/mcp"`, confirming the sync mechanism itself was already correct once the registry holds this entry.
- The 322-file re-scan before/after the live patch (see above): 6 → 0 stale, 59 → 65 correct, 0 JSON errors, 0 symlinks skipped, 0 unexpected diffs beyond the one intended key.

**Claude sessions already running do not need to be restarted for this PR** — this PR only changes how `ensure-sonarqube-mcp.sh` behaves on its next run (next devcontainer initialize or `test-helper-safety.sh` invocation); it does not touch any live profile. The **live `.claude.json` patch already applied on Eagle** (described above) is what fixes currently-affected profiles, and per MCP servers connecting at session start, **any session that was already connected before that patch — including this one — needs to be restarted (or `/resume`d fresh) to pick up the corrected URL and reconnect the `sonarqube` MCP server.** Sessions started after the patch are unaffected and already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Register dual-context SonarQube MCP routes and validate that host profiles resolve the proxy over loopback.

New Features:
- Register the SonarQube MCP proxy's host and container endpoints in the shared workbenches MCP registry for host and container profile resolution.

Bug Fixes:
- Ensure host-side Claude and Codex configurations use the loopback SonarQube MCP URL instead of the Docker-only service hostname.

CI:
- Add a GitHub Actions workflow that runs the DevBenches helper safety regression suite when relevant scripts or MCP synchronization files change.

Tests:
- Extend helper safety tests to verify both registered SonarQube routes and the rendered host Claude configuration.