### PR TITLE
devBenches/base-image: re-vendor openRepoTools at 0eb29b3 — `status` reads a parked record the way `resume` refuses it: no `parked_commit:`, no role, and whole-feature verdicts (#21, #22)

### DIFF
--- a/devBenches/base-image/files/openrepotools/status
+++ b/devBenches/base-image/files/openrepotools/status
@@ -145,14 +145,20 @@ pin that has fallen behind is named with the exit, `update-shape.py check
 workspace repository; `workspaces/<org>/<id>.yaml` in it) is read against the
 worktrees on disk: a recorded feature with no worktree here (`resume <Name>`
 brings it back — unless the record says `--no-push`, or its `pushed:` is
-missing or neither true nor false, which `resume` refuses the same way: then
-only the workstation that parked it can park it again; and where `git worktree
+missing or neither true nor false, which `resume` refuses the same way, or it
+names no parked commit for that leg, which `resume` refuses as moved-on, or it
+gives a leg no role at all, or a role this checkout's shape does not mount, or
+lists no leg for it at all, which `resume` refuses the whole feature for: then
+only the workstation that parked it can park it again — and where the role is
+really another shape's, only a checkout of that shape; and where `git worktree
 list` still holds a registration that is no longer a worktree, that is cleared
 with `worktree prune`, after a `worktree unlock` if it is locked and with any
 leftover directory moved aside, before `resume` can recreate anything), a
-worktree whose tip is not the parked commit, a leg parked with `--no-push` or
-whose `pushed:` is missing or neither true nor false, and a worktree the
-record does not know (never parked).
+worktree whose tip is not the parked commit or a record that names no parked
+commit to compare it with, a leg parked with `--no-push` or whose `pushed:` is
+missing or neither true nor false, a leg the record gives no role or a role
+this shape does not mount, a feature the record lists no leg for, and a
+worktree the record does not know (never parked).
 
 <Name> is the estate's folder under your projects directory: a FAMILY folder
 (<Name>/<Name>/family.yaml) or a standalone project root (<Name>/project.yaml).
@@ -1529,8 +1535,9 @@ read_shape() {
 #
 # 1. A RECORDED FEATURE WITH NO WORKTREE HERE on its branch: parked, and not
 #    resumed on this machine. `resume <Name>` is the exit; nothing here adds
-#    a worktree. Unless the record is a `--no-push` one (3): then there is
-#    nothing here to resume FROM, and the exit is the workstation that has it.
+#    a worktree. Unless the record is a `--no-push` one (3), or names no
+#    parked commit for that leg (2): then there is nothing here to resume
+#    FROM, and the exit is the workstation that has it.
 #    And where the porcelain still holds a REGISTRATION for that branch that
 #    is no longer a worktree — its directory gone, or git's own `prunable`
 #    with the directory left behind — what clears it is named first: a prune,
@@ -1546,6 +1553,16 @@ read_shape() {
 #    feature's tip is legitimately `<parked>~<wip_depth>` with the work back
 #    in the working tree — `resume.sh`'s `wip_gap_is_ours` is what keeps it
 #    from refusing that, and the same test is made here.
+#    AND A RECORD THAT NAMES NO PARKED COMMIT FOR THE LEG is a state of this
+#    field, not a leg to pass over (the independent review of #20,
+#    2026-09-11, note 7; this repository's #21, recorded there as out of scope). There is nothing
+#    for a tip to be compared WITH, so none of those arms can run; and with
+#    no worktree here `resume` does not bring it back either — its RR1
+#    refuses a leg whose parked commit is not origin's tip, and an absent
+#    one never is — so the line that named `resume <Name>` there named an
+#    exit that cannot work rather than merely staying quiet. Both halves say
+#    what the record does not say, and the exit is a park that parks the
+#    feature THROUGH: a park that refuses it carries the hole forward.
 # 3. A LEG PARKED WITH `--no-push`: the record says `pushed: false`, only the
 #    workstation that parked it has the WIP commit, and `resume` refuses it —
 #    so no line under this state names `resume` as the exit, and none blames
@@ -1579,6 +1596,57 @@ read_shape() {
 #    say, what `resume` makes of that, and the one exit that works.
 # 4. A WORKTREE ON DISK THAT THE RECORD DOES NOT KNOW: a feature that was
 #    never parked, which is the one thing `park` exists to carry.
+# 5. A LEG THE RECORD GIVES NO ROLE: a state of the RECORD rather than of the
+#    disk, and read here because `resume` refuses the WHOLE FEATURE for it —
+#    `collect_legs` maps each leg's role onto this checkout and its `*)
+#    return 1` takes every other leg of that feature with it (the independent
+#    review of #20, 2026-09-11, note 8; this repository's #21, recorded there as out of scope). It is
+#    the ROOT's finding, since no leg repository can be found for a leg that
+#    names no role, and the exit is a park that parks the feature through.
+# 6. A LEG WHOSE ROLE THIS CHECKOUT'S SHAPE DOES NOT HAVE — a misspelling, or
+#    another shape's role — which `resume` refuses the WHOLE FEATURE for in
+#    the same breath and the same "shape mismatch" words as 5 (the
+#    independent review of #21, 2026-09-11). The line for it named neither
+#    the refusal nor an exit; it does both now, and it is worded for a role
+#    that is genuinely another shape's as well as for a typo, because this
+#    layer cannot tell those apart and a park cannot make this root mount
+#    what its shape has not got.
+# 7. A FEATURE THE RECORD LISTS NO LEG FOR — an empty `legs:`, the `legs: []`
+#    `workspace_write_manifest` writes for a feature it has no legs for, or
+#    leg items with no `- role:` line — which `collect_legs` refuses whole at
+#    its closing `[ "${#LEG_ROLES[@]}" -gt 0 ]`, in the same "shape mismatch"
+#    words again (note 1 of the independent review of #21, 2026-09-11; this repository's #22, and
+#    the note-8 commit's own "recorded for later"). The first of these states
+#    that is not a LEG's: there is no leg to hang a reading on, so it is read
+#    per FEATURE, in `read_record`, where the comment above that function
+#    says how and why the features are judged before their legs are read.
+#
+# 5, 6 AND 7 ARE REFUSALS OF THE WHOLE FEATURE, SO NO LINE OF THAT FEATURE
+# NAMES `resume` (Copilot on #21, second round, 2026-09-11). A leg of such a
+# feature that is otherwise perfectly resumable — parked, pushed, no worktree
+# here — used to draw "`resume <Name>` brings it back" two lines under the
+# one that says `resume` refuses the whole feature, and a person reads the
+# REPORT, not one line of it: the two together name an exit that cannot work,
+# which is the rule at the top of `check_parked_leg`. `read_record`'s first
+# pass makes the verdict for every feature before any of its legs is read and
+# hands it down, so those lines say what `collect_legs` will do and end at
+# the one exit there is. Everything else a sibling can say — dirty, moved on,
+# behind, a commit that is not here — is unchanged: it was never `resume`
+# that answered those.
+#
+# WHAT THE OTHER END'S LOADER DOES WITH AN ABSENT `pushed:` IS CHANGING, AND
+# NO LINE HERE DEPENDS ON IT (the independent review of workBenches #60,
+# 2026-09-11). Paragraph 3's account of the fourth state is workBenches
+# before #60 (ec2b450): `workspace_load_project` seeds every leg's pushed
+# with `false`, so `resume` reads a missing key as `false` and RR6 refuses
+# the leg in the `--no-push` words. workBenches #60, merged as 98b8bd1 and
+# that repository's main since, stops that invention — the seed is the
+# empty string, a new `MANIFEST_LEG_PUSHED_SEEN[]` keeps absent apart from
+# bare, and RR6 refuses the leg in words of its own, "the record has no
+# `pushed:` for this leg" (both run on 2026-09-11, exit 2 each). THE OUTCOME
+# IS THE SAME UNDER BOTH — the leg is not recreated, and only a park that
+# parks the feature through writes a record that reads — so that is what the
+# findings say, and none of them says how the loader reached it.
 #
 # THE RECORD IS FOUND WHERE `park` FILES IT AND `resume` LOOKS FOR IT:
 # `${AGENT_PROTOCOL_ROOT:-~/.agents}/workspace.yaml` names the workspace
@@ -1766,9 +1834,13 @@ locate_record() {
 # position for every record `park` writes, because that key is always last
 # and always there — until it is NOT there, and then the leg had no row and
 # VANISHED from this layer: no finding, exit 0, silence about a record
-# `resume.sh` refuses, because `workspace-common.sh` defaults a leg's pushed
-# to `false` at the `- role:` line when no `pushed:` follows (the review cited
-# its line 777) and RR6 is `[ "$pushed" != true ]`. The comment that stood here called the dropped leg harmless —
+# `resume.sh` refuses: RR6 is `[ "$pushed" != true ]`, and no loader of that
+# record makes an absent key `true` — on workBenches before #60 (ec2b450)
+# `workspace-common.sh` defaults the leg's pushed to `false` at the `- role:`
+# line when no `pushed:` follows (the review cited its line 777), and under
+# workBenches #60 the seed is the empty string with the key's absence carried
+# in a field of its own, so the leg is refused either way. The comment that
+# stood here called the dropped leg harmless —
 # its branch is still known from the `branch` row, so it is never accused of
 # being unparked — which is true and beside the point: not being accused is
 # not the same as being read, and this layer exists to read the record the
@@ -1791,8 +1863,45 @@ locate_record() {
 # be spelled by the hand-edit that produced the record and read back as the
 # sentinel. The sixth field is written by THIS function and never from the
 # file: the word `pushed` where the key was seen, empty where it was not.
+#
+# AND A LEG IS OPEN FROM ITS `- role:` LINE, WHATEVER THAT LINE SAYS (the
+# independent review of #20, 2026-09-11, note 8, recorded there as out of
+# scope). `[ -n "$role" ]` was doing two jobs at both emit sites — "a leg is
+# open" and "the leg has a role" — and the second DROPPED the row for a leg
+# whose `- role:` value is EMPTY, while `workspace_load_project` creates that
+# leg exactly as it creates any other: its indent-10 arm takes the `- ` item,
+# reads `role` as the key, and assigns whatever `_SHAPE_SCALAR` holds, empty
+# or not. A leg the loader has and this reader has not is a leg `resume`
+# refuses the WHOLE FEATURE for while this layer says nothing — the shape of
+# hole the two notes before it closed. `$open` does the first job now, set at
+# the `- role:` line and cleared where the leg ends, so the role's value is
+# left to mean only what it says and the row goes out with an EMPTY role
+# field for `check_parked_leg` to read; the row's SIX FIELDS are unchanged,
+# because an empty field between two 0x1F separators shifts nothing.
+# A LEG WITH NO `- role:` LINE AT ALL is a different thing, and the two
+# readers agree about that one already: the loader's `[ "$key" = "role" ] ||
+# continue` starts no leg for it, and with no `- role:` line there is nothing
+# to open one here either, so neither reader has a leg to read.
+# EVERY VALUE THIS PARSER READS LOSES A `#` COMMENT FIRST, because
+# `workspace_load_project` takes `#` and everything after it off EVERY line
+# (`content="${raw%%#*}"`) before it splits key from value: `- role: repo # the
+# leg` is `repo` there, and `- role: # note` is a leg with no role there. Read
+# whole here, the first was a role this root does not mount and the second was
+# not empty at all, so both went to `leg_repo_for_role` and drew "the record
+# names a leg this root does not mount here" — the mounting arm's true words
+# about a record `resume` refuses for a different reason entirely (Copilot on
+# #21, after #19 had closed the same gap for `pushed:` alone). The parity is
+# per LINE, as the loader's is: a value that itself contains a `#` is cut
+# there too, exactly as `resume.sh` will cut it — this layer reads the record
+# the way `resume.sh` will judge it, and not the way YAML would.
+record_scalar() {
+    local value="$1"
+    case "$value" in *'#'*) value="${value%%#*}" ;; esac
+    trim_unquote "$value"
+}
+
 record_rows() {
-    local file="$1" sel="$2" line matched=0 value
+    local file="$1" sel="$2" line matched=0 value open=0 named=0 held=""
     local parked_at="" parked_on="" lane="" active="" branch="" role="" commit="" pushed="" depth="" seen=""
     [ -f "$file" ] || return 0
     while IFS= read -r line || [ -n "$line" ]; do
@@ -1818,58 +1927,101 @@ record_rows() {
             case "$line" in
             [![:space:]]* | '  '[![:space:]]* | '    '[![:space:]]* | \
                 '      '[![:space:]]* | '        '[![:space:]]* | '          - role:'*)
-                if [ "$matched" -eq 1 ] && [ -n "$branch" ] && [ -n "$role" ]; then
-                    printf 'leg\037%s\037%s\037%s\037%s\037%s\037%s\n' "$branch" "$role" "$commit" "$pushed" "$depth" "$seen"
+                if [ "$named" -eq 1 ] && [ "$open" -eq 1 ]; then
+                    held="$held$(printf 'leg\037%s\037%s\037%s\037%s\037%s\037%s' "$branch" "$role" "$commit" "$pushed" "$depth" "$seen")$NL"
                 fi
-                role=""
+                role=""; open=0
                 ;;
             esac
             ;;
         esac
+        # A ROW BELONGS TO ITS BLOCK, AND A BLOCK IS NOT KNOWN TO BE THE
+        # SELECTED ONE UNTIL THE KEY THAT SELECTS IT IS READ (Copilot's second
+        # round on #22). An `id=` selector is answered by the block's FIRST
+        # line, so every row after it knew where it stood; a `root=` selector
+        # — the one a family member is matched by, and the one a record found
+        # under the folder name falls back to — is answered at the `root:`
+        # key, which `workspace_write_manifest` writes above `features:` and a
+        # hand-edit or a bad merge can leave below it. Every row emitted
+        # before that line was then thrown away for a block that DID match:
+        # the `project` row, each feature's `branch` row, and every leg that
+        # ended above it. For the layout `park` writes — `features:` last —
+        # that is the whole block, so this function returned nothing and the
+        # layer said "no block for this root" about a record it had just
+        # matched; for a `root:` left INSIDE the feature it was the mangling
+        # Copilot named, a blank `- branch:` row suppressed while the leg row
+        # under it went out, reaching `read_record` with no branch row before
+        # it, taking no feature's verdict and drawing "`resume <Name>` brings
+        # it back" for a feature `resume` refuses at RR2 under a blank name.
+        # `workspace_load_project` has no such order: it matches at the
+        # `- id:` line and reads a block's keys by their INDENT, wherever they
+        # sit in it.
+        #
+        # SO THE ROWS ARE HELD AND FLUSHED, NOT EMITTED AND HOPED FOR. Every
+        # arm below appends to `$held`, the buffer goes out whole as soon as
+        # the block is known to match — in the record's own order, which is
+        # the order it was appended in — and a block that never matches is
+        # dropped at the next `- id:`, which is the only line that starts
+        # another. THE EMITTED BYTES ARE UNCHANGED for every record `park`
+        # writes: `matched` is 1 at the `root:` line above `features:`, so
+        # each row is flushed on the line after the one that appended it, in
+        # the same order and with the same fields.
+        if [ "$matched" -eq 1 ]; then
+            [ -z "$held" ] || { printf '%s' "$held"; held=""; }
+        else
+            case "$line" in '  - id:'*) held="" ;; esac
+        fi
         case "$line" in
         '  - id:'*)
             matched=0
-            parked_at=""; parked_on=""; lane=""; active=""; branch=""; role=""
-            value="$(trim_unquote "${line#*:}")"
+            parked_at=""; parked_on=""; lane=""; active=""; branch=""; role=""; open=0; named=0
+            value="$(record_scalar "${line#*:}")"
             case "$sel" in
             id=*) [ "$(lower "$value")" != "$(lower "${sel#id=}")" ] || matched=1 ;;
             esac
             ;;
         '    root:'*)
-            value="$(trim_unquote "${line#*:}")"
+            value="$(record_scalar "${line#*:}")"
             case "$sel" in
             root=*) [ "$(lower "$value")" != "$(lower "${sel#root=}")" ] || matched=1 ;;
             esac
             ;;
-        '    parked_at:'*) parked_at="$(trim_unquote "${line#*:}")" ;;
-        '    parked_on:'*) parked_on="$(trim_unquote "${line#*:}")" ;;
-        '    parked_by_lane:'*) lane="$(trim_unquote "${line#*:}")" ;;
-        '    active_feature:'*) active="$(trim_unquote "${line#*:}")" ;;
+        '    parked_at:'*) parked_at="$(record_scalar "${line#*:}")" ;;
+        '    parked_on:'*) parked_on="$(record_scalar "${line#*:}")" ;;
+        '    parked_by_lane:'*) lane="$(record_scalar "${line#*:}")" ;;
+        '    active_feature:'*) active="$(record_scalar "${line#*:}")" ;;
         '    features:'*)
-            if [ "$matched" -eq 1 ]; then
-                printf 'project\037%s\037%s\037%s\037%s\n' "$parked_at" "$parked_on" "$lane" "$active"
-            fi
+            held="$held$(printf 'project\037%s\037%s\037%s\037%s' "$parked_at" "$parked_on" "$lane" "$active")$NL"
             ;;
         '      - branch:'*)
-            branch="$(trim_unquote "${line#*:}")"
-            if [ "$matched" -eq 1 ] && [ -n "$branch" ]; then
-                printf 'branch\037%s\n' "$branch"
-            fi
+            # A `- branch:` WITH NO VALUE IS STILL A FEATURE TO THE LOADER:
+            # `workspace_load_project` appends `MANIFEST_FEATURE_BRANCHES`
+            # at every `- branch:` line, empty or not, and `resume.sh` then
+            # reads a feature named nothing — refusing it at RR2 in RR2's
+            # words with the name blank ("Error:  is no longer on origin in
+            # the repo leg", exit 2, run against the extension 2026-09-12)
+            # where it has legs, and as a shape mismatch where it has none.
+            # Read whole this row was dropped and its legs with it, and the
+            # feature vanished from this layer (Copilot on #22). The row goes
+            # out with the empty name, and `$named` — not the name — is what
+            # lets a leg row out: a leg before any `- branch:` line at all
+            # still has no feature to belong to and is still dropped. A
+            # `- branch:` READ BEFORE THE BLOCK WAS KNOWN TO MATCH — a `root:`
+            # selector answered below it — goes out with the rest of the held
+            # rows and in the record's order, which is the flush above.
+            branch="$(record_scalar "${line#*:}")"
+            named=1
+            held="$held$(printf 'branch\037%s' "$branch")$NL"
             ;;
-        '          - role:'*) role="$(trim_unquote "${line#*:}")"; commit=""; pushed=""; depth=""; seen="" ;;
-        '            parked_commit:'*) commit="$(trim_unquote "${line#*:}")" ;;
-        '            wip_depth:'*) depth="$(trim_unquote "${line#*:}")" ;;
+        '          - role:'*) role="$(record_scalar "${line#*:}")"; open=1; commit=""; pushed=""; depth=""; seen="" ;;
+        '            parked_commit:'*) commit="$(record_scalar "${line#*:}")" ;;
+        '            wip_depth:'*) depth="$(record_scalar "${line#*:}")" ;;
         '            pushed:'*)
-            # `workspace_load_project` strips a `#` comment from EVERY line
-            # (`content="${raw%%#*}"`) before it reads a value, so this field
-            # — the one this layer JUDGES rather than matches or prints —
-            # loses one here too: read whole, `pushed: true # note` was
-            # "neither true nor false" here and `true` there, and the finding
-            # named a refusal `resume` will not make (the independent review
-            # of this follow-up, 2026-09-11).
-            value="${line#*:}"
-            case "$value" in *'#'*) value="${value%%#*}" ;; esac
-            pushed="$(trim_unquote "$value")"
+            # The first value to lose its `#` comment here, in #19 — read
+            # whole, `pushed: true # note` was "neither true nor false" here
+            # and `true` to `resume.sh`; `record_scalar` above now does it for
+            # every value this parser reads, for the same reason.
+            pushed="$(record_scalar "${line#*:}")"
             seen=pushed
             ;;
         esac
@@ -1877,17 +2029,39 @@ record_rows() {
     # THE LAST LEG OF THE BLOCK, which no later line closes. Spelled out
     # rather than shared with the arm above, because the alternative is a
     # helper reading this function's locals by dynamic scope — five lines
-    # twice against an idiom this file uses nowhere else.
-    if [ "$matched" -eq 1 ] && [ -n "$branch" ] && [ -n "$role" ]; then
-        printf 'leg\037%s\037%s\037%s\037%s\037%s\037%s\n' "$branch" "$role" "$commit" "$pushed" "$depth" "$seen"
+    # twice against an idiom this file uses nowhere else. AND THE LAST FLUSH
+    # WITH IT: the end of the file is the last chance the block has to be the
+    # matched one, and a `root:` that sits at the very bottom of it is
+    # answered on the line after which there is none.
+    if [ "$named" -eq 1 ] && [ "$open" -eq 1 ]; then
+        held="$held$(printf 'leg\037%s\037%s\037%s\037%s\037%s\037%s' "$branch" "$role" "$commit" "$pushed" "$depth" "$seen")$NL"
     fi
+    [ "$matched" -eq 0 ] || printf '%s' "$held"
     return 0
 }
 
 # The repository a leg role lives in: the root for `repo` and `assembly`, else
-# the path `project.yaml` gives that role, else a folder named for the role.
+# the path `project.yaml` gives that role, else a folder named for the role,
+# else — for a `spec` or a `code` leg the manifest DECLARES — the role's own
+# name, because that is the path the other end computes for it.
+#
+# THE LOADER DEFAULTS THOSE TWO PATHS, AND ANSWERING NOTHING FOR THEM NAMED A
+# REFUSAL THAT IS NOT THE ONE MADE (the independent review of this branch,
+# 2026-09-12). `git-common.sh`'s `_shape_record_leg` is `spec)
+# _SHAPE_LEG_SPEC_PATH="${path:-spec}"` and `code) … "${path:-code}"`, so a
+# `- role: spec` with no `path:` mounts at `spec/` to `load_repo_shape`, and
+# `collect_legs` maps the role onto that path without ever looking at the
+# directory. Answering NOTHING for such a leg sent a genuinely three-leg root
+# whose `spec/` is not checked out to the whole-feature refusal below — while
+# what `resume` does there is refuse the whole ESTATE before it reads a
+# feature at all: "Error: the spec leg 'spec' is not an initialised Git
+# checkout at '…/spec'. / Run 'git submodule update --init' (or 'make
+# bootstrap') in the project root first.", exit 1 — neither the refusal that
+# line claims nor the exits it offers. Answering the default path returns that
+# state to the short line under it — the leg is not mounted here — which is
+# what this layer can prove.
 leg_repo_for_role() {
-    local root="$1" want="$2" line role="" path=""
+    local root="$1" want="$2" line role="" path="" declared=0
     case "$want" in
     repo | assembly) printf '%s\n' "$root"; return 0 ;;
     esac
@@ -1895,14 +2069,49 @@ leg_repo_for_role() {
         while IFS= read -r line || [ -n "$line" ]; do
             line="${line%$'\r'}"
             case "$line" in
-            '  - role:'*) role="$(trim_unquote "${line#*:}")"; path="" ;;
+            # `load_repo_shape` takes `#` and everything after it off EVERY
+            # line of `project.yaml` before it reads a key (`git-common.sh`,
+            # `content="${raw%%#*}"`), so `- role: spec # the spec leg` is
+            # `spec` there and its `path: spec # here` is `spec`. Read whole
+            # here, the role never matched and the leg fell to the arm that
+            # calls it a role this root cannot mount and `resume` refuses —
+            # a refusal `resume` would not make (Copilot on #22). The same
+            # cut `record_rows` makes, for the same reason.
+            '  - role:'*)
+                role="$(record_scalar "${line#*:}")"; path=""
+                [ "$role" != "$want" ] || declared=1
+                ;;
             '    path:'*)
-                path="$(trim_unquote "${line#*:}")"
+                path="$(record_scalar "${line#*:}")"
                 if [ "$role" = "$want" ] && [ -n "$path" ] && [ "$path" != "." ]; then
                     printf '%s\n' "$root/$path"
                     return 0
                 fi
                 ;;
+            # AND A FULL-LINE `#` COMMENT AT COLUMN 0 IS NO KEY EITHER, which
+            # the arm below read as one (Copilot's second round on #22). The
+            # round before taught these values to lose a `#` the way
+            # `load_repo_shape` loses one; the LINE was still read whole, so a
+            # `# note` a hand left at column 0 inside the legs list matched
+            # `[![:space:]]*` and closed the item — and a `path:` under it
+            # went to no role, leaving `spec` and `code` on
+            # `_shape_record_leg`'s default, the role's own name, and every
+            # other role with nothing. `load_repo_shape` takes `#` and
+            # everything after it off every line before it reads one and
+            # SKIPS what is left when it is empty (`[ -n "$trimmed" ] ||
+            # continue`), so that line closes nothing there and the `path:`
+            # below it still belongs to the leg above: run against the
+            # extension on 2026-09-12, a `- role: code` whose `path: spec`
+            # sits under such a comment loaded as `_SHAPE_LEG_CODE_PATH=spec`
+            # and `CODE_LEG=<root>/spec`, where this reader answered
+            # `<root>/code` and the leg drew "the record names a leg this root
+            # does not mount here" for a leg `resume` mounts and resumes. The
+            # same cut `record_rows` was given for the same line in #20
+            # (a2c8521, "a full-line `#` comment at column 0 inside a leg is
+            # no leg-ender"), for the same reason. An INDENTED comment needed
+            # no arm at either end: it matches no key here and trims to
+            # nothing there.
+            '#'*) ;;
             [![:space:]]*) role="" ;;
             esac
         done <"$root/project.yaml"
@@ -1911,6 +2120,13 @@ leg_repo_for_role() {
         printf '%s\n' "$root/$want"
         return 0
     fi
+    # AND THE DEFAULT IS THE ROLE'S OWN NAME, for the two roles
+    # `_shape_record_leg` defaults a path for and no others: every other word
+    # is one `collect_legs` refuses at its `*) return 1` however this root is
+    # laid out, and inventing a path for it would hide that.
+    case "$want" in
+    spec | code) [ "$declared" -eq 0 ] || { printf '%s\n' "$root/$want"; return 0; } ;;
+    esac
     return 1
 }
 
@@ -2031,9 +2247,129 @@ wip_gap_is_ours() {
 # both leave `$pushed` empty.
 check_parked_leg() {
     local root="$1" branch="$2" role="$3" commit="$4" pushed="$5" parked_at="$6" parked_on="$7" depth="$8" seen="$9"
-    local repo tree="" ghost="" ghost_is="" clear="" out rc=0 tip n unread="" refuses=""
+    # `${10}` and not a tenth name in the line above, because that line is
+    # already the widest in this file; `:-` because `set -u` is on and the
+    # verdict is the one argument a caller may leave off.
+    local refused="${10:-}"
+    local repo tree="" ghost="" ghost_is="" clear="" out rc=0 tip n unread="" refuses="" where=""
+    # A LEG THE RECORD GIVES NO ROLE IS ANSWERED BEFORE THE ROOT IS ASKED
+    # ABOUT IT, and it is not the arm below (the independent review of #20,
+    # 2026-09-11, note 8, recorded there as out of scope). `record_rows` used
+    # to drop such a leg — `[ -n "$role" ]` at both emit sites — so this layer
+    # said NOTHING about it, and the other end refuses the whole feature for
+    # it: `resume.sh`'s `collect_legs` maps every leg's role onto this
+    # checkout, `spec`, `code` and `repo` being all it knows, and its `*)
+    # return 1` takes the FEATURE with it — every other leg of that feature
+    # included, verified the same day against a record whose good `repo` leg
+    # sat beside an empty-role one. The words it refuses in are about the
+    # SHAPE, which is not what is wrong: "Error: 001-a-thing was parked from a
+    # single project and this checkout is single; that feature was NOT
+    # recreated", a sentence that contradicts itself, and this line is what
+    # explains it in advance.
+    #
+    # IT IS ANSWERED FIRST BECAUSE `leg_repo_for_role` WOULD ANSWER IT WRONG:
+    # asked for the empty role it falls past the `repo | assembly` case and
+    # past every `project.yaml` role, to `[ -d "$root/$want" ]` — which for an
+    # empty `$want` is `[ -d "$root/" ]`, always true — and hands back the
+    # ROOT. The leg would then be read as if the record had named the `repo`
+    # leg, which is a claim about a leg the record does not name. And it is
+    # not the "does not mount here" arm either: those words say this root has
+    # no such leg, which is a true thing to say about `role: nope` and a
+    # misleading thing to say about a record that names no role at all — the
+    # fix is not to mount anything, and the refusal is of the whole feature.
+    #
+    # THE EXIT IS A PARK THAT PARKS IT, as it is for the states above, and for
+    # the same reason at the same end: `emit_recorded_feature` carries a
+    # REFUSED feature's legs forward out of the loaded manifest, and `role` is
+    # the ONE leg key `workspace_write_manifest` does not drop when its value
+    # is empty (`if value == "" and out_key != "role": continue`), so a park
+    # that refuses this feature writes the leg back as `- role: ""` — which
+    # both readers unquote to the empty string again. Only a park that parks
+    # the feature THROUGH writes the roles this checkout's own shape has.
+    if [ -z "$role" ]; then
+        where="the record does not say where"
+        [ -z "$parked_on" ] || where="the record says $parked_on"
+        finding "parked feature $branch: a leg of it in the record has no role; \`resume\` maps each leg's role onto this checkout and refuses the WHOLE feature — the other legs with it — where one does not map, reporting it as a shape mismatch, so nothing here brings it back — park that feature again from the workstation that has it ($where), which writes the roles this checkout's own shape has"
+        return 0
+    fi
+    # AND A ROLE THIS CHECKOUT'S SHAPE DOES NOT HAVE COSTS THE WHOLE FEATURE
+    # TOO, WHICH THE LINE BELOW LEFT OUT ALONG WITH THE EXIT (the independent
+    # review of #21, 2026-09-11, recorded there as nobody's ruling). "The
+    # record names a leg this root does not mount here" is true and stops
+    # there, and it reads as ONE leg going unread — while `resume.sh`'s
+    # `collect_legs` maps EVERY leg's role onto this checkout (`spec` and
+    # `code` only where `REPO_SHAPE` is three-leg, `repo` only where it is
+    # single, `*) return 1` for every other word) and one that does not map
+    # takes the feature with it, its good legs included. Run on 2026-09-11
+    # against a scratch single-shape estate, `role: nope` answered "Error:
+    # 001-a-thing was parked from a single project and this checkout is
+    # single; that feature was NOT recreated", "REFUSED: 001-a-thing — shape
+    # mismatch", exit 2 — the same sentence about the SHAPE that says nothing
+    # about the role, and the same answer with a good `repo` leg beside it.
+    # That is the refusal the empty-role arm above explains in advance, so
+    # this arm explains it in the same words and the same order.
+    #
+    # WHICH ROLES ARE CERTAINLY REFUSED, AND WHICH ARE ONLY UNMOUNTED. The
+    # arm below fired on two different states and now says the refusal for
+    # only one of them, because only one of them is one `collect_legs`
+    # certainly refuses. `leg_repo_for_role` answers the root for `repo` and
+    # `assembly`, else the path `project.yaml` gives the role, else a folder
+    # named for it, else the role's own name where the manifest declares a
+    # `spec` or a `code` leg and gives it no `path:` — the default
+    # `_shape_record_leg` gives it — else NOTHING, and nothing is the state
+    # that proves it: `git-common.sh`'s `load_repo_shape` calls a checkout
+    # `three-leg` only where `project.yaml` says `kind: project-manifest`
+    # AND `schema: project-repo-schema` AND declares BOTH a `spec` and a
+    # `code` LEG — the leg, not its `path:`, which `_shape_record_leg`
+    # defaults to the role's own name. So a role this root has no repository
+    # for is a role `collect_legs` cannot map: a `spec` or a `code` this
+    # manifest declares no leg for, which is a manifest that cannot be
+    # three-leg, or any other word at its `*) return 1` — whether it is a
+    # misspelling (`nope`) or another shape's role (`code` here, `spec` in
+    # the family fixture's members, which declare an `assembly` leg and no
+    # other). Both were verified on 2026-09-11 against a scratch
+    # single-shape estate: "shape mismatch", exit 2, the whole feature.
+    #
+    # THE OTHER STATE IS A LEG THIS ROOT MOUNTS THAT IS NOT A CHECKOUT — a
+    # submodule that was never fetched, which is a directory with no `.git`
+    # in it, the state `git-common.sh`'s own `shape_leg_is_checkout` guards,
+    # and, since `leg_repo_for_role` learned the loader's default, a `spec`
+    # or a `code` this manifest declares whose path is not on disk at all.
+    # `collect_legs` maps that role by NAME onto paths `load_repo_shape`
+    # computed from `project.yaml`, and never looks at the directory, so in a
+    # genuinely three-leg root it maps `spec` and moves on and the feature is
+    # NOT refused for the shape. Claiming the refusal there would be this
+    # layer inventing a `resume.sh` line, so those words keep the sentence
+    # they had: what is true of that state is that the leg is not mounted
+    # here, and it is `make bootstrap`'s to mount.
+    #
+    # THE EXIT IS WORDED FOR BOTH KINDS OF UNMAPPABLE ROLE: a park from the
+    # workstation that has the feature writes the roles ITS shape has, which
+    # is what settles a misspelling; where the role really is another
+    # shape's, the record is right and this checkout is not where that
+    # feature comes back, so the line says so rather than promising that a
+    # re-park will make this root mount it.
+    #
+    # WHAT THIS ARM DOES NOT SEE, and what is therefore still unsaid: a role
+    # this root DOES mount that `collect_legs` refuses anyway — `assembly`,
+    # `repo` in a root `load_repo_shape` calls three-leg (one project checked
+    # out at two shapes, the commonest mismatch there is), `spec` in a root
+    # whose `project.yaml` declares no `code` leg, or any other word that
+    # matches a directory under the root — for which `leg_repo_for_role`
+    # hands back a repository, so the leg is read against disk and nothing
+    # here mentions the refusal (`role: assembly` in that same scratch
+    # estate: "shape mismatch", exit 2, the same day). Reading that one
+    # means computing this root's shape the way `load_repo_shape` does and
+    # holding the record's `shape:` against it, which is a reading of its
+    # own and is recorded in this commit's message, not taken here.
     repo="$(leg_repo_for_role "$root" "$role" || true)"
-    if [ -z "$repo" ] || [ ! -e "$repo/.git" ]; then
+    if [ -z "$repo" ]; then
+        where="the record does not say where"
+        [ -z "$parked_on" ] || where="the record says $parked_on"
+        finding "parked feature $branch ($role leg): the record names a leg this root does not mount here; \`resume\` maps each leg's role onto this checkout and refuses the WHOLE feature — the other legs with it — where one does not map, reporting it as a shape mismatch, so nothing here brings it back — park that feature again from the workstation that has it ($where), which writes the roles its own shape has; where that shape is not this checkout's, the feature comes back in a checkout of that shape, not here"
+        return 0
+    fi
+    if [ ! -e "$repo/.git" ]; then
         finding "parked feature $branch ($role leg): the record names a leg this root does not mount here"
         return 0
     fi
@@ -2108,13 +2444,16 @@ check_parked_leg() {
     # 2026-09-11). Not a fourth spelling of the third — `record_rows` keeps
     # the two apart in `$seen`, because the record is not saying something
     # that cannot be read, it is saying NOTHING — and what makes it a finding
-    # rather than a shrug is the other end. `workspace_load_project` seeds
-    # every leg's `MANIFEST_LEG_PUSHED` with `false` AT THE `- role:` LINE
-    # and overwrites it only where a `pushed:` key follows, so `resume.sh`
-    # reads a missing one as `false` and RR6 refuses the leg in the
-    # `--no-push` words: run against a record with no `pushed:` on
-    # 2026-09-11, the extension answered "Error: 001-a-thing (repo leg) was
-    # parked with --no-push; that feature was NOT recreated", exit 2. Until
+    # rather than a shrug is the other end. On workBenches before #60
+    # (ec2b450) `workspace_load_project` seeds every leg's
+    # `MANIFEST_LEG_PUSHED` with `false` AT THE `- role:` LINE and overwrites
+    # it only where a `pushed:` key follows, so `resume.sh` reads a missing
+    # one as `false` and RR6 refuses the leg in the `--no-push` words: run
+    # against a record with no `pushed:` on 2026-09-11, the extension
+    # answered "Error: 001-a-thing
+    # (repo leg) was parked with --no-push; that feature was NOT recreated",
+    # exit 2 — and the paragraph after next is what workBenches #60 changes
+    # about that, which is the words and not the refusal. Until
     # this change `status` was SILENT about that record — no row, no finding,
     # exit 0 — which is the worse half of note (d): a wrong line can be
     # argued with, a missing one cannot. So it is read exactly as the
@@ -2125,19 +2464,49 @@ check_parked_leg() {
     # AND THE EXIT IS A PARK THAT PARKS IT, which is why every arm says from
     # THERE. `park.sh`'s `emit_recorded_feature` carries a REFUSED feature's
     # entry forward out of the loaded manifest untouched — `pushed` included,
-    # which for an absent key is the loader's defaulted `false` — so a park
-    # that refuses this feature rewrites the record as `pushed: false`, a
-    # `--no-push` claim nobody made, and `resume` refuses it still. Only the
-    # workstation that has the worktree parks it through, and that path
+    # which for an absent key is whatever that loader seeded: on workBenches
+    # before #60 (ec2b450) the defaulted `false`, so a park that refuses this
+    # feature rewrites the record as `pushed: false`, a `--no-push` claim
+    # nobody made; under workBenches #60 the empty string, which
+    # `workspace_write_manifest` drops rather than writes, so the same park
+    # carries the hole forward as a hole. Neither is a record that says what
+    # happened, and `resume` refuses it after either. Only the workstation
+    # that has the worktree parks it through, and that path
     # writes `true` or `false` from the push it just made. It is also where
     # this state comes from WITHOUT a hand-edit: a bare `pushed:` loads as
     # the empty string, `emit_recorded_feature` carries the empty string
     # forward, and `workspace_write_manifest` drops any key whose value is
     # empty — so one park that refuses a note-(d) record degrades it into
     # this one (both halves verified against those functions the same day).
+    #
+    # AND WHICH LOADER IT IS DECIDES THE WORDS AND NOTHING ELSE, WHICH IS WHY
+    # THE CLAUSE BELOW NAMES NEITHER (the independent review of workBenches
+    # #60, 2026-09-11). That pull request stops `workspace_load_project`
+    # inventing `pushed: false` for a key the record does not carry: the seed
+    # becomes the empty string, and a new `MANIFEST_LEG_PUSHED_SEEN[]` keeps
+    # absent apart from bare exactly as `$seen` does here. So under it
+    # `resume` does not READ a missing one as not pushed — it reads it as
+    # nothing and says so: run against the same record on 2026-09-11 with
+    # #60's scripts, the extension answered "Error: 001-a-thing (repo leg):
+    # the record has no `pushed:` for this leg; that feature was NOT
+    # recreated. / Whether its parked commit <sha> ever left Falcon cannot be
+    # read from the record. / Park it again from there, which writes the
+    # record afresh", exit 2, and its REFUSED line read "the record has no
+    # `pushed:` for the repo leg" where main's read "parked with --no-push".
+    # The clause that stood here — "`resume` reads a missing one as not
+    # pushed and refuses it" — was main's MECHANISM copied into this
+    # command's output, and it would have gone stale the day #60 landed: a
+    # line about the other end that the other end had stopped agreeing with.
+    # WHAT IS TRUE UNDER BOTH is the refusal and the exit, and this layer
+    # only ever needed those: RR6 is `[ "$pushed" != true ]` in both, an
+    # absent key loads as `false` in one and as the empty string in the
+    # other and neither is `true`, so the leg is not recreated either way;
+    # and either way the record is written afresh only by a park that parks
+    # the feature THROUGH, as the paragraph above says. The clause says that
+    # much and stops.
     if [ -z "$seen" ]; then
         unread="the record has no \`pushed:\` for that leg"
-        refuses="\`resume\` reads a missing one as not pushed and refuses it"
+        refuses="\`resume\` refuses a leg whose record has no \`pushed:\`"
     else
         case "$pushed" in
         true | false) ;;
@@ -2178,7 +2547,104 @@ check_parked_leg() {
     if [ -n "$unread" ]; then
         finding "parked feature $branch ($role leg): $unread, so whether its parked commit ever left ${parked_on:-that workstation} cannot be read; $refuses, so park it again from there to write the record afresh"
     fi
+    # THE RECORD'S `parked_commit:` HAS TWO READINGS, PRESENT AND ABSENT, and
+    # the second was read as neither (the independent review of #20,
+    # 2026-09-11, note 7, recorded there as out of scope). `park.sh` records
+    # the commit it parked each leg at, and `workspace_write_manifest` drops
+    # any key whose value is empty — so a leg it could name none for is
+    # written with no `parked_commit:` line at all. ABSENT AND BARE ARE ONE
+    # STATE HERE, unlike `pushed:`, and the sixth field's argument does not
+    # apply: `workspace_load_project` leaves `MANIFEST_LEG_COMMIT` at the
+    # empty string either way and `trim_unquote` gives the empty string
+    # either way, so the two readers make one state of them and so does this.
+    #
+    # IT IS NOT A LEG LIKE ANY OTHER, BECAUSE `resume.sh` WILL NOT RECREATE
+    # IT. With no worktree here: RR6 passes (`pushed: true` is the only way
+    # through the arms above on that path — with a worktree here the RR6
+    # states fall through to the arm below and it is a second finding),
+    # RR4 finds no worktree to call already-done, RR3 nothing in the way, RR2
+    # the branch on origin, and RR1 — `[ "$remote_tip" != "$parked_commit" ]`
+    # — refuses it, because an absent parked commit never equals a tip: run
+    # against such a record on 2026-09-11 the extension answered "Error:
+    # 001-a-thing (repo leg) has moved since it was parked; that feature was
+    # NOT recreated. / parked commit     (parked 2026-09-10T20:00:00Z on
+    # Falcon) / current tip    050d1ee…   (origin/001-a-thing)", exit 2.
+    # Until this change the `[ -n "$commit" ] || return 0` that stood here
+    # sat AFTER the arm below, so the line a person got was "no worktree on
+    # that branch here; parked … — `resume Atlas` brings it back": the layer
+    # did not merely stay silent about a record `resume` refuses, it NAMED
+    # AN EXIT THAT CANNOT WORK, which is the one thing the rule at the top
+    # of this function forbids.
+    #
+    # AND WITH A WORKTREE HERE IT WAS SILENT, the same hole from its other
+    # side: that `return 0` skipped the three tip arms below, which are the
+    # only thing this layer says about a worktree that IS here. They cannot
+    # run — there is no parked commit to compare the tip with, and the empty
+    # string is not one: the FIRST of them, `cat-file -e "$commit^{commit}"`,
+    # fails on it, so what would fire is "its parked commit  is not here —
+    # the record says it was pushed, so this repository has never fetched it,
+    # or origin no longer has it" — a blank sha and a reason invented for a
+    # commit the record never named (the independent review of this branch,
+    # 2026-09-11, proved it by removing this arm). So the line says what
+    # cannot be compared instead of guessing at one of them, and it names no
+    # refusal: with the worktree at the path it computes, `resume.sh`'s RR4
+    # calls that leg already recreated and only warns — "HEAD is 7b4773d…,
+    # not the parked commit ; the parked WIP was NOT un-committed" (verified
+    # the same day) — so the exit is the moved-on arm's, park again, and the
+    # workstation to park from is the one the worktree is on, which is this.
+    #
+    # THE EXIT IS A PARK THAT PARKS IT, for the reason the paragraph above
+    # gives for an absent `pushed:`: `emit_recorded_feature` carries a
+    # REFUSED feature's entry forward out of the loaded manifest untouched —
+    # the empty commit with it — and `workspace_write_manifest` drops the
+    # empty key again, so a park that refuses this feature writes the hole
+    # back unchanged. Only a park that parks the feature THROUGH records a
+    # commit for it, which is why the no-worktree arm sends the person to the
+    # workstation that has the feature rather than saying "park again" here.
+    if [ -z "$commit" ]; then
+        if [ -z "$tree" ]; then
+            if [ -n "$ghost" ]; then
+                finding "parked feature $branch ($role leg): the record names no parked commit for that leg, and no worktree on that branch here, but $ghost_is — clear it with $clear; \`resume\` matches origin's tip against the parked commit before it recreates anything, an absent one never matches, and it refuses the leg as having moved on since it was parked, so nothing here brings it back — park it again from ${parked_on:-the workstation that has it}, which writes the record afresh"
+            else
+                finding "parked feature $branch ($role leg): the record names no parked commit for that leg, and no worktree on that branch here; \`resume\` matches origin's tip against the parked commit before it recreates anything, an absent one never matches, and it refuses the leg as having moved on since it was parked, so nothing here brings it back — park it again from ${parked_on:-the workstation that has it}, which writes the record afresh"
+            fi
+        else
+            finding "parked feature $branch ($role leg): the record names no parked commit for that leg, so there is nothing to read this worktree's tip against; whether it moved on, fell behind or diverged since it was parked cannot be told here — park again before leaving, which writes that leg's parked commit"
+        fi
+        return 0
+    fi
+    # NO LINE OF A FEATURE `resume` REFUSES WHOLE MAY NAME `resume` (Copilot
+    # on #21, second round, 2026-09-11). These two arms are the only ones in
+    # this function that offer it — the `--no-push`, unreadable-`pushed:` and
+    # absent-parked-commit arms all rule it out for themselves — and they
+    # offered it to a leg whose FEATURE `collect_legs` throws out: a record
+    # with a roleless leg beside a good `repo` leg drew "the record has no
+    # role … `resume` refuses the WHOLE feature" on one line and "`resume
+    # Atlas` brings it back" on the next, and the two together recommend a
+    # command that cannot recreate it. The leg that costs the feature says so
+    # on its own line, but a person reads the REPORT, not one line of it.
+    #
+    # THE VERDICT IS THE FEATURE'S, SO IT IS MADE WHERE THE FEATURES ARE:
+    # `read_record`'s first pass — the one that counts each feature's legs
+    # for state 7 — also asks of each leg the two questions `collect_legs`
+    # asks, has it a role and can this root answer that role, and hands the
+    # answer down as `$refused`, a clause naming the leg that costs the
+    # feature. Empty for every feature `resume` does not refuse whole, which
+    # is what keeps every other record's lines exactly as they were. It is
+    # not computed HERE because by the time this function has the leg in
+    # front of it the sibling that spoils the feature may not have been read
+    # yet: the record's order is the loader's, not the reader's convenience.
     if [ -z "$tree" ]; then
+        if [ -n "$refused" ]; then
+            where="the record does not say where"
+            [ -z "$parked_on" ] || where="the record says $parked_on"
+            if [ -n "$ghost" ]; then
+                finding "parked feature $branch ($role leg): no worktree on that branch here, but $ghost_is — clear it with $clear; and \`resume\` refuses the WHOLE feature in any case, because $refused, so it does not bring this leg back either — park that feature again from the workstation that has it ($where)"
+            else
+                finding "parked feature $branch ($role leg): no worktree on that branch here, parked ${parked_at:-?} on ${parked_on:-?}; \`resume\` refuses the WHOLE feature, because $refused, so it does not bring this leg back — park that feature again from the workstation that has it ($where)"
+            fi
+            return 0
+        fi
         if [ -n "$ghost" ]; then
             finding "parked feature $branch ($role leg): no worktree on that branch here, but $ghost_is — clear it with $clear, then \`resume $ESTATE_NAME\` brings it back"
         else
@@ -2186,7 +2652,6 @@ check_parked_leg() {
         fi
         return 0
     fi
-    [ -n "$commit" ] || return 0
     tip="$(g "$repo" rev-parse -q --verify "refs/heads/$branch" 2>/dev/null || true)"
     [ -n "$tip" ] || return 0
     [ "$tip" != "$commit" ] || return 0
@@ -2280,13 +2745,51 @@ unrecorded_worktrees() {
 }
 
 # A root's block of the record against its disk: the note line, one finding
-# per leg that is out of step, and the worktrees the record does not know.
-# The selectors are tried in order until one names a block: a standalone root
-# by its `id:` first, then by its folder as `root:` — the block a record found
-# by folder name carries — and a family member by its `root:` alone.
+# per leg that is out of step, one per FEATURE the record leaves with no legs
+# at all, and the worktrees the record does not know. The selectors are tried
+# in order until one names a block: a standalone root by its `id:` first, then
+# by its folder as `root:` — the block a record found by folder name carries —
+# and a family member by its `root:` alone.
+#
+# A FEATURE THE RECORD LISTS NO LEG FOR IS A READING THIS LAYER OWES, AND IT
+# IS PER FEATURE, NOT PER LEG (the independent review of #21, 2026-09-11,
+# note 1, and the note-8 commit's own "recorded for later"; nobody has ruled
+# on it). `collect_legs` ends `[ "${#LEG_ROLES[@]}" -gt 0 ]`, so a feature
+# whose `legs:` is empty — the key with nothing under it, `legs: []`, or leg
+# items with no `- role:` line, which start no leg in either reader — is
+# refused WHOLE, in the shape words again: run on 2026-09-11 against a
+# scratch single-shape estate, each of those three spellings answered "Error:
+# 001-a-thing was parked from a single project and this checkout is single;
+# that feature was NOT recreated", "REFUSED: 001-a-thing — shape mismatch",
+# exit 2. This layer said NOTHING about any of them — no finding, exit 0 —
+# because every reading it had was a LEG's, and there is no leg here to hang
+# one on. That is the hole the last three notes closed for legs, in its
+# per-feature shape.
+#
+# SO THE FEATURES ARE JUDGED BEFORE THE LEGS ARE READ. `record_rows` emits a
+# `branch` row per feature and a `leg` row per leg, in the record's order, so
+# a first pass counts each feature's legs and the main loop reads the count
+# back at that feature's `branch` row — before any of its legs' arms run,
+# which is where the second job needs it. THE SECOND JOB IS THE VERDICT
+# (Copilot on #21, second round, 2026-09-11): the same pass asks of each leg
+# the two questions `collect_legs` asks — has it a role, and can this root
+# answer that role — and keeps the first clause that costs the feature, so
+# `check_parked_leg` can be told that the feature its leg belongs to is one
+# `resume` throws out whole and stop offering `resume` for it. It cannot be
+# asked of a leg as the leg arrives: the leg that spoils the feature may come
+# after the one being read, and the record's order is the loader's, not the
+# reader's convenience. ONE ENTRY PER `branch` ROW, NOT
+# PER BRANCH NAME: `workspace_load_project` makes a new feature of every
+# `- branch:` line it reads, so a name that appears twice is two features to
+# the loader and `collect_legs` judges each on its own legs; `$recorded` and
+# the feature COUNT still fold the duplicates, because those answer "is this
+# branch in the record", which is one question however many entries there
+# are.
 read_record() {
     local root="$1" sel rows="" kind a b c d e f n_features=0
     local parked_at="" parked_on="" lane="" active="" recorded="$NL"
+    local seen_branches=0 legs where="" refused="" unnamed=0
+    local -a feature_legs=() feature_why=()
     shift
     [ -n "$RECORD_FILE" ] || return 0
     for sel in "$@"; do
@@ -2298,16 +2801,108 @@ read_record() {
         # which is the one thing worth saying about it.
         say "    parked record: no block for this root in ${RECORD_FILE##*/}"
     else
+        # THE FIRST PASS: how many legs each feature entry has, in order. A
+        # `leg` row belongs to the `branch` row before it — `record_rows`
+        # emits one only while a branch is open — so the count goes onto the
+        # last entry; the `-gt 0` guard is for a record so mangled that a leg
+        # row arrives with no branch row before it, which is a row this pass
+        # then ignores rather than an index it invents.
+        while IFS=$'\037' read -r kind a b c d e f; do
+            case "$kind" in
+            branch) feature_legs+=(0); feature_why+=("") ;;
+            leg)
+                legs=${#feature_legs[@]}
+                if [ "$legs" -gt 0 ]; then
+                    feature_legs[legs - 1]=$((feature_legs[legs - 1] + 1))
+                    # THE FIRST LEG THAT COSTS THE FEATURE IS THE ONE NAMED:
+                    # `collect_legs` walks the legs in the record's order and
+                    # returns at the first role it cannot map, so that is the
+                    # one `resume`'s refusal is about, and a second would only
+                    # lengthen a line about a feature that is already gone.
+                    if [ -z "${feature_why[legs - 1]}" ]; then
+                        if [ -z "$b" ]; then
+                            feature_why[legs - 1]="a leg of it in the record has no role"
+                        elif ! leg_repo_for_role "$root" "$b" >/dev/null 2>&1; then
+                            feature_why[legs - 1]="its \`$b\` leg names a role this root does not mount"
+                        fi
+                    fi
+                fi
+                ;;
+            esac
+        done <<<"$rows"
         while IFS=$'\037' read -r kind a b c d e f; do
             case "$kind" in
             project) parked_at="$a"; parked_on="$b"; lane="$c"; active="$d" ;;
             branch)
+                seen_branches=$((seen_branches + 1))
+                # A FEATURE THE RECORD GIVES NO BRANCH NAME (Copilot on #22)
+                # is one to the loader and is refused by `resume` whatever its
+                # legs say — with legs, at RR2 with the name blank, "Error:  is
+                # no longer on origin in the repo leg", because no branch is
+                # named nothing on origin; with none, as a shape mismatch
+                # before any leg is read (both run against the extension
+                # 2026-09-12). It is counted as the loader counts it, its
+                # name is not added to the recorded set (an empty name would
+                # match every sweep), and its legs are not read one by one:
+                # there is no branch to find a worktree for, and each would
+                # only print the refusal again with the name blank. One line,
+                # on the root's row, with RR2's own two exits.
+                if [ -z "$a" ]; then
+                    unnamed=1
+                    n_features=$((n_features + 1))
+                    where="the record does not say where"
+                    [ -z "$parked_on" ] || where="the record says $parked_on"
+                    if [ "${feature_legs[seen_branches - 1]:-0}" -eq 0 ]; then
+                        finding "parked feature with no branch name: a \`- branch:\` in the record has no value and lists no leg; \`resume\` reads it as a feature named nothing and refuses it whole as a shape mismatch before it reads a leg, so nothing here brings it back — if that feature landed, remove its \`- branch:\` block from ${RECORD_FILE##*/}; if it was parked, park it again from the workstation that has it ($where), which writes the branch it parks"
+                    else
+                        finding "parked feature with no branch name: a \`- branch:\` in the record has no value; \`resume\` reads it as a feature named nothing and refuses it as a branch origin has not got (\"is no longer on origin\", the name blank), so nothing here brings it back — if that feature landed, remove its \`- branch:\` block from ${RECORD_FILE##*/}; if it was parked, park it again from the workstation that has it ($where), which writes the branch it parks"
+                    fi
+                    continue
+                fi
+                unnamed=0
                 case "$recorded" in
                 *"$NL$a$NL"*) ;;
                 *) recorded="$recorded$a$NL"; n_features=$((n_features + 1)) ;;
                 esac
+                # NO LEGS, NO LEG TO SAY IT ON: the finding is the feature's,
+                # printed where the feature is, and the exit is the exit the
+                # roleless arm names — a park that parks the feature THROUGH.
+                # `workspace_write_manifest` writes `legs: []` for a feature
+                # it has no legs for, and `emit_recorded_feature` carries a
+                # REFUSED feature's legs forward out of the loaded manifest,
+                # which for this one is none: a park that refuses it writes
+                # the hole back as a hole (read off those two functions the
+                # same day).
+                if [ "${feature_legs[seen_branches - 1]:-0}" -eq 0 ]; then
+                    where="the record does not say where"
+                    [ -z "$parked_on" ] || where="the record says $parked_on"
+                    finding "parked feature $a: the record lists no leg for it; \`resume\` collects a feature's legs before it recreates anything and refuses the WHOLE feature where it finds none, reporting it as a shape mismatch, so nothing here brings it back — park that feature again from the workstation that has it ($where), which writes the record afresh with the legs it parks"
+                fi
                 ;;
-            leg) check_parked_leg "$root" "$a" "$b" "$c" "$d" "$parked_at" "$parked_on" "$e" "$f" ;;
+            leg)
+                # The legs of a feature with no branch name were answered on
+                # the feature's own line, above.
+                [ "$unnamed" -eq 0 ] || continue
+                # THE SAME GUARD THE FIRST PASS MAKES, for the same mangled
+                # record: a leg row before any branch row has no feature to
+                # take a verdict from, and `${feature_why[-1]}` is "bad array
+                # subscript" on bash 3.2 and the LAST feature's verdict on
+                # bash 5 — a clause about a feature this leg is no leg of
+                # (the independent review of this branch, 2026-09-12).
+                # THE RECORD THAT REACHED IT WAS THE ROW `record_rows` WAS
+                # DROPPING, and it drops it no longer: a leg row goes out only
+                # while a branch is open, `$named` is set by the very line
+                # that appends that branch's row, and the two are flushed in
+                # the record's order — so no record builds this shape now
+                # (Copilot's second round on #22). The guard stays as the belt
+                # to that brace, matching the first pass's, because an index
+                # this reader invents is a claim about a feature the record
+                # does not make.
+                refused=""
+                [ "$seen_branches" -eq 0 ] ||
+                    refused="${feature_why[seen_branches - 1]:-}"
+                check_parked_leg "$root" "$a" "$b" "$c" "$d" "$parked_at" "$parked_on" "$e" "$f" "$refused"
+                ;;
             esac
         done <<<"$rows"
         say "    parked record: $n_features feature(s), parked ${parked_at:-?} on ${parked_on:-?}${lane:+ (lane $lane)}${active:+; active $active}"

--- a/devBenches/base-image/upstream-pin.yaml
+++ b/devBenches/base-image/upstream-pin.yaml
@@ -57,7 +57,7 @@ sources:
     source_repository: opensoft/openRepoTools
     materialization: copied
     revision_kind: commit
-    commit: "a40cbb7403fcc730c4590e8bd284196d0a91f9f0"
+    commit: "0eb29b34daed39960c9ecf89c2600644a9fed784"
     vendor_dir: files/openrepotools
     files:
       - path: openRepoTools
@@ -70,5 +70,5 @@ sources:
         sha256: "db6fe6237648714936467be7236cd6450db23e9d5bd96c415a6ae1322becab07"
         mode: "100755"
       - path: status
-        sha256: "f9586b9d75b554a179ac5a4395bd64fbf4060bc22402590e0006c9ae8724a0d8"
+        sha256: "ffc8084389c7f4278d7f7925e32eea70981bb3a260f957e8868b454d9b1ce1a5"
         mode: "100755"


### PR DESCRIPTION
The `openrepotools` source pin moves from a40cbb7403fcc730c4590e8bd284196d0a91f9f0 (pinned in #59) to 0eb29b34daed39960c9ecf89c2600644a9fed784 — `gh api repos/opensoft/openRepoTools/compare/main...0eb29b34daed39960c9ecf89c2600644a9fed784` says `identical`, so it is the commit opensoft/openRepoTools's main carries after opensoft/openRepoTools#22.

Between the two commits, both squash-merged 2026-09-12: opensoft/openRepoTools#21 — `status`'s record layer reads a leg whose record names no `parked_commit:` as the RR1 refusal `resume.sh` makes ("has moved since it was parked") instead of offering `resume <Name>`, and a leg whose `- role:` value is empty as the whole-feature refusal `collect_legs` makes, naming the exit (park that feature again from the workstation that has it); `record_scalar` cuts a `#` comment before it unquotes, for every value `record_rows` reads. opensoft/openRepoTools#22 — the record is read PER FEATURE before any leg, the way `collect_legs` judges it: a feature `resume` refuses whole (a role this checkout's shape does not mount, no legs at all, a blank branch) never has a leg line offering `resume <Name>`; the absent-`pushed:` line names the refusal rather than one loader's reading; `record_rows` holds a block's rows until the key that selects the block is read, so a `root:` below the `features:` no longer loses the block or drops its legs; and a full-line `#` comment at column 0 inside a `project.yaml` leg no longer ends the leg.

Only `status` changes bytes: `update-upstream.py apply` reported `unchanged openRepoTools`, `unchanged park`, `unchanged resume`, `take status`. No consumer edits, because no command was added; update-upstream.py and the Dockerfile are untouched.

check: exit 0, 6 rows across 2 sources.
devcontainer.test/test-setup-estate-commands.sh: 83 PASS, GREEN, exit 0.
devBenches/devcontainer.test/test-speckit-git-feature.sh: 59 PASS, GREEN, exit 0.
The base image was not rebuilt here; the pin row and one vendored file are the only changes.

Lane: openrepotools-11 (openRepoTools-11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Re-vendor openRepoTools to incorporate corrected status handling for parked and partially configured feature records.

Bug Fixes:
- Update the vendored openRepoTools status command to correctly handle parked records, feature-level refusals, comments, and multi-feature record parsing.

Build:
- Re-vendor openRepoTools and update the pinned upstream commit and file checksum.

Tests:
- Validate the updated command behavior with the estate-command and speckit-git-feature test suites.